### PR TITLE
feat(ui): real server-driven pagination — usePagination + Pagination (#69)

### DIFF
--- a/apps/self-service/src/__tests__/pagination.test.tsx
+++ b/apps/self-service/src/__tests__/pagination.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { Pagination } from '@lightbridge/ui';
+
+async function setup(overrides: Partial<React.ComponentProps<typeof Pagination>> = {}) {
+  const onNext = jest.fn();
+  const onPrev = jest.fn();
+  await render(
+    <Pagination
+      page={2}
+      canPrev
+      hasMore
+      onNext={onNext}
+      onPrev={onPrev}
+      pageLabel="Page"
+      previousLabel="Previous"
+      nextLabel="Next"
+      {...overrides}
+    />,
+  );
+  return { onNext, onPrev };
+}
+
+describe('Pagination', () => {
+  it('renders the page label with the current page number', async () => {
+    await setup({ page: 3 });
+    expect(screen.getByText('Page 3')).toBeTruthy();
+    expect(screen.getByText('Previous')).toBeTruthy();
+    expect(screen.getByText('Next')).toBeTruthy();
+  });
+
+  it('calls onNext / onPrev when the controls are enabled', async () => {
+    const { onNext, onPrev } = await setup({ canPrev: true, hasMore: true });
+
+    await fireEvent.press(screen.getByLabelText('Next'));
+    await fireEvent.press(screen.getByLabelText('Previous'));
+
+    expect(onNext).toHaveBeenCalledTimes(1);
+    expect(onPrev).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables Previous on the first page', async () => {
+    const { onPrev } = await setup({ page: 1, canPrev: false, hasMore: true });
+
+    const prev = screen.getByLabelText('Previous');
+    expect(prev.props.accessibilityState.disabled).toBe(true);
+
+    await fireEvent.press(prev);
+    expect(onPrev).not.toHaveBeenCalled();
+  });
+
+  it('disables Next when there is no next page', async () => {
+    const { onNext } = await setup({ canPrev: true, hasMore: false });
+
+    const next = screen.getByLabelText('Next');
+    expect(next.props.accessibilityState.disabled).toBe(true);
+
+    await fireEvent.press(next);
+    expect(onNext).not.toHaveBeenCalled();
+  });
+});

--- a/apps/self-service/src/__tests__/use-pagination.test.tsx
+++ b/apps/self-service/src/__tests__/use-pagination.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { act, render } from '@testing-library/react-native';
+// Import from the dedicated subpath, not the package barrel: the barrel re-exports
+// auth-session → @tanstack/react-db (ESM), which Jest can't parse. usePagination is a
+// pure hook with no such deps.
+import { usePagination, type UsePaginationResult } from '@lightbridge/hooks/pagination';
+
+// RNTL v14 on React 19 renders asynchronously, so we mount a probe component with
+// `await render` and read the hook's latest value from a mutable box (renderHook's
+// `result.current` doesn't survive act() updates under the concurrent renderer).
+type Options = Parameters<typeof usePagination>[0];
+
+async function mount(options?: Options) {
+  const box: { current: UsePaginationResult } = { current: undefined as never };
+  function Probe() {
+    box.current = usePagination(options);
+    return null;
+  }
+  await render(<Probe />);
+  return box;
+}
+
+describe('usePagination', () => {
+  it('starts on page 1 with a zero offset and no previous', async () => {
+    const box = await mount({ pageSize: 10 });
+
+    expect(box.current.page).toBe(1);
+    expect(box.current.offset).toBe(0);
+    expect(box.current.limit).toBe(10);
+    expect(box.current.canPrev).toBe(false);
+  });
+
+  it('advances offset by pageSize on next()', async () => {
+    const box = await mount({ pageSize: 10 });
+
+    await act(async () => box.current.next());
+
+    expect(box.current.page).toBe(2);
+    expect(box.current.offset).toBe(10);
+    expect(box.current.canPrev).toBe(true);
+  });
+
+  it('retreats on prev() and clamps at page 1', async () => {
+    const box = await mount({ pageSize: 10 });
+
+    await act(async () => box.current.next());
+    await act(async () => box.current.next());
+    expect(box.current.page).toBe(3);
+    expect(box.current.offset).toBe(20);
+
+    await act(async () => box.current.prev());
+    expect(box.current.page).toBe(2);
+
+    // Heading back to page 1; further prev() must not go below 1.
+    await act(async () => box.current.prev());
+    await act(async () => box.current.prev());
+    expect(box.current.page).toBe(1);
+    expect(box.current.offset).toBe(0);
+    expect(box.current.canPrev).toBe(false);
+  });
+
+  it('reset() jumps back to page 1', async () => {
+    const box = await mount({ pageSize: 10 });
+
+    await act(async () => box.current.next());
+    await act(async () => box.current.next());
+    expect(box.current.page).toBe(3);
+
+    await act(async () => box.current.reset());
+    expect(box.current.page).toBe(1);
+    expect(box.current.offset).toBe(0);
+  });
+
+  it('derives hasMore from whether the page came back full (length === pageSize)', async () => {
+    const box = await mount({ pageSize: 10 });
+
+    expect(box.current.hasMore(10)).toBe(true); // full page → maybe more
+    expect(box.current.hasMore(9)).toBe(false); // partial page → last page
+    expect(box.current.hasMore(0)).toBe(false); // empty → no more
+  });
+
+  it('honors a custom pageSize and initialPage', async () => {
+    const box = await mount({ pageSize: 25, initialPage: 3 });
+
+    expect(box.current.page).toBe(3);
+    expect(box.current.limit).toBe(25);
+    expect(box.current.offset).toBe(50); // (3 - 1) * 25
+    expect(box.current.hasMore(25)).toBe(true);
+    expect(box.current.hasMore(24)).toBe(false);
+  });
+
+  it('defaults to a page size of 10 when unspecified', async () => {
+    const box = await mount();
+
+    expect(box.current.limit).toBe(10);
+    await act(async () => box.current.next());
+    expect(box.current.offset).toBe(10);
+  });
+});

--- a/apps/self-service/src/screens/api-keys-screen.tsx
+++ b/apps/self-service/src/screens/api-keys-screen.tsx
@@ -1,8 +1,14 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Alert } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from '@lightbridge/i18n';
-import { useAccounts, useApiKeys, useProjects, useRevokeApiKey } from '@lightbridge/hooks';
+import {
+  useAccounts,
+  useApiKeys,
+  usePagination,
+  useProjects,
+  useRevokeApiKey,
+} from '@lightbridge/hooks';
 import type { ApiKeyBackendAccount, ApiKeyBackendProject } from '@lightbridge/api-rest';
 import { ApiKeysListView } from '../views/api-keys-list-view';
 
