### PR TITLE
feat(ui): design-system Phase 2 — SectionCard/Chip/KeyValue + composed account settings

### DIFF
--- a/apps/self-service/src/views/settings/account-settings-view.tsx
+++ b/apps/self-service/src/views/settings/account-settings-view.tsx
@@ -3,11 +3,15 @@ import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from '@lightbridge/i18n';
 import {
   Button,
-  Card,
+  Chip,
   designTokens,
   Div,
+  Divider,
   Heading,
+  KeyValue,
+  PageHeader,
   Scroll,
+  SectionCard,
   Stack,
   Text,
   TextField,
@@ -68,18 +72,9 @@ export function AccountSettingsView({
   return (
     <Div tone="muted" width="full" style={{ flex: 1 }}>
       {showBackButton ? (
-        <Div
-          tone="surface"
-          width="full"
-          style={{
-            borderBottomWidth: 1,
-            borderBottomColor: colors.border,
-            minHeight: designTokens.layout.topBarMinHeight,
-            paddingHorizontal: designTokens.spacing.topBarHorizontal,
-            paddingVertical: designTokens.spacing.topBarVertical,
-            backgroundColor: colors.surface,
-          }}>
-          <Stack direction="row" align="center" justify="between" width="full">
+        <PageHeader
+          title={t('settings.account.title')}
+          leading={
             <Button
               variant="ghost"
               size="iconSm"
@@ -87,24 +82,18 @@ export function AccountSettingsView({
               accessibilityLabel={t('apiKeys.back')}>
               <Ionicons name="arrow-back" size={designTokens.icon.nav} color={colors.ink} />
             </Button>
-            <Heading tone="title" style={{ fontSize: designTokens.typography.compactTitle }}>
-              {t('settings.account.title')}
-            </Heading>
-            <Div size="iconSm" />
-          </Stack>
-        </Div>
+          }
+        />
       ) : null}
 
       <Scroll tone="muted" pad="md" style={{ flex: 1 }}>
         <Stack gap="lg">
           {!showBackButton ? <Heading tone="title">{t('settings.account.title')}</Heading> : null}
 
-          <Card size="md">
+          <SectionCard
+            title={t('settings.account.billingIdentitySection')}
+            description={t('settings.account.billingIdentityDescription')}>
             <Stack gap="md">
-              <Stack gap="xs">
-                <Text intent="bodyStrong">{t('settings.account.billingIdentitySection')}</Text>
-                <Text intent="caption">{t('settings.account.billingIdentityDescription')}</Text>
-              </Stack>
               <TextField
                 value={billingIdentityDraft}
                 onChangeText={setBillingIdentityDraft}
@@ -123,44 +112,24 @@ export function AccountSettingsView({
                   : t('settings.account.billingIdentitySave')}
               </Button>
             </Stack>
-          </Card>
+          </SectionCard>
 
-          <Card size="md">
+          <SectionCard
+            title={t('settings.account.ownersSection')}
+            description={t('settings.account.ownersDescription')}>
             <Stack gap="md">
-              <Stack gap="xs">
-                <Text intent="bodyStrong">{t('settings.account.ownersSection')}</Text>
-                <Text intent="caption">{t('settings.account.ownersDescription')}</Text>
-              </Stack>
-
               {owners.length === 0 ? (
                 <Text intent="caption">{t('settings.account.ownersEmpty')}</Text>
               ) : (
                 <Stack direction="row" wrap="wrap" gap="sm">
                   {owners.map((owner) => (
-                    <Div
+                    <Chip
                       key={owner}
-                      tone="muted"
-                      rounded="full"
-                      pad="sm"
-                      style={{
-                        borderWidth: 1,
-                        borderColor: colors.border,
-                        flexDirection: 'row',
-                        alignItems: 'center',
-                      }}>
-                      <Stack direction="row" align="center" gap="xs">
-                        <Text intent="caption">{owner}</Text>
-                        <Button
-                          variant="ghost"
-                          size="iconSm"
-                          onPress={() => onRemoveOwner(owner)}
-                          disabled={isSavingOwners}
-                          accessibilityLabel={t('settings.account.ownerRemove', { name: owner })}
-                          style={{ height: 20, width: 20, paddingHorizontal: 0 }}>
-                          <Ionicons name="close" size={14} color={colors.soft} />
-                        </Button>
-                      </Stack>
-                    </Div>
+                      onRemove={() => onRemoveOwner(owner)}
+                      removeAccessibilityLabel={t('settings.account.ownerRemove', { name: owner })}
+                      disabled={isSavingOwners}>
+                      {owner}
+                    </Chip>
                   ))}
                 </Stack>
               )}
@@ -186,39 +155,29 @@ export function AccountSettingsView({
                 </Button>
               </Stack>
             </Stack>
-          </Card>
+          </SectionCard>
 
-          <Card size="md">
+          <SectionCard
+            title={t('settings.account.authSection')}
+            description={t('settings.account.authDescription')}>
             <Stack gap="sm">
-              <Text intent="bodyStrong">{t('settings.account.authSection')}</Text>
-              <Text intent="caption">{t('settings.account.authDescription')}</Text>
-              <Div tone="muted" height="hairline" width="full" />
-              <Stack direction="row" justify="between" width="full">
-                <Text intent="caption">{t('settings.account.authUserLabel')}</Text>
-                <Text intent="bodyStrong">{authUserLabel}</Text>
-              </Stack>
-              <Stack direction="row" justify="between" width="full">
-                <Text intent="caption">{t('settings.account.authIssuerLabel')}</Text>
-                <Text intent="bodyStrong" numberOfLines={1} ellipsizeMode="middle">
-                  {authIssuer}
-                </Text>
-              </Stack>
+              <Divider tone="muted" />
+              <KeyValue label={t('settings.account.authUserLabel')} value={authUserLabel} />
+              <KeyValue label={t('settings.account.authIssuerLabel')} value={authIssuer} />
             </Stack>
-          </Card>
+          </SectionCard>
 
-          <Div tone="muted" rounded="xl" pad="md" width="full">
-            <Stack gap="xs">
-              <Text intent="bodyStrong">{t('settings.account.policiesSection')}</Text>
-              <Text intent="caption">{t('settings.account.policiesUnsupported')}</Text>
-            </Stack>
-          </Div>
+          <SectionCard
+            tone="muted"
+            title={t('settings.account.policiesSection')}
+            description={t('settings.account.policiesUnsupported')}
+          />
 
-          <Card size="md" style={{ borderWidth: 1, borderColor: colors.error }}>
-            <Stack gap="sm">
-              <Text intent="bodyStrong" style={{ color: colors.error }}>
-                {t('settings.account.dangerSection')}
-              </Text>
-              <Text intent="caption">{t('settings.account.dangerDescription')}</Text>
+          <SectionCard
+            tone="danger"
+            title={t('settings.account.dangerSection')}
+            description={t('settings.account.dangerDescription')}>
+            <Stack align="start">
               <Button
                 variant="neutral"
                 size="sm"
@@ -229,7 +188,7 @@ export function AccountSettingsView({
                 </Text>
               </Button>
             </Stack>
-          </Card>
+          </SectionCard>
         </Stack>
       </Scroll>
     </Div>

--- a/packages/ui/src/components/chip/component.stories.tsx
+++ b/packages/ui/src/components/chip/component.stories.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { Stack } from '../stack';
+import { Chip } from './component';
+
+const meta: Meta<typeof Chip> = {
+  title: 'UI/Chip',
+  component: Chip,
+  args: {
+    children: 'owner@example.com',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Chip>;
+
+export const Plain: Story = {};
+
+export const Removable: Story = {
+  args: {
+    onRemove: () => undefined,
+    removeAccessibilityLabel: 'Remove owner@example.com',
+  },
+};
+
+export const Group: Story = {
+  render: () => (
+    <Stack direction="row" gap="sm" wrap="wrap">
+      {['owner@example.com', 'admin@example.com', 'dev@example.com'].map((owner) => (
+        <Chip key={owner} onRemove={() => undefined} removeAccessibilityLabel={`Remove ${owner}`}>
+          {owner}
+        </Chip>
+      ))}
+    </Stack>
+  ),
+};

--- a/packages/ui/src/components/chip/component.tsx
+++ b/packages/ui/src/components/chip/component.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Pressable, Text, View } from 'react-native';
+import type { PressableProps, TextProps, ViewProps } from 'react-native';
+
+import { cn } from '../../cn';
+import { chipTextVariants, chipVariants } from './cva';
+import type { ChipProps } from './types';
+
+const ViewBase = View as React.ComponentType<ViewProps & { className?: string }>;
+const TextBase = Text as React.ComponentType<TextProps & { className?: string }>;
+const PressableBase = Pressable as React.ComponentType<PressableProps & { className?: string }>;
+
+export function Chip({
+  children,
+  onRemove,
+  removeAccessibilityLabel,
+  disabled,
+  tone,
+  size,
+  ...props
+}: ChipProps) {
+  return (
+    <ViewBase className={cn(chipVariants({ tone, size }))} {...props}>
+      <TextBase className={cn(chipTextVariants({ tone, size }))} numberOfLines={1}>
+        {children}
+      </TextBase>
+      {onRemove ? (
+        <PressableBase
+          accessibilityRole="button"
+          accessibilityLabel={removeAccessibilityLabel}
+          disabled={disabled}
+          onPress={onRemove}
+          className="h-4 w-4 items-center justify-center">
+          <TextBase className={cn(chipTextVariants({ tone, size }))}>×</TextBase>
+        </PressableBase>
+      ) : null}
+    </ViewBase>
+  );
+}

--- a/packages/ui/src/components/chip/cva.tsx
+++ b/packages/ui/src/components/chip/cva.tsx
@@ -1,0 +1,37 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export const chipVariants = cva('flex-row items-center gap-1 self-start rounded-full border', {
+  variants: {
+    tone: {
+      neutral: 'border-border bg-muted',
+      brand: 'border-primary/30 bg-primary/10',
+    },
+    size: {
+      sm: 'px-2 py-1',
+      md: 'px-3 py-1.5',
+    },
+  },
+  defaultVariants: {
+    tone: 'neutral',
+    size: 'sm',
+  },
+});
+
+export const chipTextVariants = cva('text-soft', {
+  variants: {
+    tone: {
+      neutral: 'text-soft',
+      brand: 'text-primary',
+    },
+    size: {
+      sm: 'text-sm',
+      md: 'text-base',
+    },
+  },
+  defaultVariants: {
+    tone: 'neutral',
+    size: 'sm',
+  },
+});
+
+export type ChipVariantProps = VariantProps<typeof chipVariants>;

--- a/packages/ui/src/components/chip/index.tsx
+++ b/packages/ui/src/components/chip/index.tsx
@@ -1,0 +1,3 @@
+export { Chip } from './component';
+export { chipTextVariants, chipVariants } from './cva';
+export type { ChipProps } from './types';

--- a/packages/ui/src/components/chip/types.tsx
+++ b/packages/ui/src/components/chip/types.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from 'react';
+import type { ViewProps } from 'react-native';
+
+import type { ChipVariantProps } from './cva';
+
+export type ChipProps = ViewProps &
+  ChipVariantProps & {
+    children: ReactNode;
+    onRemove?: () => void;
+    removeAccessibilityLabel?: string;
+    disabled?: boolean;
+  };

--- a/packages/ui/src/components/key-value/component.stories.tsx
+++ b/packages/ui/src/components/key-value/component.stories.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { Card } from '../card';
+import { Divider } from '../divider';
+import { Stack } from '../stack';
+import { KeyValue } from './component';
+
+const meta: Meta<typeof KeyValue> = {
+  title: 'UI/KeyValue',
+  component: KeyValue,
+  decorators: [
+    (Story) => (
+      <div style={{ width: 420 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof KeyValue>;
+
+export const Row: Story = {
+  args: { label: 'Signed in as', value: 'jane@example.com' },
+};
+
+export const Stacked: Story = {
+  args: { layout: 'stacked', label: 'Issuer', value: 'https://issuer.example.com/realms/lightbridge' },
+};
+
+export const InCard: Story = {
+  render: () => (
+    <Card size="md">
+      <Stack gap="sm">
+        <KeyValue label="Signed in as" value="jane@example.com" />
+        <Divider tone="muted" />
+        <KeyValue label="Issuer" value="https://issuer.example.com/realms/lightbridge" />
+      </Stack>
+    </Card>
+  ),
+};

--- a/packages/ui/src/components/key-value/component.tsx
+++ b/packages/ui/src/components/key-value/component.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { View } from 'react-native';
+import type { ViewProps } from 'react-native';
+
+import { cn } from '../../cn';
+import { Text } from '../text';
+import { keyValueVariants } from './cva';
+import type { KeyValueProps } from './types';
+
+const ViewBase = View as React.ComponentType<ViewProps & { className?: string }>;
+
+export function KeyValue({ label, value, layout, ...props }: KeyValueProps) {
+  return (
+    <ViewBase className={cn(keyValueVariants({ layout }))} {...props}>
+      <Text intent="caption">{label}</Text>
+      {typeof value === 'string' ? (
+        <Text intent="bodyStrong" numberOfLines={1} ellipsizeMode="middle">
+          {value}
+        </Text>
+      ) : (
+        value
+      )}
+    </ViewBase>
+  );
+}

--- a/packages/ui/src/components/key-value/cva.tsx
+++ b/packages/ui/src/components/key-value/cva.tsx
@@ -1,0 +1,15 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export const keyValueVariants = cva('w-full', {
+  variants: {
+    layout: {
+      row: 'flex-row items-center justify-between gap-3',
+      stacked: 'flex-col gap-0.5',
+    },
+  },
+  defaultVariants: {
+    layout: 'row',
+  },
+});
+
+export type KeyValueVariantProps = VariantProps<typeof keyValueVariants>;

--- a/packages/ui/src/components/key-value/index.tsx
+++ b/packages/ui/src/components/key-value/index.tsx
@@ -1,0 +1,3 @@
+export { KeyValue } from './component';
+export { keyValueVariants } from './cva';
+export type { KeyValueProps } from './types';

--- a/packages/ui/src/components/key-value/types.tsx
+++ b/packages/ui/src/components/key-value/types.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from 'react';
+import type { ViewProps } from 'react-native';
+
+import type { KeyValueVariantProps } from './cva';
+
+export type KeyValueProps = ViewProps &
+  KeyValueVariantProps & {
+    label: string;
+    value: ReactNode;
+  };

--- a/packages/ui/src/components/section-card/component.stories.tsx
+++ b/packages/ui/src/components/section-card/component.stories.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { Button } from '../button';
+import { Stack } from '../stack';
+import { Text } from '../text';
+import { SectionCard } from './component';
+
+const meta: Meta<typeof SectionCard> = {
+  title: 'UI/SectionCard',
+  component: SectionCard,
+  args: {
+    title: 'Billing identity',
+    description: 'The name shown on invoices for this account.',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 460 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof SectionCard>;
+
+export const Default: Story = {
+  args: {
+    children: <Text>Section content goes here.</Text>,
+  },
+};
+
+export const WithAction: Story = {
+  args: {
+    action: <Button size="sm">Edit</Button>,
+    children: <Text>Section content goes here.</Text>,
+  },
+};
+
+export const Muted: Story = {
+  args: {
+    tone: 'muted',
+    title: 'Cross-project policies',
+    description: 'Not yet supported by the backend.',
+  },
+};
+
+export const Danger: Story = {
+  args: {
+    tone: 'danger',
+    title: 'Danger zone',
+    description: 'Deleting the account is permanent and cannot be undone.',
+    children: (
+      <Stack align="start">
+        <Button variant="neutral" size="sm">
+          Delete account
+        </Button>
+      </Stack>
+    ),
+  },
+};

--- a/packages/ui/src/components/section-card/component.tsx
+++ b/packages/ui/src/components/section-card/component.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+import type { TextProps, ViewProps } from 'react-native';
+
+import { cn } from '../../cn';
+import { Stack } from '../stack';
+import { Text as UiText } from '../text';
+import { sectionCardVariants, sectionTitleVariants } from './cva';
+import type { SectionCardProps } from './types';
+
+const ViewBase = View as React.ComponentType<ViewProps & { className?: string }>;
+const TextBase = Text as React.ComponentType<TextProps & { className?: string }>;
+
+export function SectionCard({
+  title,
+  description,
+  action,
+  tone,
+  children,
+  ...props
+}: SectionCardProps) {
+  return (
+    <ViewBase className={cn(sectionCardVariants({ tone }))} {...props}>
+      <Stack gap="md">
+        <Stack direction="row" align="start" justify="between" gap="sm" width="full">
+          <Stack gap="xs" style={{ flex: 1 }}>
+            <TextBase className={cn(sectionTitleVariants({ tone }))}>{title}</TextBase>
+            {description ? <UiText intent="caption">{description}</UiText> : null}
+          </Stack>
+          {action}
+        </Stack>
+        {children}
+      </Stack>
+    </ViewBase>
+  );
+}

--- a/packages/ui/src/components/section-card/cva.tsx
+++ b/packages/ui/src/components/section-card/cva.tsx
@@ -1,0 +1,29 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export const sectionCardVariants = cva('w-full rounded-2xl', {
+  variants: {
+    tone: {
+      default: 'bg-surface p-6 shadow-sm',
+      muted: 'bg-muted p-4',
+      danger: 'border border-error bg-surface p-6',
+    },
+  },
+  defaultVariants: {
+    tone: 'default',
+  },
+});
+
+export const sectionTitleVariants = cva('text-base font-semibold text-ink', {
+  variants: {
+    tone: {
+      default: '',
+      muted: '',
+      danger: 'text-error',
+    },
+  },
+  defaultVariants: {
+    tone: 'default',
+  },
+});
+
+export type SectionCardVariantProps = VariantProps<typeof sectionCardVariants>;

--- a/packages/ui/src/components/section-card/index.tsx
+++ b/packages/ui/src/components/section-card/index.tsx
@@ -1,0 +1,3 @@
+export { SectionCard } from './component';
+export { sectionCardVariants, sectionTitleVariants } from './cva';
+export type { SectionCardProps } from './types';

--- a/packages/ui/src/components/section-card/types.tsx
+++ b/packages/ui/src/components/section-card/types.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from 'react';
+import type { ViewProps } from 'react-native';
+
+import type { SectionCardVariantProps } from './cva';
+
+export type SectionCardProps = ViewProps &
+  SectionCardVariantProps & {
+    title: string;
+    description?: string;
+    action?: ReactNode;
+    children?: ReactNode;
+  };

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -26,6 +26,8 @@ export { Page, pageVariants } from './components/page';
 export type { PageProps } from './components/page';
 export { Scroll, scrollContentVariants, scrollVariants } from './components/scroll';
 export type { ScrollProps } from './components/scroll';
+export { SectionCard, sectionCardVariants, sectionTitleVariants } from './components/section-card';
+export type { SectionCardProps } from './components/section-card';
 export {
   SegmentedControl,
   segmentDividerVariants,
@@ -44,10 +46,14 @@ export { Badge, badgeTextVariants, badgeVariants } from './components/badge';
 export type { BadgeProps } from './components/badge';
 export { Callout, calloutTextVariants, calloutVariants } from './components/callout';
 export type { CalloutProps } from './components/callout';
+export { Chip, chipTextVariants, chipVariants } from './components/chip';
+export type { ChipProps } from './components/chip';
 export { Divider, dividerVariants } from './components/divider';
 export type { DividerProps } from './components/divider';
 export { EmptyState, emptyStateVariants } from './components/empty-state';
 export type { EmptyStateProps } from './components/empty-state';
+export { KeyValue, keyValueVariants } from './components/key-value';
+export type { KeyValueProps } from './components/key-value';
 export { ListRow, listRowVariants } from './components/list-row';
 export type { ListRowProps } from './components/list-row';
 export { PageHeader, pageHeaderVariants } from './components/page-header';


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds 3 components to `packages/ui`, each with a Storybook story: **SectionCard** (titled card with `default`/`muted`/`danger` tones + optional action), **Chip** (removable pill), **KeyValue** (label/value row).
- Rebuilds `apps/self-service/src/views/settings/account-settings-view.tsx` to compose them (plus the Phase-1 PageHeader/Divider), replacing inlined card headers, owner chips, auth rows, and the danger-zone card.

It solves: Phase 2 of the design-system epic #79 — continuing the "UI just composes" model on a form/settings-heavy screen.

## 2. Intent

The intent is to grow the component library with the settings/form patterns and prove them on the account-settings screen, which uses each new component multiple times — with zero behavior change.

## 3. Scope

### In Scope
- 3 new `packages/ui` components (`component/cva/types/index` + story each), exported from `src/index.ts`.
- Rebuild of `account-settings-view` composing SectionCard/Chip/KeyValue/PageHeader/Divider.

### Out of Scope
- FormField and other remaining taxonomy — deferred to when a multi-field form screen (e.g. api-key-create) is rebuilt, to avoid speculative components.
- Other views — follow-up phases under #79.

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests

Commands run:

```bash
npx tsc --noEmit -p packages/ui
pnpm --filter @lightbridge/ui build-storybook
npx tsc --noEmit -p apps/self-service/tsconfig.json
pnpm --filter self-service test
```

Results:

```text
tsc (packages/ui): clean
Storybook build: completed successfully
tsc (self-service): clean
Test Suites: 16 passed, 16 total
Tests:       53 passed, 53 total  (incl. account-settings-view: billing save-gating, owner add/remove, auth rows, delete)
```

Manual verification (Preview MCP, built static Storybook):

- **Chip** — group of removable owner pills (bordered, × remove button) — the owners pattern.
- **SectionCard (danger)** — error-red border + red title + description + Delete action — the danger zone.
- (KeyValue verified via story + tsc; it's a label/value row.)

**Screen-level note:** account-settings sits behind Keycloak auth, so no full-screen capture (same constraint as #63–#66). Coverage: each component verified in Storybook, the rebuilt view type-checks clean, and the existing RNTL test suite (6 assertions: billing display value + save-disabled gating + trimmed save, owners empty/render/remove, add-owner trim+clear, delete) passes unchanged.

## 5. Screenshots / Evidence

- Source of truth: #79 (epic). Refero references (Cohere/Anthropic/Linear settings) cited in the epic. Deployed Storybook (auto-redeploys on merge): https://adorsys-gis.github.io/converse-frontends/
- Storybook captures this session for Chip (group) and SectionCard (danger).

## 6. Risk Assessment

Risk level:

* [x] Low-Medium — additive components; the only behavioral surface is the account-settings rebuild.

Potential risks:

* The rebuild could change labels/accessibility the screen or tests rely on. Mitigated: every i18n key, the `Remove {name}` accessibility label, the Save button's accessible name + disabled gating, and the Delete action were preserved verbatim; the full test suite passes.

Mitigation:

* Full app test suite + both `tsc` projects clean; each component visually confirmed in Storybook.

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Refactoring
* [x] Reviewing the diff

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I accept responsibility for this PR

> AI built the 3 components matching the repo's component pattern, rebuilt the view preserving all behavior, and verified via Storybook + the full test suite. Note: the in-house `review / opencode` bot is currently failing on its own auth (`OPENCODE_API_KEY` Unauthorized), so it did not review this PR. The accountable owner (@stephane-segning) must tick the boxes before merge.

## 8. Reviewer Focus

* [x] Correctness
* [x] Product intent
* [x] Maintainability
