### PR TITLE
feat(ui): brand the checkbox checked state

### DIFF
--- a/packages/ui/src/components/checkbox/component.tsx
+++ b/packages/ui/src/components/checkbox/component.tsx
@@ -10,7 +10,13 @@ const CheckboxBase = ExpoCheckbox as React.ComponentType<
   ExpoCheckboxProps & { className?: string }
 >;
 
-export function Checkbox({ size, disabled, value, ...props }: CheckboxProps) {
+// expo-checkbox renders its own control (a native checkbox on the web fallback),
+// so NativeWind classes on the wrapper don't reach the checked fill/border — the
+// `color` prop is the real styling lever. Default it to the brand primary so the
+// checked state reads as intentional instead of the browser-default gray.
+const DEFAULT_CHECKBOX_COLOR = '#1d5bff';
+
+export function Checkbox({ size, disabled, value, color, ...props }: CheckboxProps) {
   const resolvedValue = Boolean(value);
   const resolvedDisabled = Boolean(disabled);
 
@@ -18,6 +24,7 @@ export function Checkbox({ size, disabled, value, ...props }: CheckboxProps) {
     <CheckboxBase
       value={resolvedValue}
       disabled={resolvedDisabled}
+      color={color ?? DEFAULT_CHECKBOX_COLOR}
       className={cn(
         checkboxVariants({
           size,


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Defaults the `Checkbox` primitive's `color` prop to the brand primary (`#1d5bff`), overridable per instance.

It solves: the Storybook review (#68) found the checkbox rendered as a browser-default gray square. `expo-checkbox`'s web fallback renders a native control that NativeWind classes on the wrapper don't reach — its `color` prop is the actual styling lever.

## 2. Intent

The intent of this PR is:

> To make the checkbox's checked state read as intentional (branded blue fill + white check) instead of an unstyled gray box, without adopting a new library. First concrete revamp item surfaced by the Storybook review, tracked under #72.

## 3. Scope

### In Scope

- One-line-ish default on the `Checkbox` component (`packages/ui/src/components/checkbox/component.tsx`): `color` defaults to the brand primary, still overridable via the `color` prop.

### Out of Scope

- Theme-reactive checkbox color (dark-mode-aware fill) — the default is a single brand blue that reads acceptably on both light and dark surfaces; consumers can pass a themed `color` if needed.
- Any other component — this is scoped to the checkbox finding.

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests

Commands run:

```bash
npx tsc --noEmit -p packages/ui
pnpm --filter @lightbridge/ui build-storybook
```

Results:

```text
tsc: clean
Storybook build: completed successfully
```

Manual verification (Preview MCP against the built static Storybook), confirmed via computed style, not just screenshots:

- **Checked**: box `background-color: rgb(29, 91, 255)` (brand primary) with a white checkmark — was a gray outline before.
- **Unchecked**: white background, `border-color: rgb(29, 91, 255)`.
- **Sizes** (sm/md/lg) and **Disabled** render correctly.

## 5. Screenshots / Evidence

- Source of truth: #68 (Storybook review that surfaced this), #72 (component revamp ticket this folds into). Deployed Storybook: https://adorsys-gis.github.io/converse-frontends/
- Computed-style checks quoted above (checked fill = `rgb(29,91,255)`, unchecked border = `rgb(29,91,255)`).

## 6. Risk Assessment

Risk level:

* [x] Low — the `Checkbox` primitive is not used anywhere in the app yet (only in its own story), so there is no app-facing regression surface; the change is additive and overridable.

Potential risks:

* Hardcoded brand hex won't follow a future token change. Mitigated: documented in-code as the brand primary and overridable via the `color` prop; a themed color can be passed by consumers. `expo-checkbox`'s `color` requires a concrete value (not a CSS variable), and this low-level primitive has no theme-hook access by design.

Mitigation:

* Overridable prop; documented default; verified rendering via computed style.

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I accept responsibility for this PR

> AI traced the "unstyled checkbox" to `expo-checkbox`'s web fallback (NativeWind classes don't reach the native control; `color` is the real lever), applied the minimal fix, and verified the result via computed style. The accountable owner (@stephane-segning) must tick the boxes before merge.

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Maintainability