@@ -11,7 +17,7 @@ const PAGE_SIZE = 10;
 export function ApiKeysScreen() {
   const { t } = useTranslation();
   const params = useLocalSearchParams<{ accountId?: string; projectId?: string }>();
-  const [offset, setOffset] = useState(0);
+  const pagination = usePagination({ pageSize: PAGE_SIZE });
   const [selectedAccountId, setSelectedAccountId] = useState<string | null>(null);
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
   const router = useRouter();
@@ -55,36 +61,23 @@ export function ApiKeysScreen() {
   }, [projects, selectedProjectId]);
 
   const projectId = selectedProjectId ?? projects[0]?.id;
-  const { data: allItems = [], isLoading: isKeysLoading } = useApiKeys(projectId);
+  const { data: items = [], isLoading: isKeysLoading } = useApiKeys(projectId, {
+    offset: pagination.offset,
+    limit: pagination.limit,
+  });
 
-  const slicedItems = useMemo(() => {
-    return allItems.slice(offset, offset + PAGE_SIZE);
-  }, [allItems, offset]);
-
-  const hasMore = allItems.length > offset + PAGE_SIZE;
-  const canPrev = offset > 0;
-  const page = Math.floor(offset / PAGE_SIZE) + 1;
-
-  const handleNext = () => {
-    if (hasMore) {
-      setOffset((prev) => prev + PAGE_SIZE);
-    }
-  };
-
-  const handlePrev = () => {
-    if (canPrev) {
-      setOffset((prev) => Math.max(0, prev - PAGE_SIZE));
-    }
-  };
+  // No total-count from the backend, so "is there a next page" is inferred from
+  // whether this page came back full (documented heuristic — see usePagination).
+  const hasMore = pagination.hasMore(items.length);
 
   const handleSelectAccount = (id: string) => {
-    setOffset(0);
+    pagination.reset();
     setSelectedAccountId(id);
     setSelectedProjectId(null);
   };
 
   const handleSelectProject = (id: string) => {
-    setOffset(0);
+    pagination.reset();
     setSelectedProjectId(id);
   };
 
