### PR TITLE
docs(adr): 0006 — do not adopt @expo/ui (SDK gap, no web support)

### DIFF
--- a/docs/adr/0006-expo-ui-not-adopted-web.md
+++ b/docs/adr/0006-expo-ui-not-adopted-web.md
@@ -1,0 +1,33 @@
+# ADR 0006: `@expo/ui` is not adopted; web-viable primitives are used instead
+
+## Status
+
+Accepted
+
+## Context
+
+This product is built with Expo + React Native but **ships as a pure web app** (React Native Web). During a UI review, the team asked whether to lean on Expo's `@expo/ui` universal components — `BottomSheet`, `Spacer`, `Checkbox`, `ScrollView` — motivated by two real rough edges in the current components: no first-class bottom-sheet primitive, and an unstyled-looking checkbox (the plain `expo-checkbox` web fallback).
+
+The Expo documentation that describes these universal components is at `docs.expo.dev/versions/latest/sdk/ui/universal/…` — i.e. the **latest** SDK docs. This app is on **Expo SDK 55**. The published `@expo/ui` packages were inspected directly (via `npm view … exports`) to check what our version actually provides, rather than assuming the docs apply.
+
+Findings (each verifiable from the published packages):
+
+1. **On SDK 55, the universal components do not exist and there is no web entry point.** `@expo/ui@55.0.17` (the `sdk-55`-tagged release) exports only `./swift-ui` (iOS), `./jetpack-compose` (Android), `./datetimepicker`, and `./community/segmented-control`. There is no universal (`.`) export and no web condition anywhere — a web-only app cannot import a usable component from it.
+2. **`BottomSheet` / `Spacer` / the universal `Checkbox` were introduced in SDK 56.** The universal root export (`.`) and `./community/bottom-sheet` first appear in `@expo/ui@56`. Reaching them requires an Expo **SDK 55 → 56/57 upgrade** — a separate, larger migration, not a UI change.
+3. **Even in the latest release, web support is minimal.** In `@expo/ui@57.0.4` the entire package ships exactly one `.web.tsx` file (`DateTimePicker.web.tsx`); the universal `Host`/`BottomSheet`/`Spacer`/`Checkbox` have no dedicated web implementation. This is consistent with Expo's own "experimental" labeling of the web target and is not a foundation to build a web-first product on yet.
+
+## Decision
+
+**Do not adopt `@expo/ui` for this app at this time.** Meet the underlying needs with web-proven tools instead:
+
+- **Bottom sheet** → `@gorhom/bottom-sheet` (web-capable; built on `react-native-reanimated`, already a dependency). This is the mature library that Expo itself re-wraps under `@expo/ui/community/bottom-sheet`.
+- **Checkbox** → restyle the existing checkbox (or a thin custom control over a native `<input>`); this is a styling gap, not a missing-primitive problem, and needs no new dependency.
+
+`NativeWind` is **not** implicated in either issue and is retained — the components that rely on it render correctly; the checkbox problem is `expo-checkbox`'s web fallback, and the font/asset issues addressed separately were asset-loading, not styling.
+
+## Consequences
+
+- Reconsidering `@expo/ui` is **gated on an Expo SDK 55 → 56/57 upgrade** and on its web target maturing past experimental. Tracked as a future decision, not scheduled here.
+- The `@expo/ui` pilot (issue #71) is closed as **no-go**, with this ADR as its verification evidence and decision record.
+- Follow-up work is tracked separately: a `@gorhom/bottom-sheet` spike on one modal flow (new ticket) and the checkbox restyle (folds into the component-revamp ticket #72).
+- Investigation cost was deliberately kept to package-metadata inspection — no dependency was installed and no code was written, because the SDK-55 blocker is decisive on its own.


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds `docs/adr/0006-expo-ui-not-adopted-web.md` recording the decision **not** to adopt `@expo/ui` for this web-first app, with the evidence behind it.

It solves: it closes out the `@expo/ui` pilot (#71) with a durable decision record, so future contributors don't re-litigate "why aren't we using the official Expo UI components?"

## 2. Intent

The intent of this PR is:

> To capture, as an ADR (consistent with #0003–0005), the evidence-based conclusion of the #71 spike: `@expo/ui`'s universal components aren't usable on our Expo SDK 55 and have no real web implementation even in the latest SDK, so we meet the underlying needs (bottom sheet, checkbox) with web-viable tools instead.

## 3. Scope

### In Scope

- One ADR file documenting the decision and its three verifiable findings.

### Out of Scope

- The follow-up implementation (`@gorhom/bottom-sheet` spike, checkbox restyle) — tracked as separate tickets/PRs.
- Any Expo SDK upgrade — explicitly deferred as a future decision.

## 4. Verification

I verified this change by:

- [x] Checking logs

Commands run:

```bash
npm view @expo/ui@55.0.17 exports   # our SDK 55: only swift-ui / jetpack-compose / datetimepicker / community-segmented-control
npm view @expo/ui@56.0.21 exports   # universal "." + community/bottom-sheet first appear
npm view @expo/ui@57.0.4  exports
npm pack @expo/ui@57.0.4 && tar -tzf … | grep -c '.web.'   # => 1 (only DateTimePicker.web.tsx)
```

Results:

```text
SDK 55 @expo/ui exports: ./swift-ui, ./jetpack-compose, ./datetimepicker, ./community/segmented-control
  → no universal export, no web entry point.
SDK 56/57 @expo/ui: adds "." (universal) and ./community/bottom-sheet.
SDK 57 tarball: exactly 1 *.web.tsx file across the whole package (DateTimePicker.web.tsx).
```

This is a docs-only change; the "verification" is the package inspection that produced the decision, quoted above and in the ADR.

## 5. Screenshots / Evidence

- Source of truth: #71 (the spike this ADR concludes) and #67 (epic). The ADR body cites the exact `@expo/ui` export sets per SDK version.

## 6. Risk Assessment

Risk level:

* [x] Low — documentation only, no code or dependency changes.

Potential risks:

* The decision could look premature if the reader assumes the `latest`-SDK docs apply to us; the ADR explicitly addresses that by pinning the finding to SDK 55 vs 56/57.

Mitigation:

* Findings are reproducible via the exact `npm view` / `npm pack` commands in the Verification section.

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Drafting documentation

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

> AI ran the package-metadata inspection that produced the finding (no install, no code — the SDK-55 blocker is decisive on its own) and drafted the ADR. The accountable owner (@stephane-segning) should confirm the decision and tick the boxes before merge.

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Product intent
