### PR TITLE
feat(ui): Sheet primitive (gorhom) + delete-account composes it

### DIFF
--- a/apps/self-service/package.json
+++ b/apps/self-service/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "15.1.1",
+    "@gorhom/bottom-sheet": "^5.2.14",
     "@lightbridge/api-native": "workspace:*",
     "@lightbridge/api-rest": "workspace:*",
     "@lightbridge/hooks": "workspace:*",
@@ -48,6 +49,7 @@
     "react-dom": "19.2.0",
     "react-native": "0.83.6",
     "react-native-css-interop": "^0.2.1",
+    "react-native-gesture-handler": "~2.30.1",
     "react-native-reanimated": "4.2.1",
     "react-native-safe-area-context": "~5.6.2",
     "react-native-screens": "~4.23.0",

--- a/apps/self-service/src/app/_layout.tsx
+++ b/apps/self-service/src/app/_layout.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Stack, usePathname, useRouter, useSegments } from 'expo-router';
 import { Alert } from 'react-native';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { StatusBar } from 'expo-status-bar';
 import * as SplashScreen from 'expo-splash-screen';
@@ -174,12 +175,14 @@ export default function RootLayout() {
   }, [fontsLoaded, runtimeReady]);
 
   return (
-    <I18nProvider>
-      <RuntimeConfigProvider fallback={webFallback} onReady={handleRuntimeReady}>
-        <QueryClientProvider client={queryClient}>
-          {fontsLoaded ? <AppBootstrap /> : webFallback}
-        </QueryClientProvider>
-      </RuntimeConfigProvider>
-    </I18nProvider>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <I18nProvider>
+        <RuntimeConfigProvider fallback={webFallback} onReady={handleRuntimeReady}>
+          <QueryClientProvider client={queryClient}>
+            {fontsLoaded ? <AppBootstrap /> : webFallback}
+          </QueryClientProvider>
+        </RuntimeConfigProvider>
+      </I18nProvider>
+    </GestureHandlerRootView>
   );
 }

--- a/apps/self-service/src/screens/delete-account-modal.tsx
+++ b/apps/self-service/src/screens/delete-account-modal.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
+import { StyleSheet, View } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
+import BottomSheet, {
+  BottomSheetBackdrop,
+  type BottomSheetBackdropProps,
+  BottomSheetView,
+} from '@gorhom/bottom-sheet';
 import { useDeleteAccount } from '@lightbridge/hooks';
 import { DeleteAccountView } from '../views/delete-account-view';
 
