### PR TITLE
feat(ui): console visual redesign — recalibrated palette + centered shell

### DIFF
--- a/apps/self-service/src/components/usage-kpi-card.tsx
+++ b/apps/self-service/src/components/usage-kpi-card.tsx
@@ -14,23 +14,19 @@ export function UsageKpiCard({ label, value, icon, variant = 'default', tone = '
 
   if (isBrand) {
     return (
-      <Div 
-        tone="brand" 
-        rounded="xl" 
-        shadow="lg" 
-        pad="lg" 
-        width="full"
-      >
-        <Stack gap="md">
-          <Stack direction="row" justify="between" align="center" width="full">
-            <Text intent="inverseBodyStrong">{label}</Text>
-            {icon}
+      <Card size="md">
+        <Stack direction="row" justify="between" align="start" width="full">
+          <Stack gap="xs" style={{ flex: 1 }}>
+            <Text intent="eyebrow">{label}</Text>
+            <Text intent="display">{value}</Text>
           </Stack>
-          <Stack gap="xs">
-            <Text intent="inverseValue">{value}</Text>
-          </Stack>
+          {icon ? (
+            <Div tone={tone} rounded="full" size="iconMd" align="center" justify="center">
+              {icon}
+            </Div>
+          ) : null}
         </Stack>
-      </Div>
+      </Card>
     );
   }
 

--- a/apps/self-service/src/views/api-keys-list-view.tsx
+++ b/apps/self-service/src/views/api-keys-list-view.tsx
@@ -15,7 +15,6 @@ import {
   PageHeader,
   Pagination,
   Scroll,
-  SegmentedControl,
   Stack,
   Text,
 } from '@lightbridge/ui';
@@ -140,7 +139,7 @@ export function ApiKeysListView({
                       return (
                         <Button
                           key={account.id}
-                          variant={isSelected ? 'primary' : 'neutral'}
+                          variant={isSelected ? 'brandSoft' : 'neutral'}
                           size="sm"
                           onPress={() => onSelectAccount(account.id)}
                           accessibilityLabel={t('apiKeys.selectAccount', {
@@ -168,7 +167,7 @@ export function ApiKeysListView({
                       return (
                         <Button
                           key={project.id}
-                          variant={isSelected ? 'primary' : 'neutral'}
+                          variant={isSelected ? 'brandSoft' : 'neutral'}
                           size="sm"
                           onPress={() => onSelectProject(project.id)}
                           accessibilityLabel={t('apiKeys.selectProject', {
@@ -277,31 +276,30 @@ export function ApiKeysListView({
 
                       <Divider tone="muted" />
 
-                      <SegmentedControl
-                        width="full"
-                        value=""
-                        options={[
-                          {
-                            key: 'revoke',
-                            label: t('apiKeys.revoke'),
-                            accessibilityLabel: t('apiKeys.revokeNamed', { name: item.name }),
-                            disabled: !isActive,
-                          },
-                          {
-                            key: 'rotate',
-                            label: t('apiKeys.rotate'),
-                            accessibilityLabel: t('apiKeys.rotateNamed', { name: item.name }),
-                            disabled: !isActive,
-                          },
-                        ]}
-                        onChange={(key) => {
-                          if (key === 'revoke') {
-                            onRevoke(item.id, item.name);
-                          } else if (key === 'rotate') {
-                            onRotate(item.id, item.name);
-                          }
-                        }}
-                      />
+                      {/* Two discrete actions — a segmented control implies a
+                          persistent selection, which these aren't. Rotate is
+                          neutral; Revoke is destructive (error-tinted label). */}
+                      <Stack direction="row" gap="sm" width="full">
+                        <Button
+                          variant="neutral"
+                          size="sm"
+                          disabled={!isActive}
+                          onPress={() => onRotate(item.id, item.name)}
+                          accessibilityLabel={t('apiKeys.rotateNamed', { name: item.name })}
+                          style={{ flex: 1 }}>
+                          {t('apiKeys.rotate')}
+                        </Button>
+                        <Button
+                          variant="neutral"
+                          size="sm"
+                          disabled={!isActive}
+                          onPress={() => onRevoke(item.id, item.name)}
+                          accessibilityLabel={t('apiKeys.revokeNamed', { name: item.name })}
+                          textProps={{ style: { color: colors.error } }}
+                          style={{ flex: 1 }}>
+                          {t('apiKeys.revoke')}
+                        </Button>
+                      </Stack>
 
                       <Divider tone="muted" />
 

--- a/apps/self-service/src/views/home-view.tsx
+++ b/apps/self-service/src/views/home-view.tsx
@@ -209,19 +209,18 @@ export function HomeView({
           </Stack>
         </Card>
 
-        <Div tone="brand" rounded="xl" shadow="lg" pad="lg" width="full">
-          <Stack gap="md">
-            <Stack direction="row" justify="between" align="center" width="full">
-              <Text intent="inverseBodyStrong">{t('home.currentUsage')}</Text>
-              <Ionicons name="stats-chart" size={18} color={colors.surface} />
+        <Card size="md">
+          <Stack direction="row" justify="between" align="start" width="full">
+            <Stack gap="xs" style={{ flex: 1 }}>
+              <Text intent="eyebrow">{t('home.currentUsage')}</Text>
+              <Text intent="display">${usedRequests.toFixed(2)}</Text>
+              <Text intent="caption">{summaryLabel}</Text>
             </Stack>
-
-            <Stack gap="xs">
-              <Text intent="inverseValue">${usedRequests.toFixed(2)}</Text>
-              <Text intent="inverseCaption">{summaryLabel}</Text>
-            </Stack>
+            <Div tone="brandSoft" rounded="full" size="iconMd" align="center" justify="center">
+              <Ionicons name="stats-chart" size={designTokens.icon.action} color={colors.primary} />
+            </Div>
           </Stack>
-        </Div>
+        </Card>
 
         <Stack gap="md">
           <Text intent="eyebrow">{t('home.quickActions.title')}</Text>

--- a/apps/self-service/src/views/mcp-builder-view.tsx
+++ b/apps/self-service/src/views/mcp-builder-view.tsx
@@ -7,7 +7,7 @@ import {
   Card,
   designTokens,
   Div,
-  Heading,
+  PageHeader,
   Scroll,
   SegmentedControl,
   Stack,
@@ -331,19 +331,13 @@ export function McpBuilderView({
   };
 
   return (
-    <Div tone="muted" width="full" style={{ flex: 1, backgroundColor: colors.muted }}>
-      <Div
-        tone="surface"
-        width="full"
-        style={{
-          borderBottomWidth: 1,
-          borderBottomColor: colors.border,
-          minHeight: designTokens.layout.topBarMinHeight,
-          paddingHorizontal: designTokens.spacing.topBarHorizontal,
-          paddingVertical: designTokens.spacing.topBarVertical,
-          backgroundColor: colors.surface,
-        }}>
-        <Stack direction="row" align="center" justify="between" width="full">
+    <Div tone="muted" width="full" style={{ flex: 1 }}>
+      {/* Shared PageHeader — centers its content to the same column as the body,
+          so the title aligns with the page below on wide screens. */}
+      <PageHeader
+        border
+        title={t('apiKeyBuilder.title')}
+        leading={
           <Button
             variant="ghost"
             size="iconSm"
@@ -351,20 +345,8 @@ export function McpBuilderView({
             accessibilityLabel={t('apiKeyBuilder.back')}>
             <Ionicons name="arrow-back" size={designTokens.icon.nav} color={colors.ink} />
           </Button>
-
-          <Heading
-            tone="title"
-            style={{
-              fontSize: designTokens.typography.compactTitle,
-              color: colors.ink,
-              fontWeight: '700',
-            }}>
-            {t('apiKeyBuilder.title')}
-          </Heading>
-
-          <Div size="iconSm" />
-        </Stack>
-      </Div>
+        }
+      />
 
       <Scroll tone="muted" pad="none" style={{ flex: 1 }}>
         <Div

--- a/apps/self-service/src/views/settings/settings-category-list-view.tsx
+++ b/apps/self-service/src/views/settings/settings-category-list-view.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from '@lightbridge/i18n';
-import { designTokens, Div, Heading, Scroll, Stack, Text } from '@lightbridge/ui';
+import { Card, designTokens, Div, Heading, Scroll, Stack, Text } from '@lightbridge/ui';
 import { useThemeColors } from '../../hooks/use-theme-colors';
 import type { SettingsCategory, SettingsCategoryKey } from '../../navigation/settings-categories';
 
@@ -75,8 +75,17 @@ export function SettingsCategoryListView({
   return (
     <Scroll tone="muted" pad="md">
       <Stack gap="lg">
-        <Heading tone="title">{t('settings.title')}</Heading>
-        {content}
+        <Stack gap="xs">
+          <Heading tone="title">{t('settings.title')}</Heading>
+          <Text intent="body">
+            {t('settings.subtitle', {
+              defaultValue: 'Manage your account, billing, and preferences.',
+            })}
+          </Text>
+        </Stack>
+        {/* Group the categories into a single card so the index reads as an
+            intentional list rather than a lone row floating in the column. */}
+        <Card size="sm">{content}</Card>
       </Stack>
     </Scroll>
   );

--- a/packages/ui/src/components/page-header/component.tsx
+++ b/packages/ui/src/components/page-header/component.tsx
@@ -26,29 +26,38 @@ export function PageHeader({
       style={[
         {
           minHeight: designTokens.layout.topBarMinHeight,
-          paddingHorizontal: designTokens.spacing.topBarHorizontal,
           paddingVertical: designTokens.spacing.topBarVertical,
         },
         style,
       ]}
       {...props}>
-      <Stack direction="row" align="center" gap="sm" width="full">
-        {leading}
-        <Stack style={{ flex: 1 }}>
-          <Text
-            intent="bodyStrong"
-            numberOfLines={1}
-            style={{ fontSize: designTokens.typography.compactTitle }}>
-            {title}
-          </Text>
-          {subtitle ? (
-            <Text intent="caption" numberOfLines={1}>
-              {subtitle}
+      {/* Bar spans full width; its content is centered to the same column as the
+          page body so the title aligns with the content below on wide screens. */}
+      <ViewBase
+        style={{
+          width: '100%',
+          maxWidth: designTokens.layout.maxContentWidth,
+          marginHorizontal: 'auto',
+          paddingHorizontal: designTokens.spacing.topBarHorizontal,
+        }}>
+        <Stack direction="row" align="center" gap="sm" width="full">
+          {leading}
+          <Stack style={{ flex: 1 }}>
+            <Text
+              intent="bodyStrong"
+              numberOfLines={1}
+              style={{ fontSize: designTokens.typography.compactTitle }}>
+              {title}
             </Text>
-          ) : null}
+            {subtitle ? (
+              <Text intent="caption" numberOfLines={1}>
+                {subtitle}
+              </Text>
+            ) : null}
+          </Stack>
+          {trailing}
         </Stack>
-        {trailing}
-      </Stack>
+      </ViewBase>
     </ViewBase>
   );
 }

--- a/packages/ui/src/components/pagination/component.tsx
+++ b/packages/ui/src/components/pagination/component.tsx
@@ -32,13 +32,23 @@ export function Pagination({
       className={cn(paginationVariants({ border }))}
       style={[
         {
-          paddingHorizontal: designTokens.spacing.topBarHorizontal,
           paddingVertical: 12,
         },
         style,
       ]}
       {...props}>
-      <Stack direction="row" align="center" justify="between" width="full">
+      {/* Bar spans full width; controls center to the content column so the
+          footer aligns with the page header and body on wide screens. */}
+      <Stack
+        direction="row"
+        align="center"
+        justify="between"
+        width="full"
+        style={{
+          maxWidth: designTokens.layout.maxContentWidth,
+          marginHorizontal: 'auto',
+          paddingHorizontal: designTokens.spacing.topBarHorizontal,
+        }}>
         <Button
           variant="ghost"
           size="sm"

--- a/packages/ui/src/components/scroll/component.tsx
+++ b/packages/ui/src/components/scroll/component.tsx
@@ -9,10 +9,10 @@ import type { ScrollProps } from './types';
 const ScrollBase = ScrollView as React.ComponentType<ScrollViewProps & { className?: string }>;
 const ViewBase = View as React.ComponentType<ViewProps & { className?: string }>;
 
-export function Scroll({ tone, pad, children, ...props }: ScrollProps) {
+export function Scroll({ tone, pad, container, children, ...props }: ScrollProps) {
   return (
     <ScrollBase className={cn(scrollVariants({ tone }))} {...props}>
-      <ViewBase className={cn(scrollContentVariants({ pad }))}>{children}</ViewBase>
+      <ViewBase className={cn(scrollContentVariants({ pad, container }))}>{children}</ViewBase>
     </ScrollBase>
   );
 }

--- a/packages/ui/src/components/scroll/cva.tsx
+++ b/packages/ui/src/components/scroll/cva.tsx
@@ -20,9 +20,17 @@ export const scrollContentVariants = cva('w-full', {
       md: 'p-6',
       lg: 'p-8',
     },
+    // Centers content in a bounded column on wide screens (opt out with
+    // `container={false}` for screens that manage their own width). Below the
+    // max width it stays full-bleed, so mobile is unchanged.
+    container: {
+      true: 'max-w-[1040px] mx-auto',
+      false: '',
+    },
   },
   defaultVariants: {
     pad: 'md',
+    container: true,
   },
 });
 

--- a/packages/ui/src/components/text/cva.tsx
+++ b/packages/ui/src/components/text/cva.tsx
@@ -9,6 +9,9 @@ export const textVariants = cva('text-ink', {
       bodyStrong: 'text-base font-semibold text-ink',
       key: 'text-sm text-subtle',
       value: 'text-2xl font-semibold text-ink',
+      // Hero metric — the big number on a calm surface card (replaces the old
+      // full-bleed inverseValue banners). Ink, not surface-white.
+      display: 'text-3xl font-bold tracking-tight text-ink',
       caption: 'text-sm text-subtle',
       link: 'text-sm font-semibold text-primary',
       warning: 'text-sm text-secondary',

--- a/packages/ui/src/design/tokens.ts
+++ b/packages/ui/src/design/tokens.ts
@@ -7,6 +7,9 @@ export const designTokens = {
     topBarMinHeight: 58,
     bottomNavClearance: 100,
     formFooterClearance: 140,
+    // Content sits in a centered column of this max width on wide screens, so
+    // nothing goes full-bleed on desktop; below it, content is edge-to-edge.
+    maxContentWidth: 1040,
   },
   icon: {
     nav: 22,

--- a/packages/ui/tailwind-preset.js
+++ b/packages/ui/tailwind-preset.js
@@ -20,31 +20,36 @@ module.exports = {
   plugins: [
     ({ addBase }) =>
       addBase({
+        // Recalibrated palette: one calm-but-confident accent (#3E63DD, was the
+        // electric #1D5BFF) reserved for actions/links/active state — never used
+        // as full-bleed fills. Neutrals carry a deliberate cool-slate bias so
+        // they read as chosen, not defaulted. Semantic hues sit apart from the
+        // accent and are lightly desaturated.
         ':root': {
-          '--color-primary': '29 91 255',
-          '--color-secondary': '249 115 22',
-          '--color-accent': '124 58 237',
-          '--color-error': '239 68 68',
-          '--color-success': '16 185 129',
-          '--color-ink': '17 24 39',
-          '--color-soft': '107 114 128',
-          '--color-subtle': '156 163 175',
-          '--color-muted': '247 247 248',
-          '--color-surface': '255 255 255',
-          '--color-border': '229 231 235',
+          '--color-primary': '62 99 221', // #3E63DD
+          '--color-secondary': '219 122 52', // #DB7A34
+          '--color-accent': '107 79 214', // #6B4FD6
+          '--color-error': '221 75 75', // #DD4B4B
+          '--color-success': '47 158 107', // #2F9E6B
+          '--color-ink': '21 26 33', // #151A21
+          '--color-soft': '91 100 114', // #5B6472
+          '--color-subtle': '154 162 175', // #9AA2AF
+          '--color-muted': '245 246 248', // #F5F6F8
+          '--color-surface': '255 255 255', // #FFFFFF
+          '--color-border': '230 232 236', // #E6E8EC
         },
         '.dark': {
-          '--color-primary': '96 165 250',
-          '--color-secondary': '251 146 60',
-          '--color-accent': '167 139 250',
-          '--color-error': '248 113 113',
-          '--color-success': '52 211 153',
-          '--color-ink': '243 244 246',
-          '--color-soft': '209 213 219',
-          '--color-subtle': '156 163 175',
-          '--color-muted': '17 24 39',
-          '--color-surface': '31 41 55',
-          '--color-border': '55 65 81',
+          '--color-primary': '125 160 255', // #7DA0FF
+          '--color-secondary': '224 151 90', // #E0975A
+          '--color-accent': '164 139 240', // #A48BF0
+          '--color-error': '240 115 111', // #F0736F
+          '--color-success': '70 197 139', // #46C58B
+          '--color-ink': '232 234 237', // #E8EAED
+          '--color-soft': '162 171 184', // #A2ABB8
+          '--color-subtle': '107 114 128', // #6B7280
+          '--color-muted': '15 18 22', // #0F1216
+          '--color-surface': '24 28 34', // #181C22
+          '--color-border': '42 47 55', // #2A2F37
         },
       }),
   ],


### PR DESCRIPTION
## 1. Summary

Screenshot-driven visual redesign of the self-service console, scoped from the deployed Storybook review under epic **#67** and delivering the concrete change list that placeholder ticket **#72** was holding a slot for. A review of the running app (desktop + mobile, light + dark) surfaced three problems, all fixed here:

1. **No max-width container** → every screen was full-bleed and looked broken stretched across a desktop monitor.
2. **Over-saturated accent as giant fills** → electric `#1D5BFF` appeared as full-width banners and solid chips, reading as garish/arbitrary.
3. **Inconsistent surfaces** → MCP builder had a bespoke top bar; API-keys misused a `SegmentedControl` for two discrete actions and used solid-blue chips; Settings was a lone row in a void.

> Note on #72: it is a deliberate placeholder whose own text asks to be *rescoped before implementation*. This PR is that evidence-based outcome; the ticket body was left unedited (out of my write scope) — **@stephane-segning** may want to rescope it to match.

## 2. Intent

> One recalibrated palette + one shared centered layout, applied across every console screen, so the app reads as a single considered product instead of five differently-coloured pages. Evidence-based (screenshots), not vibes-based. Source of truth: **#72** (ticket), **#67** (epic).

## 3. Scope

### In scope
- **Palette** (`packages/ui/tailwind-preset.js`): `#1D5BFF` → `#3E63DD` accent (actions/links/active only), cool-slate neutrals, desaturated semantics, matching dark ramp. Soft tints cascade from base tokens.
- **Centered shell**: new `maxContentWidth` token; `Scroll`, `PageHeader`, `Pagination` center to a 1040px column on desktop, edge-to-edge on mobile.
- **Hero metric cards** (new `display` text intent): replace the saturated home "Current Usage" + usage "Total Cost" banners.
- **Components**: MCP builder → shared `PageHeader`; API-keys chips → soft `brandSoft` when selected; Revoke/Rotate → two buttons (Revoke destructive); Settings → subtitle + grouped card.

### Out of scope / notes
- No fake sparkline data on the home usage card (kept honest — surface card + number + accent chip only).
- The app's dark-mode wiring (class-driven vs `prefers-color-scheme`) — a separate observation worth its own follow-up; the preview's OS-scheme emulation did not flip it.
- The MCP builder's inline-styled cards were left as-is (they render correctly under the new tokens); a full rewrite wasn't warranted.

## 4. Verification

- [x] Running automated tests
- [x] Running manual tests (browser)

```bash
npx tsc --noEmit -p packages/ui/tsconfig.json          # clean
npx tsc --noEmit -p apps/self-service/tsconfig.json    # clean
pnpm --filter self-service test                        # 20 suites / 74 tests pass
```

Browser verification of **every** screen (login, home, usage, MCP, API-keys, settings) via a temporary ungated preview route (removed before commit; the app is Keycloak-gated):
- **Centered column measured**: `width 1040px, margin 200px each side` at a 1440 viewport — dead-centered.
- **Mobile (375px)**: content stays edge-to-edge; only the palette changed.
- **Light + dark**: both legible; dark ground `#0F1216`, surfaces `#181C22`, accent lightens to `#7DA0FF`.
- Console clean (no errors).

## 5. Screenshots / Evidence

Source of truth: **#72** (ticket), **#67** (epic). Screenshots (desktop + mobile, light + dark, per screen) attached in the PR conversation.

## 6. Risk Assessment

Risk level: **Low-Medium**

- Highest-scrutiny item is the **palette recalibration** in `tailwind-preset.js` — it propagates app-wide via CSS variables; verified across all screens in both themes.
- The `Scroll` `container` centering defaults **on** but is opt-out (`container={false}`); mobile is unaffected (max-width only bites above 1040px).
- `PageHeader` / `Pagination` gained an inner centered wrapper — pure layout, no API change; existing tests green.
- Gated screens were exercised via a temp preview route that is **not** part of this diff.

## 7. AI Usage Declaration

AI was used for:
- [x] Reviewing the running UI + defining the concrete scope
- [x] Generating the token/layout/component changes
- [x] Browser verification (screenshots, measured geometry)
- [x] Reviewing the diff

Human verification:
- [ ] I reviewed the palette recalibration and accept the new accent
- [ ] I confirmed the centered layout on the real (SSO) app
- [ ] I accept responsibility for this PR

> AI recalibrated the palette, added the shared centered shell, replaced the saturated banners with hero cards, and cleaned up MCP/API-keys/Settings — verifying each screen in the browser and documenting what it deliberately left out (fake sparkline data, dark-mode wiring, MCP inline-style rewrite). @stephane-segning must tick the boxes after reviewing on the SSO app.

## 8. Reviewer Focus

- [x] Palette values + that the accent never appears as a full-bleed fill
- [x] `Scroll`/`PageHeader`/`Pagination` centering (header/body/footer alignment)
- [x] The Revoke/Rotate two-button change (destructive affordance)
- [x] Dark mode legibility across screens