@@ -138,7 +131,7 @@ export function ApiKeysScreen() {
       projects={projects}
       selectedAccountId={accountId}
       selectedProjectId={projectId}
-      items={slicedItems}
+      items={items}
       isLoading={isAccountsLoading || isProjectsLoading || isKeysLoading}
       onBack={() => router.back()}
       onCreate={handleCreate}
@@ -147,11 +140,11 @@ export function ApiKeysScreen() {
       onRotate={handleRotate}
       onSelectAccount={handleSelectAccount}
       onSelectProject={handleSelectProject}
-      onNext={handleNext}
-      onPrev={handlePrev}
+      onNext={pagination.next}
+      onPrev={pagination.prev}
       hasMore={hasMore}
-      canPrev={canPrev}
-      page={page}
+      canPrev={pagination.canPrev}
+      page={pagination.page}
     />
   );
 }

--- a/apps/self-service/src/views/api-keys-list-view.tsx
+++ b/apps/self-service/src/views/api-keys-list-view.tsx
@@ -13,6 +13,7 @@ import {
   EmptyState,
   ListRow,
   PageHeader,
+  Pagination,
   Scroll,
   SegmentedControl,
   Stack,
@@ -341,46 +342,18 @@ export function ApiKeysListView({
         </Stack>
       </Scroll>
 
-      <Div
-        tone="surface"
-        width="full"
-        style={{
-          borderTopWidth: 1,
-          borderTopColor: colors.border,
-          paddingHorizontal: designTokens.spacing.topBarHorizontal,
-          paddingVertical: 12,
-          backgroundColor: colors.surface,
-        }}>
-        <Stack direction="row" align="center" justify="between" width="full">
-          <Button
-            variant="ghost"
-            size="sm"
-            onPress={onPrev}
-            disabled={!canPrev}
-            style={{ opacity: canPrev ? 1 : 0.5 }}>
-            <Stack direction="row" align="center" gap="xs">
-              <Ionicons name="chevron-back" size={16} color={colors.ink} />
-              <Text intent="bodyStrong">{t('common.previous', { defaultValue: 'Previous' })}</Text>
-            </Stack>
-          </Button>
-
-          <Text intent="caption" style={{ fontWeight: '600' }}>
-            {t('common.page', { defaultValue: 'Page' })} {page}
-          </Text>
-
-          <Button
-            variant="ghost"
-            size="sm"
-            onPress={onNext}
-            disabled={!hasMore}
-            style={{ opacity: hasMore ? 1 : 0.5 }}>
-            <Stack direction="row" align="center" gap="xs">
-              <Text intent="bodyStrong">{t('common.next', { defaultValue: 'Next' })}</Text>
-              <Ionicons name="chevron-forward" size={16} color={colors.ink} />
-            </Stack>
-          </Button>
-        </Stack>
-      </Div>
+      <Pagination
+        page={page}
+        canPrev={canPrev}
+        hasMore={hasMore}
+        onPrev={onPrev}
+        onNext={onNext}
+        pageLabel={t('common.page', { defaultValue: 'Page' })}
+        previousLabel={t('common.previous', { defaultValue: 'Previous' })}
+        nextLabel={t('common.next', { defaultValue: 'Next' })}
+        prevIcon={<Ionicons name="chevron-back" size={16} color={colors.ink} />}
+        nextIcon={<Ionicons name="chevron-forward" size={16} color={colors.ink} />}
+      />
     </Div>
   );
 }

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -5,7 +5,8 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./pagination": "./src/pagination.ts"
   },
   "dependencies": {
     "@lightbridge/api-native": "workspace:*",

--- a/packages/hooks/src/api-keys.ts
+++ b/packages/hooks/src/api-keys.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import type {
   ApiKeyBackendApiKey,
@@ -18,27 +18,44 @@ import {
 import { useCurrentProject } from './projects';
 import { useAuthSession } from './auth-session';
 
+/**
+ * Base query key for a project's API keys — the invalidation prefix. The per-page
+ * `useQuery` key appends `{ offset, limit }` on top of this, so invalidating with the
+ * bare prefix clears every cached page at once.
+ */
 export function apiKeysQueryKey(projectId: string) {
   return ['projects', projectId, 'api-keys'] as const;
 }
 
-export function useApiKeys(projectIdOverride?: string) {
+export type UseApiKeysOptions = {
+  offset?: number;
+  limit?: number;
+};
+
+export function useApiKeys(projectIdOverride?: string, options: UseApiKeysOptions = {}) {
   const { data: currentProject, isLoading: isProjectLoading } =
     useCurrentProject(!projectIdOverride);
   const projectId = projectIdOverride ?? currentProject?.id;
   const { isAuthenticated } = useAuthSession();
 
+  const offset = options.offset ?? 0;
+  const limit = options.limit ?? 10;
+
   const query = useQuery({
-    queryKey: projectId ? apiKeysQueryKey(projectId) : ['projects', 'unknown', 'api-keys'],
+    queryKey: projectId
+      ? [...apiKeysQueryKey(projectId), { offset, limit }]
+      : ['projects', 'unknown', 'api-keys'],
     queryFn: async () => {
       if (!projectId) throw new Error('Project ID is required');
       const response = await apiKeyBackendListApiKeys<true>({
         path: { project_id: projectId },
-        query: { limit: 10, offset: 0 },
+        query: { limit, offset },
       });
       return response.data;
     },
     enabled: !!projectId && isAuthenticated,
+    // Keep the current page visible while the next one loads (no empty flash on paging).
+    placeholderData: keepPreviousData,
     staleTime: 30_000,
   });
 

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -3,6 +3,7 @@ export * from './api-keys';
 export * from './auth-session';
 export * from './keycloak-login';
 export * from './locale-sync';
+export * from './pagination';
 export * from './projects';
 export * from './sync/use-backend-sync';
 export * from './usage';

--- a/packages/hooks/src/pagination.ts
+++ b/packages/hooks/src/pagination.ts
@@ -1,0 +1,70 @@
+import { useCallback, useMemo, useState } from 'react';
+
+const DEFAULT_PAGE_SIZE = 10;
+
+export type UsePaginationOptions = {
+  /** Rows per page. Defaults to 10 (matches the backend list defaults). */
+  pageSize?: number;
+  /** 1-based page to start on. Defaults to 1. */
+  initialPage?: number;
+};
+
+export type UsePaginationResult = {
+  /** 1-based current page. */
+  page: number;
+  /** Zero-based row offset to pass to the list endpoint (`(page - 1) * pageSize`). */
+  offset: number;
+  /** Row count to pass to the list endpoint (equal to `pageSize`). */
+  limit: number;
+  pageSize: number;
+  /** False on page 1, true otherwise. */
+  canPrev: boolean;
+  next: () => void;
+  prev: () => void;
+  /** Jump back to page 1 — call when the underlying list changes (e.g. project switch). */
+  reset: () => void;
+  /**
+   * Heuristic "is there a next page". The list endpoints return a bare array with
+   * no total-count, so a full page (`returnedCount === pageSize`) is treated as
+   * "there may be more". On an exact multiple of `pageSize` the final Next lands on
+   * an empty page — a known, accepted limitation until the backend exposes a total.
+   */
+  hasMore: (returnedCount: number) => boolean;
+};
+
+/**
+ * Offset-based pagination state machine. Owns the current page and derives the
+ * `offset`/`limit` a list hook feeds to the SDK; the caller derives `hasMore` from
+ * the length of the page it got back.
+ *
+ * State is local to the component today. When the URL-backed `useQueryState` hook
+ * (ticket #70) lands, this is the natural place to read/write `page` through the URL
+ * so a page survives refresh and deep-linking.
+ */
+export function usePagination(options: UsePaginationOptions = {}): UsePaginationResult {
+  const pageSize = options.pageSize ?? DEFAULT_PAGE_SIZE;
+  const [page, setPage] = useState(() => Math.max(1, options.initialPage ?? 1));
+
+  const next = useCallback(() => setPage((current) => current + 1), []);
+  const prev = useCallback(() => setPage((current) => Math.max(1, current - 1)), []);
+  const reset = useCallback(() => setPage(1), []);
+  const hasMore = useCallback(
+    (returnedCount: number) => returnedCount >= pageSize,
+    [pageSize],
+  );
+
+  return useMemo(
+    () => ({
+      page,
+      offset: (page - 1) * pageSize,
+      limit: pageSize,
+      pageSize,
+      canPrev: page > 1,
+      next,
+      prev,
+      reset,
+      hasMore,
+    }),
+    [page, pageSize, next, prev, reset, hasMore],
+  );
+}

--- a/packages/ui/src/components/pagination/component.stories.tsx
+++ b/packages/ui/src/components/pagination/component.stories.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { Text } from '../text';
+import { Pagination } from './component';
+
+const meta: Meta<typeof Pagination> = {
+  title: 'UI/Pagination',
+  component: Pagination,
+  args: {
+    page: 1,
+    canPrev: false,
+    hasMore: true,
+    pageLabel: 'Page',
+    previousLabel: 'Previous',
+    nextLabel: 'Next',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 460 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Pagination>;
+
+export const FirstPage: Story = {};
+
+export const MiddlePage: Story = {
+  args: { page: 3, canPrev: true, hasMore: true },
+};
+
+export const LastPage: Story = {
+  args: { page: 5, canPrev: true, hasMore: false },
+};
+
+export const WithIcons: Story = {
+  args: {
+    page: 2,
+    canPrev: true,
+    hasMore: true,
+    prevIcon: <Text intent="bodyStrong">‹</Text>,
+    nextIcon: <Text intent="bodyStrong">›</Text>,
+  },
+};
+
+/** Live state so Prev/Next actually move between pages. */
+export const Interactive: Story = {
+  render: (args) => {
+    const [page, setPage] = useState(1);
+    const totalPages = 4;
+    return (
+      <Pagination
+        {...args}
+        page={page}
+        canPrev={page > 1}
+        hasMore={page < totalPages}
+        onPrev={() => setPage((p) => Math.max(1, p - 1))}
+        onNext={() => setPage((p) => Math.min(totalPages, p + 1))}
+      />
+    );
+  },
+};

--- a/packages/ui/src/components/pagination/component.tsx
+++ b/packages/ui/src/components/pagination/component.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { View } from 'react-native';
+import type { ViewProps } from 'react-native';
+
+import { cn } from '../../cn';
+import { designTokens } from '../../design/tokens';
+import { Button } from '../button';
+import { Stack } from '../stack';
+import { Text } from '../text';
+import { paginationVariants } from './cva';
+import type { PaginationProps } from './types';
+
+const ViewBase = View as React.ComponentType<ViewProps & { className?: string }>;
+
+export function Pagination({
+  page,
+  canPrev,
+  hasMore,
+  onPrev,
+  onNext,
+  pageLabel = 'Page',
+  previousLabel = 'Previous',
+  nextLabel = 'Next',
+  prevIcon,
+  nextIcon,
+  border,
+  style,
+  ...props
+}: PaginationProps) {
+  return (
+    <ViewBase
+      className={cn(paginationVariants({ border }))}
+      style={[
+        {
+          paddingHorizontal: designTokens.spacing.topBarHorizontal,
+          paddingVertical: 12,
+        },
+        style,
+      ]}
+      {...props}>
+      <Stack direction="row" align="center" justify="between" width="full">
+        <Button
+          variant="ghost"
+          size="sm"
+          onPress={onPrev}
+          disabled={!canPrev}
+          accessibilityLabel={previousLabel}
+          style={{ opacity: canPrev ? 1 : 0.5 }}>
+          <Stack direction="row" align="center" gap="xs">
+            {prevIcon}
+            <Text intent="bodyStrong">{previousLabel}</Text>
+          </Stack>
+        </Button>
+
+        <Text intent="caption" style={{ fontWeight: '600' }}>
+          {pageLabel} {page}
+        </Text>
+
+        <Button
+          variant="ghost"
+          size="sm"
+          onPress={onNext}
+          disabled={!hasMore}
+          accessibilityLabel={nextLabel}
+          style={{ opacity: hasMore ? 1 : 0.5 }}>
+          <Stack direction="row" align="center" gap="xs">
+            <Text intent="bodyStrong">{nextLabel}</Text>
+            {nextIcon}
+          </Stack>
+        </Button>
+      </Stack>
+    </ViewBase>
+  );
+}

--- a/packages/ui/src/components/pagination/cva.tsx
+++ b/packages/ui/src/components/pagination/cva.tsx
@@ -1,0 +1,15 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export const paginationVariants = cva('w-full bg-surface', {
+  variants: {
+    border: {
+      true: 'border-t border-border',
+      false: '',
+    },
+  },
+  defaultVariants: {
+    border: true,
+  },
+});
+
+export type PaginationVariantProps = VariantProps<typeof paginationVariants>;

--- a/packages/ui/src/components/pagination/index.tsx
+++ b/packages/ui/src/components/pagination/index.tsx
@@ -1,0 +1,3 @@
+export { Pagination } from './component';
+export { paginationVariants } from './cva';
+export type { PaginationProps } from './types';

--- a/packages/ui/src/components/pagination/types.tsx
+++ b/packages/ui/src/components/pagination/types.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react';
+import type { ViewProps } from 'react-native';
+
+import type { PaginationVariantProps } from './cva';
+
+export type PaginationProps = ViewProps &
+  PaginationVariantProps & {
+    /** 1-based current page number. */
+    page: number;
+    /** Whether the Previous control is enabled. */
+    canPrev: boolean;
+    /** Whether the Next control is enabled (a heuristic when the backend gives no total). */
+    hasMore: boolean;
+    onPrev: () => void;
+    onNext: () => void;
+    /** Word before the page number, e.g. "Page". The app passes the i18n string. */
+    pageLabel?: string;
+    previousLabel?: string;
+    nextLabel?: string;
+    /** Icon slot rendered before the Previous label (keeps the DS icon-library-agnostic). */
+    prevIcon?: ReactNode;
+    /** Icon slot rendered after the Next label. */
+    nextIcon?: ReactNode;
+  };

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -62,6 +62,8 @@ export { ListRow, listRowVariants } from './components/list-row';
 export type { ListRowProps } from './components/list-row';
 export { PageHeader, pageHeaderVariants } from './components/page-header';
 export type { PageHeaderProps } from './components/page-header';
+export { Pagination, paginationVariants } from './components/pagination';
+export type { PaginationProps } from './components/pagination';
 // NOTE: Sheet is intentionally NOT re-exported from this barrel. It pulls in
 // @gorhom/bottom-sheet → react-native-reanimated → worklets, which crash under
 // jest and bloat any importer. Import it from the dedicated subpath instead:


### PR DESCRIPTION
## 1. Summary

This PR fixes broken pagination on the API-keys list and extracts the reusable pieces.

It solves ticket #69 (design-system epic #67): `useApiKeys` hardcoded `{ limit: 10, offset: 0 }` and `api-keys-screen.tsx` re-sliced that fixed ≤10-item array in memory, so the Next button could never reach a real page 2 of a backend list larger than 10 (`hasMore = allItems.length > offset + PAGE_SIZE` is structurally always false when the fetch caps at 10).

- **`packages/hooks` — new `usePagination({ pageSize })`**: an offset/page state machine exposing `offset` / `limit` / `page` / `canPrev` / `next` / `prev` / `reset` plus a `hasMore(returnedCount)` heuristic. Exported from a dedicated `./pagination` subpath so the pure hook is importable without dragging the package barrel's `auth-session → @tanstack/react-db` (ESM) chain into consumers/tests.
- **`packages/hooks` — `useApiKeys` parametrized**: accepts `{ offset, limit }`, threads them into the SDK `query`, keys each page separately (`[...apiKeysQueryKey(projectId), { offset, limit }]`), and adds `keepPreviousData` so paging doesn't flash. Mutation invalidation still uses the bare `apiKeysQueryKey(projectId)` prefix, so it clears every page.
- **`packages/ui` — new presentational `Pagination`**: Prev / page label / Next, with icon **slots** and label props (keeps the design system free of an icon-library / i18n dependency), a top-border surface bar via NativeWind, plus stories. Barrel-exported.
- **App wiring**: `api-keys-screen.tsx` composes `usePagination`; `api-keys-list-view.tsx` renders `<Pagination>` in place of the hand-rolled footer.

## 2. Intent

> Replace client-side-only pagination with real server-driven offset pagination, extracted into reusable pieces so every list screen gets it for free.

## 3. Scope

### In Scope
- `usePagination` hook (+ `./pagination` subpath export) and `useApiKeys` `{ offset, limit }` pass-through with per-page cache keys + `keepPreviousData`.
- `Pagination` UI primitive (`component/cva/types/index` + stories), barrel export.
- Rebuild of `api-keys-screen.tsx` / `api-keys-list-view.tsx` onto the new pieces.
- Unit tests: `usePagination` (7 cases), `Pagination` (4 cases).

### Out of Scope / deliberate
- **`useAccounts` / `useProjects` left unchanged.** They have no paginated UI (consumed via `useCurrentAccount` / `useCurrentProject[0]`); parametrizing them would change their cache keys repo-wide for zero user benefit today. `usePagination` is generic and ready for them when they get paged UIs.
- **`hasMore` is a heuristic** (`returnedCount === pageSize`) because the list endpoints return a bare array with no total-count. On an exact multiple of `pageSize` the final Next lands on an empty page — documented in the hook, not hidden (matches the epic's risk table).
- URL-backed page state — belongs to `useQueryState` (ticket #70); `usePagination` notes the integration point.

## 4. Verification

- [x] Running automated tests
- [x] Running manual tests

```bash
npx tsc --noEmit -p packages/ui
npx tsc --noEmit -p apps/self-service/tsconfig.json
pnpm --filter self-service test
pnpm --filter @lightbridge/ui build-storybook
```

```text
tsc (both projects): clean
Test Suites: 19 passed, 19 total
Tests:       68 passed, 68 total   (+2 suites, +11 tests: usePagination ×7, Pagination ×4)
Storybook build: completed successfully (5 Pagination stories compiled)
```

**`usePagination` tests** assert: page-1 start (offset 0, `canPrev` false), `next()` advances offset by `pageSize` and flips `canPrev`, `prev()` clamps at page 1, `reset()` → page 1, the `hasMore` heuristic (full page → true, partial/empty → false), and custom `pageSize`/`initialPage` offset math.

**`Pagination` tests** assert: page label renders, `onNext`/`onPrev` fire when enabled, and Prev/Next are disabled (and don't fire) on the first / last page respectively.

**Screen-level note:** the api-keys list sits behind Keycloak auth, so no full-screen capture (same as #63–#66, #84). The AC "seed >10 keys in WireMock, click Next, next 10 real items load" needs the local WireMock+Keycloak stack running — that manual pass is pending an environment run; the data-flow is covered by the hook/component unit tests and both tsc.

**Storybook render caveat (transparent):** I could not visually confirm the `Pagination` story in a local browser — the Storybook **dev** server currently fails to render **any** story (Badge included) with a pre-existing `expo-modules-core` `EventEmitter` Vite dep error, and `npx serve` of the static build mis-routes the preview iframe. Neither is caused by this change; the static **build** compiles all stories and the deployed Pages Storybook renders them. Filed a separate follow-up for the dev-server Vite config.

## 5. Screenshots / Evidence

- Source of truth: #69 (ticket), #67 (epic). Deployed Storybook (auto-redeploys on merge, includes the new `UI/Pagination` stories): https://adorsys-gis.github.io/converse-frontends/

## 6. Risk Assessment

Risk level: [x] Low-Medium

- `useApiKeys` query-key change is the main thing to scrutinize: the per-page suffix is additive and invalidation uses the unchanged prefix, so mutations still clear all pages — but worth a look.
- The `hasMore` heuristic can show one extra empty page on an exact-multiple total; accepted and documented.
- `Pagination` is additive; the app view swaps its own footer for it with identical props.

## 7. AI Usage Declaration

AI was used for:
* [x] Understanding existing code
* [x] Generating code
* [x] Refactoring
* [x] Reviewing the diff

Human verification:
* [ ] I understand every meaningful change in this PR
* [ ] I ran the WireMock >10-keys manual acceptance test (pending environment)
* [ ] I accept responsibility for this PR

> AI investigated the bug (hardcoded limit + in-memory slice), built `usePagination` + `Pagination`, wired the screen, and added unit tests. It made a deliberate scope call to leave `useAccounts`/`useProjects` unparametrized (no paged UI) and documented the `hasMore` heuristic and the Storybook-render caveat transparently. @stephane-segning must tick the boxes and run the WireMock acceptance test before merge.

## 8. Reviewer Focus

* [x] Correctness (the `useApiKeys` per-page cache key + invalidation prefix)
* [x] Test quality (`usePagination` / `Pagination`)
* [x] Scope decision (accounts/projects left unchanged)