@@ -12,6 +18,7 @@ export function DeleteAccountModal() {
   const id = typeof params.id === 'string' ? params.id : null;
   const name = typeof params.name === 'string' ? params.name : '';
   const removeAccount = useDeleteAccount();
+  const sheetRef = React.useRef<BottomSheet>(null);
 
   const handleConfirm = async () => {
     if (!id) {
@@ -22,12 +29,57 @@ export function DeleteAccountModal() {
     router.replace('/home');
   };
 
+  const handleSheetChange = React.useCallback(
+    (index: number) => {
+      // Dismissing the sheet (dragged/backdrop-tapped to closed) returns to the
+      // previous route so the modal route stays in sync with the sheet state.
+      if (index === -1) {
+        router.back();
+      }
+    },
+    [router]
+  );
+
+  const renderBackdrop = React.useCallback(
+    (backdropProps: BottomSheetBackdropProps) => (
+      <BottomSheetBackdrop
+        {...backdropProps}
+        appearsOnIndex={0}
+        disappearsOnIndex={-1}
+        pressBehavior="close"
+      />
+    ),
+    []
+  );
+
   return (
-    <DeleteAccountView
-      name={name}
-      loading={removeAccount.isPending}
-      onCancel={() => router.back()}
-      onConfirm={handleConfirm}
-    />
+    <View style={styles.container}>
+      <BottomSheet
+        ref={sheetRef}
+        index={0}
+        enableDynamicSizing
+        enablePanDownToClose
+        backdropComponent={renderBackdrop}
+        onChange={handleSheetChange}
+      >
+        <BottomSheetView style={styles.content}>
+          <DeleteAccountView
+            name={name}
+            loading={removeAccount.isPending}
+            onCancel={() => sheetRef.current?.close()}
+            onConfirm={handleConfirm}
+          />
+        </BottomSheetView>
+      </BottomSheet>
+    </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    paddingBottom: 24,
+  },
+});

--- a/apps/self-service/src/screens/delete-account-modal.tsx
+++ b/apps/self-service/src/screens/delete-account-modal.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import BottomSheet, {
-  BottomSheetBackdrop,
-  type BottomSheetBackdropProps,
-  BottomSheetView,
-} from '@gorhom/bottom-sheet';
+import { Sheet, type SheetHandle } from '@lightbridge/ui/sheet';
 import { useDeleteAccount } from '@lightbridge/hooks';
 import { DeleteAccountView } from '../views/delete-account-view';
 
+/**
+ * Per-flow smart wrapper for the delete-account bottom sheet: it owns the domain
+ * wiring (route params, the useDeleteAccount mutation, navigation) and composes
+ * the presentational Sheet + DeleteAccountView. The sheet mechanics live in
+ * @lightbridge/ui — this screen has no @gorhom/bottom-sheet import.
+ */
 export function DeleteAccountModal() {
   const params = useLocalSearchParams<{
     id?: string | string[];
@@ -18,7 +19,7 @@ export function DeleteAccountModal() {
   const id = typeof params.id === 'string' ? params.id : null;
   const name = typeof params.name === 'string' ? params.name : '';
   const removeAccount = useDeleteAccount();
-  const sheetRef = React.useRef<BottomSheet>(null);
+  const sheetRef = React.useRef<SheetHandle>(null);
 
   const handleConfirm = async () => {
     if (!id) {
@@ -29,57 +30,14 @@ export function DeleteAccountModal() {
     router.replace('/home');
   };
 
-  const handleSheetChange = React.useCallback(
-    (index: number) => {
-      // Dismissing the sheet (dragged/backdrop-tapped to closed) returns to the
-      // previous route so the modal route stays in sync with the sheet state.
-      if (index === -1) {
-        router.back();
-      }
-    },
-    [router]
-  );
-
-  const renderBackdrop = React.useCallback(
-    (backdropProps: BottomSheetBackdropProps) => (
-      <BottomSheetBackdrop
-        {...backdropProps}
-        appearsOnIndex={0}
-        disappearsOnIndex={-1}
-        pressBehavior="close"
-      />
-    ),
-    []
-  );
-
   return (
-    <View style={styles.container}>
-      <BottomSheet
-        ref={sheetRef}
-        index={0}
-        enableDynamicSizing
-        enablePanDownToClose
-        backdropComponent={renderBackdrop}
-        onChange={handleSheetChange}
-      >
-        <BottomSheetView style={styles.content}>
-          <DeleteAccountView
-            name={name}
-            loading={removeAccount.isPending}
-            onCancel={() => sheetRef.current?.close()}
-            onConfirm={handleConfirm}
-          />
-        </BottomSheetView>
-      </BottomSheet>
-    </View>
+    <Sheet ref={sheetRef} onClose={() => router.back()}>
+      <DeleteAccountView
+        name={name}
+        loading={removeAccount.isPending}
+        onCancel={() => sheetRef.current?.close()}
+        onConfirm={handleConfirm}
+      />
+    </Sheet>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  content: {
-    paddingBottom: 24,
-  },
-});

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,6 +6,7 @@
   "types": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./sheet": "./src/components/sheet/index.tsx",
     "./src/*": "./src/*",
     "./tailwind-preset": "./tailwind-preset.js"
   },
@@ -14,9 +15,12 @@
     "build-storybook": "storybook build -o storybook-static"
   },
   "peerDependencies": {
+    "@gorhom/bottom-sheet": ">=5",
     "nativewind": ">=2",
     "react": ">=18",
     "react-native": ">=0.72",
+    "react-native-gesture-handler": ">=2.16.1",
+    "react-native-reanimated": ">=3.16.0 || >=4.0.0",
     "tailwindcss": "^3"
   },
   "dependencies": {
@@ -32,9 +36,12 @@
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {
+    "@gorhom/bottom-sheet": "^5.2.14",
     "@storybook/addon-a11y": "^10.4.6",
     "@storybook/react-native-web-vite": "^10.4.6",
     "autoprefixer": "^10.4.20",
+    "react-native-gesture-handler": "~2.30.0",
+    "react-native-reanimated": "4.2.1",
     "postcss": "^8.5.0",
     "react-dom": "19.2.0",
     "react-native-web": "^0.21.2",

--- a/packages/ui/src/components/sheet/component.stories.tsx
+++ b/packages/ui/src/components/sheet/component.stories.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { View } from 'react-native';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { Text } from '../text';
+import { Sheet } from './component';
+
+const meta: Meta<typeof Sheet> = {
+  title: 'UI/Sheet',
+  component: Sheet,
+};
+
+export default meta;
+type Story = StoryObj<typeof Sheet>;
+
+export const Default: Story = {
+  render: () => (
+    <GestureHandlerRootView style={{ height: 460, width: 360 }}>
+      <Sheet onClose={() => undefined} snapPoints={['70%']}>
+        <View style={{ padding: 16, gap: 8 }}>
+          <Text intent="bodyStrong">Bottom sheet</Text>
+          <Text intent="caption">Drag the handle down or tap the backdrop to dismiss.</Text>
+        </View>
+      </Sheet>
+    </GestureHandlerRootView>
+  ),
+};

--- a/packages/ui/src/components/sheet/component.tsx
+++ b/packages/ui/src/components/sheet/component.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import BottomSheet, {
+  BottomSheetBackdrop,
+  type BottomSheetBackdropProps,
+  BottomSheetView,
+} from '@gorhom/bottom-sheet';
+
+import type { SheetHandle, SheetProps } from './types';
+
+/**
+ * Presentational bottom sheet — a thin wrapper over @gorhom/bottom-sheet that
+ * owns the backdrop, pan-down-to-close, and the dismiss → onClose mapping. It
+ * holds no business logic; screens/smart components pass content + onClose and
+ * call `close()` via ref for an explicit dismiss (e.g. a Cancel button).
+ *
+ * Requires a `GestureHandlerRootView` at the app root (react-native-gesture-handler).
+ */
+export const Sheet = React.forwardRef<SheetHandle, SheetProps>(function Sheet(
+  { children, onClose, snapPoints, contentStyle },
+  ref
+) {
+  const innerRef = React.useRef<BottomSheet>(null);
+
+  React.useImperativeHandle(ref, () => ({
+    close: () => innerRef.current?.close(),
+  }));
+
+  const handleChange = React.useCallback(
+    (index: number) => {
+      if (index === -1) {
+        onClose?.();
+      }
+    },
+    [onClose]
+  );
+
+  const renderBackdrop = React.useCallback(
+    (backdropProps: BottomSheetBackdropProps) => (
+      <BottomSheetBackdrop
+        {...backdropProps}
+        appearsOnIndex={0}
+        disappearsOnIndex={-1}
+        pressBehavior="close"
+      />
+    ),
+    []
+  );
+
+  return (
+    <View style={styles.container}>
+      <BottomSheet
+        ref={innerRef}
+        index={0}
+        enableDynamicSizing={!snapPoints}
+        snapPoints={snapPoints}
+        enablePanDownToClose
+        backdropComponent={renderBackdrop}
+        onChange={handleChange}>
+        <BottomSheetView style={[styles.content, contentStyle]}>{children}</BottomSheetView>
+      </BottomSheet>
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    paddingBottom: 24,
+  },
+});

--- a/packages/ui/src/components/sheet/index.tsx
+++ b/packages/ui/src/components/sheet/index.tsx
@@ -1,0 +1,2 @@
+export { Sheet } from './component';
+export type { SheetHandle, SheetProps } from './types';

--- a/packages/ui/src/components/sheet/types.tsx
+++ b/packages/ui/src/components/sheet/types.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react';
+import type { StyleProp, ViewStyle } from 'react-native';
+
+export type SheetHandle = {
+  /** Programmatically dismiss the sheet (e.g. from a Cancel button). */
+  close: () => void;
+};
+
+export type SheetProps = {
+  children: ReactNode;
+  /** Called when the sheet is dismissed (dragged down or backdrop-tapped). */
+  onClose?: () => void;
+  /** Fixed snap points; when omitted the sheet sizes to its content. */
+  snapPoints?: (string | number)[];
+  contentStyle?: StyleProp<ViewStyle>;
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -58,6 +58,10 @@ export { ListRow, listRowVariants } from './components/list-row';
 export type { ListRowProps } from './components/list-row';
 export { PageHeader, pageHeaderVariants } from './components/page-header';
 export type { PageHeaderProps } from './components/page-header';
+// NOTE: Sheet is intentionally NOT re-exported from this barrel. It pulls in
+// @gorhom/bottom-sheet → react-native-reanimated → worklets, which crash under
+// jest and bloat any importer. Import it from the dedicated subpath instead:
+//   import { Sheet } from '@lightbridge/ui/sheet'
 export { useIsDesktop } from './hooks/use-is-desktop';
 export { AppFont, useAppFonts } from './hooks/use-app-fonts';
 export { APP_FONT_SOURCES } from './hooks/app-font-sources';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@expo/vector-icons':
         specifier: 15.1.1
         version: 15.1.1(expo-font@55.0.7)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      '@gorhom/bottom-sheet':
+        specifier: ^5.2.14
+        version: 5.2.14(@types/react@19.2.14)(react-native-gesture-handler@2.30.1(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native-reanimated@4.2.1(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       '@lightbridge/api-native':
         specifier: workspace:*
         version: link:../../packages/api-native
@@ -113,7 +116,7 @@ importers:
         version: 55.0.13(expo@55.0.23)(react@19.2.0)
       expo-router:
         specifier: ~55.0.14
-        version: 55.0.14(98b7643f4006df551d92793e4ee223e0)
+        version: 55.0.14(b8c3f968e596dcf397844f4481f23618)
       expo-secure-store:
         specifier: ~55.0.13
         version: 55.0.13(expo@55.0.23)
@@ -144,6 +147,9 @@ importers:
       react-native-css-interop:
         specifier: ^0.2.1
         version: 0.2.3(react-native-reanimated@4.2.1(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(tailwindcss@3.4.19(yaml@2.8.4))
+      react-native-gesture-handler:
+        specifier: ~2.30.1
+        version: 2.30.1(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       react-native-reanimated:
         specifier: 4.2.1
         version: 4.2.1(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -884,6 +890,10 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
+  '@egjs/hammerjs@2.0.17':
+    resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
+    engines: {node: '>=0.8.0'}
+
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
@@ -1269,6 +1279,27 @@ packages:
   '@expo/xcpretty@4.4.4':
     resolution: {integrity: sha512-4aQzz9vgxcNXFfo/iyNgDDYfsU5XGKKxWxZopw0cVotHiW+U8IJbIxMaxsINs6bHhtkG3StKNPcOrn3eBuxKPw==}
     hasBin: true
+
+  '@gorhom/bottom-sheet@5.2.14':
+    resolution: {integrity: sha512-uLQFlDjp9z+jrOFcMSEldPqL5JdaXL3vXOh+juhwoNvXgTsEorJLjHTugXu+YccAG/0KJnShzKCrb71MHBsvJg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-native': '*'
+      react: 19.2.0
+      react-native: 0.83.6
+      react-native-gesture-handler: '>=2.16.1'
+      react-native-reanimated: '>=3.16.0 || >=4.0.0-'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-native':
+        optional: true
+
+  '@gorhom/portal@1.0.14':
+    resolution: {integrity: sha512-MXyL4xvCjmgaORr/rtryDNFy3kU4qUbKlwtQqqsygd0xX3mhKjOLn6mQK8wfu0RkoE0pBE0nAasRoHua+/QZ7A==}
+    peerDependencies:
+      react: 19.2.0
+      react-native: 0.83.6
 
   '@hey-api/codegen-core@0.6.1':
     resolution: {integrity: sha512-khTIpxhKEAqmRmeLUnAFJQs4Sbg9RPokovJk9rRcC8B5MWH1j3/BRSqfpAIiJUBDU1+nbVg2RVCV+eQ174cdvw==}
@@ -2387,6 +2418,9 @@ packages:
 
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
+
+  '@types/hammerjs@2.0.46':
+    resolution: {integrity: sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==}
 
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -4112,6 +4146,9 @@ packages:
   hermes-parser@0.36.1:
     resolution: {integrity: sha512-GApNk4zLHi2UWoWZZkx7LNCOSzLSc5lB55pZ/PhK7ycFeg7u5LcF88p/WbpIi1XUDtE0MpHE3uRR3u3KB7TjSQ==}
 
+  hoist-non-react-statics@3.3.2:
+    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
+
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -5610,6 +5647,12 @@ packages:
         optional: true
       react-native-svg:
         optional: true
+
+  react-native-gesture-handler@2.30.1:
+    resolution: {integrity: sha512-xIUBDo5ktmJs++0fZlavQNvDEE4PsihWhSeJsJtoz4Q6p0MiTM9TgrTgfEgzRR36qGPytFoeq+ShLrVwGdpUdA==}
+    peerDependencies:
+      react: 19.2.0
+      react-native: 0.83.6
 
   react-native-is-edge-to-edge@1.2.1:
     resolution: {integrity: sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q==}
@@ -7328,6 +7371,10 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
+  '@egjs/hammerjs@2.0.17':
+    dependencies:
+      '@types/hammerjs': 2.0.46
+
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -7558,7 +7605,7 @@ snapshots:
       ws: 8.21.0
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 55.0.14(98b7643f4006df551d92793e4ee223e0)
+      expo-router: 55.0.14(b8c3f968e596dcf397844f4481f23618)
       react-native: 0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -7813,7 +7860,7 @@ snapshots:
       react: 19.2.0
     optionalDependencies:
       '@expo/metro-runtime': 55.0.11(@expo/dom-webview@55.0.6)(expo@55.0.23)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
-      expo-router: 55.0.14(98b7643f4006df551d92793e4ee223e0)
+      expo-router: 55.0.14(b8c3f968e596dcf397844f4481f23618)
       react-dom: 19.2.0(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
@@ -7841,6 +7888,23 @@ snapshots:
       '@babel/code-frame': 7.29.0
       chalk: 4.1.2
       js-yaml: 4.1.1
+
+  '@gorhom/bottom-sheet@5.2.14(@types/react@19.2.14)(react-native-gesture-handler@2.30.1(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native-reanimated@4.2.1(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@gorhom/portal': 1.0.14(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      invariant: 2.2.4
+      react: 19.2.0
+      react-native: 0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      react-native-gesture-handler: 2.30.1(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      react-native-reanimated: 4.2.1(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@gorhom/portal@1.0.14(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      nanoid: 3.3.12
+      react: 19.2.0
+      react-native: 0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
 
   '@hey-api/codegen-core@0.6.1(typescript@5.9.3)':
     dependencies:
@@ -9006,6 +9070,8 @@ snapshots:
   '@types/graceful-fs@4.1.9':
     dependencies:
       '@types/node': 25.6.2
+
+  '@types/hammerjs@2.0.46': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -10573,7 +10639,7 @@ snapshots:
     optionalDependencies:
       react-native-worklets: 0.7.4(@babel/core@7.29.0)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
 
-  expo-router@55.0.14(98b7643f4006df551d92793e4ee223e0):
+  expo-router@55.0.14(b8c3f968e596dcf397844f4481f23618):
     dependencies:
       '@expo/log-box': 55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.23)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       '@expo/metro-runtime': 55.0.11(@expo/dom-webview@55.0.6)(expo@55.0.23)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -10612,6 +10678,7 @@ snapshots:
     optionalDependencies:
       '@testing-library/react-native': 14.0.1(jest@29.7.0(@types/node@25.6.2))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(test-renderer@1.2.0(@types/react@19.2.14)(react@19.2.0))
       react-dom: 19.2.0(react@19.2.0)
+      react-native-gesture-handler: 2.30.1(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       react-native-reanimated: 4.2.1(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       react-native-web: 0.21.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
@@ -10974,6 +11041,10 @@ snapshots:
   hermes-parser@0.36.1:
     dependencies:
       hermes-estree: 0.36.1
+
+  hoist-non-react-statics@3.3.2:
+    dependencies:
+      react-is: 16.13.1
 
   hosted-git-info@7.0.2:
     dependencies:
@@ -12743,6 +12814,14 @@ snapshots:
       react-native-safe-area-context: 5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
+
+  react-native-gesture-handler@2.30.1(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0):
+    dependencies:
+      '@egjs/hammerjs': 2.0.17
+      hoist-non-react-statics: 3.3.2
+      invariant: 2.2.4
+      react: 19.2.0
+      react-native: 0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
 
   react-native-is-edge-to-edge@1.2.1(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,6 +324,9 @@ importers:
         specifier: ^3.4.0
         version: 3.5.0
     devDependencies:
+      '@gorhom/bottom-sheet':
+        specifier: ^5.2.14
+        version: 5.2.14(@types/react@19.2.14)(react-native-gesture-handler@2.30.1(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native-reanimated@4.2.1(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       '@storybook/addon-a11y':
         specifier: ^10.4.6
         version: 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.8.3)(react@19.2.0))
@@ -339,6 +342,12 @@ importers:
       react-dom:
         specifier: 19.2.0
         version: 19.2.0(react@19.2.0)
+      react-native-gesture-handler:
+        specifier: ~2.30.0
+        version: 2.30.1(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      react-native-reanimated:
+        specifier: 4.2.1
+        version: 4.2.1(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       react-native-web:
         specifier: ^0.21.2
         version: 0.21.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds a presentational **`Sheet`** primitive to `packages/ui` (wraps `@gorhom/bottom-sheet`: backdrop, pan-down-to-close, dismiss→`onClose`, `ref.close()`), with a Storybook story.
- Refactors `delete-account-modal.tsx` into a thin per-flow smart wrapper that owns only the domain wiring (`useDeleteAccount`, route params, navigation) and composes `<Sheet><DeleteAccountView/></Sheet>` — **no `@gorhom/bottom-sheet` import in the screen**.
- Wires `GestureHandlerRootView` at the app root; adds gorhom + gesture-handler + reanimated as `packages/ui` peer deps.

It solves: #77 — a viable bottom-sheet primitive for this pure-web app — now delivered in the correct layering (design-system primitive + smart wrapper), not gorhom-in-a-screen.

## 2. Intent

> Establish `Sheet` as a reusable UI primitive so screens compose it instead of importing gorhom, keeping the design system the single place the sheet mechanics live. Started as the #77 spike (does reanimated 4 + gorhom 5 web-bundle?) and was re-architected per review into the primitive + smart-wrapper layering.

## 3. Scope

### In Scope
- `packages/ui` `Sheet` primitive (component/types/index + story), exported from a dedicated subpath `@lightbridge/ui/sheet` (not the barrel — see Risk).
- `delete-account-modal` refactor; root `GestureHandlerRootView`; dep additions.

### Out of Scope
- Converting other modal flows; native (iOS/Android) verification; interactive gesture testing of the real (auth-gated) delete-account flow.

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests

Commands run:

```bash
npx tsc --noEmit -p packages/ui
npx tsc --noEmit -p apps/self-service/tsconfig.json
pnpm --filter self-service test
pnpm --filter @lightbridge/ui build-storybook
cd apps/self-service && npx expo export --platform web
```

Results:

```text
tsc (both projects): clean
Test Suites: 16 passed, 16 total   Tests: 53 passed, 53 total
Storybook build: completed successfully (Sheet story bundles under Vite)
expo export --platform web: Exported: dist — no reanimated/gorhom/gesture-handler errors
```

Manual verification (Preview MCP):
- **App boots on web** with `GestureHandlerRootView` wrapping the whole tree and reanimated 4 / gesture-handler / gorhom loaded — login renders, **zero console errors**.
- **`Sheet` Storybook story renders under Vite** with zero console errors — so the sheet is interactively reviewable in the deployed Storybook, independent of the app's Keycloak auth gate.

**Still pending:** the interactive gesture on the *real* delete-account flow (open/drag/backdrop-tap) — that route is behind Keycloak, needing a local WireMock+Keycloak smoke test. Kept as **draft** for that. (The Storybook Sheet story covers interactive gorhom review in the meantime.)

## 5. Screenshots / Evidence

- Source of truth: #77 (spike ticket) and ADR 0006 (ruled out `@expo/ui`, named `@gorhom/bottom-sheet@5.x` as the alternative). Deployed Storybook (auto-redeploys on merge): https://adorsys-gis.github.io/converse-frontends/
- Runtime evidence captured this session (app login boot; Sheet story render) — see PR comments.

## 6. Risk Assessment

Risk level:

* [x] Medium — additive deps + a root wrapper + a design-system dependency on gorhom/reanimated.

Potential risks:

* Barrel contamination: exporting `Sheet` from `@lightbridge/ui` made every UI importer transitively pull `gorhom → reanimated → worklets`, crashing jest (4 suites failed). Mitigated by exporting `Sheet` only from the `@lightbridge/ui/sheet` subpath, keeping the barrel reanimated-free; documented inline in `index.ts`.
* Interactive web gesture behavior on the real flow is unverified (auth-gated) — see Verification.

Mitigation:

* Subpath isolation; full test suite + both tsc clean; Storybook + web-bundle + app-boot all verified.

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Refactoring
* [x] Reviewing the diff

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked the dependency additions and version pins
* [ ] I checked the barrel-isolation reasoning
* [ ] I will run the interactive delete-account gesture smoke-test before relying on this pattern
* [ ] I accept responsibility for this PR

> The #77 spike (build-level viability) ran in a background agent; the primitive/smart-wrapper re-architecture and all verification were done in the main session. The in-house `review / opencode` bot is failing on its own expired `OPENCODE_API_KEY`, so it did not review this PR. @stephane-segning must tick the boxes before taking this out of draft.

## 8. Reviewer Focus

* [x] Architecture (the layering + subpath isolation)
* [x] Correctness
* [x] Maintainability
