### PR TITLE
chore: adopt AI Governance v1.0.0 (pinned caller + dropdown forms)

### DIFF
--- a/.github/ISSUE_TEMPLATE/dev-ticket.yml
+++ b/.github/ISSUE_TEMPLATE/dev-ticket.yml
@@ -132,23 +132,24 @@ body:
     validations:
       required: true
 
-  - type: checkboxes
+  - type: dropdown
     id: ai-usage
     attributes:
       label: AI Usage Declaration
-      description: Declare how AI was used. AI output is not truth.
+      description: Declare how AI was used — select all that apply, or "Not used". AI output is not truth.
+      multiple: true
       options:
-        - label: Drafting the ticket
-        - label: Understanding code
-        - label: Proposing implementation
-        - label: Generating code
-        - label: Refactoring
-        - label: Generating tests
-        - label: Reviewing the diff
-        - label: Writing documentation
-        - label: Not used
-        - label: I have declared AI usage above (ticked the relevant items, or "Not used").
-          required: true
+        - Drafting the ticket
+        - Understanding code
+        - Proposing implementation
+        - Generating code
+        - Refactoring
+        - Generating tests
+        - Reviewing the diff
+        - Writing documentation
+        - Not used
+    validations:
+      required: true
 
   - type: checkboxes
     id: human-verification

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -120,20 +120,21 @@ body:
     validations:
       required: true
 
-  - type: checkboxes
+  - type: dropdown
     id: ai-usage
     attributes:
       label: AI Usage Declaration
-      description: Declare how AI was used. AI output is not truth.
+      description: Declare how AI was used — select all that apply, or "Not used". AI output is not truth.
+      multiple: true
       options:
-        - label: Drafting
-        - label: Summarization
-        - label: Research
-        - label: Ticket decomposition
-        - label: Technical proposal
-        - label: Not used
-        - label: I have declared AI usage above (ticked the relevant items, or "Not used").
-          required: true
+        - Drafting
+        - Summarization
+        - Research
+        - Ticket decomposition
+        - Technical proposal
+        - Not used
+    validations:
+      required: true
 
   - type: checkboxes
     id: human-verification

--- a/.github/ISSUE_TEMPLATE/user-story.yml
+++ b/.github/ISSUE_TEMPLATE/user-story.yml
@@ -116,21 +116,22 @@ body:
     validations:
       required: true
 
-  - type: checkboxes
+  - type: dropdown
     id: ai-usage
     attributes:
       label: AI Usage Declaration
-      description: Declare how AI was used. AI output is not truth.
+      description: Declare how AI was used — select all that apply, or "Not used". AI output is not truth.
+      multiple: true
       options:
-        - label: Drafting this story
-        - label: Refining acceptance criteria
-        - label: Suggesting implementation
-        - label: Generating code
-        - label: Generating tests
-        - label: Reviewing code
-        - label: Not used
-        - label: I have declared AI usage above (ticked the relevant items, or "Not used").
-          required: true
+        - Drafting this story
+        - Refining acceptance criteria
+        - Suggesting implementation
+        - Generating code
+        - Generating tests
+        - Reviewing code
+        - Not used
+    validations:
+      required: true
 
   - type: checkboxes
     id: human-verification

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -6,6 +6,10 @@
 # reference, or verification evidence — and posts a sticky comment listing what's missing.
 #
 # Source of truth: https://adorsys-gis.github.io/ai-governance/
+#
+# The reusable workflow is pinned to an immutable release tag (not @main), so a future
+# push to ai-governance cannot change what runs here with write access. Bump the tag
+# deliberately when you want to adopt new governance behaviour.
 name: AI Governance
 
 on:
@@ -14,7 +18,7 @@ on:
 
 jobs:
   governance:
-    uses: ADORSYS-GIS/ai-governance/.github/workflows/governance-check.yml@main
+    uses: ADORSYS-GIS/ai-governance/.github/workflows/governance-check.yml@v1.0.0
     permissions:
       pull-requests: write
       contents: read

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -7,9 +7,10 @@
 #
 # Source of truth: https://adorsys-gis.github.io/ai-governance/
 #
-# The reusable workflow is pinned to an immutable release tag (not @main), so a future
-# push to ai-governance cannot change what runs here with write access. Bump the tag
-# deliberately when you want to adopt new governance behaviour.
+# The reusable workflow is pinned to an immutable commit SHA (the v1.0.0 release), not
+# @main or a movable tag, so a future push — or a moved tag — to ai-governance cannot
+# change what runs here with write access. Bump the SHA deliberately when adopting a new
+# governance release.
 name: AI Governance
 
 on:
@@ -18,7 +19,8 @@ on:
 
 jobs:
   governance:
-    uses: ADORSYS-GIS/ai-governance/.github/workflows/governance-check.yml@v1.0.0
+    # ADORSYS-GIS/ai-governance @ v1.0.0
+    uses: ADORSYS-GIS/ai-governance/.github/workflows/governance-check.yml@959d8565041ddef86d3a10001b64393a6d4a60a2
     permissions:
       pull-requests: write
       contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,8 +96,6 @@ Each UI component in `@lightbridge/ui` must follow this folder structure:
 - **Containerization**: Multi-stage, non-root user, multi-platform (`amd64`/`arm64`).
 
 <!-- ai-governance:stanza -->
-## AI Governance
-
 <!-- BEGIN: AI Governance stanza (managed by ADORSYS-GIS/ai-governance) -->
 ## AI Governance
 


### PR DESCRIPTION
## Intent / Source of Truth

Applies the round-2 AI Governance hardening (`ADORSYS-GIS/ai-governance` v1.0.0) to this repo, following up the adoption PR.

Source of truth: https://github.com/ADORSYS-GIS/ai-governance/pull/3

## What changed

- **Pin the governance caller to `@v1.0.0`** (immutable) instead of `@main`, so a future upstream push can't change what runs here with write access unreviewed.
- **AI Usage Declaration** on the issue forms is now a **required multi-select dropdown** — a real choice (one or more categories, or "Not used") is enforced at submission instead of a hollow self-attestation.

## Verification

- [x] Workflow + forms copied verbatim from `ai-governance@v1.0.0`; the gate logic was harness-tested in `ai-governance#3` (source-of-truth scoping + dropdown).

```
git show v1.0.0:.github/workflows/governance.yml   # caller pinned to @v1.0.0
```

## AI Usage Declaration

- [x] Not used — files copied verbatim from the reviewed canonical kit by a deterministic propagation step.

Human accountable owner: @stephane-segning
