### PR TITLE
fix(ui): unify light/dark theme — wire NativeWind .dark class + recalibrate inline palette

### DIFF
--- a/apps/self-service/src/app/_layout.tsx
+++ b/apps/self-service/src/app/_layout.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Stack, usePathname, useRouter, useSegments } from 'expo-router';
-import { Alert } from 'react-native';
+import { Alert, useColorScheme } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { StatusBar } from 'expo-status-bar';
@@ -162,7 +162,20 @@ function AppBootstrap() {
 export default function RootLayout() {
   const fontsLoaded = useAppFonts(APP_FONT_SOURCES);
   const [runtimeReady, setRuntimeReady] = useState(false);
+  const colorScheme = useColorScheme();
   const webFallback = isWebPlatform() ? <AppSplashView /> : null;
+
+  // Keep the NativeWind class-based dark theme (className tokens → CSS variables)
+  // in lockstep with useColorScheme, which also drives useThemeColors' inline
+  // colors. Without this the two desync on web — the class is never applied, so
+  // className tokens stay light while inline colors follow the OS, producing the
+  // "half-dark" split (e.g. the MCP builder rendering as a dark island).
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+    document.documentElement.classList.toggle('dark', colorScheme === 'dark');
+  }, [colorScheme]);
 
   const handleRuntimeReady = React.useCallback(() => {
     setRuntimeReady(true);

--- a/apps/self-service/src/hooks/__tests__/use-theme-colors.test.ts
+++ b/apps/self-service/src/hooks/__tests__/use-theme-colors.test.ts
@@ -16,8 +16,8 @@ describe('useThemeColors', () => {
 
     const { result } = await renderHook(() => useThemeColors());
 
-    expect(result.current.surface).toBe('rgb(31 41 55)');
-    expect(result.current.border).toBe('rgb(55 65 81)');
+    expect(result.current.surface).toBe('rgb(24 28 34)');
+    expect(result.current.border).toBe('rgb(42 47 55)');
   });
 
   it('resolves the light palette when the system scheme is light', async () => {
@@ -26,7 +26,7 @@ describe('useThemeColors', () => {
     const { result } = await renderHook(() => useThemeColors());
 
     expect(result.current.surface).toBe('rgb(255 255 255)');
-    expect(result.current.border).toBe('rgb(229 231 235)');
+    expect(result.current.border).toBe('rgb(230 232 236)');
   });
 
   it('falls back to the light palette when the system scheme is unavailable', async () => {

--- a/apps/self-service/src/theme/theme-colors.ts
+++ b/apps/self-service/src/theme/theme-colors.ts
@@ -1,31 +1,37 @@
 import type { ColorSchemeName } from 'react-native';
 
+// Inline-style counterpart of the CSS-variable palette in
+// packages/ui/tailwind-preset.js — MUST stay in sync with it. `useThemeColors`
+// reads these for `style={{ color: colors.x }}` / Ionicons tints, while
+// className tokens (bg-surface, text-ink…) read the CSS variables. The two are
+// kept identical so a component never mixes a light inline color with a dark
+// className token (or vice versa).
 const lightColors = {
-  primary: 'rgb(29 91 255)',
-  secondary: 'rgb(249 115 22)',
-  accent: 'rgb(124 58 237)',
-  error: 'rgb(239 68 68)',
-  success: 'rgb(16 185 129)',
-  ink: 'rgb(17 24 39)',
-  soft: 'rgb(107 114 128)',
-  subtle: 'rgb(156 163 175)',
-  muted: 'rgb(247 247 248)',
-  surface: 'rgb(255 255 255)',
-  border: 'rgb(229 231 235)',
+  primary: 'rgb(62 99 221)', // #3E63DD
+  secondary: 'rgb(219 122 52)', // #DB7A34
+  accent: 'rgb(107 79 214)', // #6B4FD6
+  error: 'rgb(221 75 75)', // #DD4B4B
+  success: 'rgb(47 158 107)', // #2F9E6B
+  ink: 'rgb(21 26 33)', // #151A21
+  soft: 'rgb(91 100 114)', // #5B6472
+  subtle: 'rgb(154 162 175)', // #9AA2AF
+  muted: 'rgb(245 246 248)', // #F5F6F8
+  surface: 'rgb(255 255 255)', // #FFFFFF
+  border: 'rgb(230 232 236)', // #E6E8EC
 };
 
 const darkColors = {
-  primary: 'rgb(96 165 250)',
-  secondary: 'rgb(251 146 60)',
-  accent: 'rgb(167 139 250)',
-  error: 'rgb(248 113 113)',
-  success: 'rgb(52 211 153)',
-  ink: 'rgb(243 244 246)',
-  soft: 'rgb(209 213 219)',
-  subtle: 'rgb(156 163 175)',
-  muted: 'rgb(17 24 39)',
-  surface: 'rgb(31 41 55)',
-  border: 'rgb(55 65 81)',
+  primary: 'rgb(125 160 255)', // #7DA0FF
+  secondary: 'rgb(224 151 90)', // #E0975A
+  accent: 'rgb(164 139 240)', // #A48BF0
+  error: 'rgb(240 115 111)', // #F0736F
+  success: 'rgb(70 197 139)', // #46C58B
+  ink: 'rgb(232 234 237)', // #E8EAED
+  soft: 'rgb(162 171 184)', // #A2ABB8
+  subtle: 'rgb(107 114 128)', // #6B7280
+  muted: 'rgb(15 18 22)', // #0F1216
+  surface: 'rgb(24 28 34)', // #181C22
+  border: 'rgb(42 47 55)', // #2A2F37
 };
 
 export function getThemeColors(scheme: ColorSchemeName) {

--- a/apps/self-service/src/views/__tests__/api-key-create-view.theme.test.tsx
+++ b/apps/self-service/src/views/__tests__/api-key-create-view.theme.test.tsx
@@ -25,8 +25,8 @@ describe('ApiKeyCreateView theme', () => {
     const view = await render(<ApiKeyCreateView onBack={noop} onCreate={noop} onCopy={noop} />);
 
     const tree = JSON.stringify(view.toJSON());
-    expect(tree).toContain('rgb(96 165 250)'); // dark primary (inline via useThemeColors)
-    expect(tree).not.toContain('rgb(29 91 255)'); // light primary must not leak in
+    expect(tree).toContain('rgb(125 160 255)'); // dark primary (inline via useThemeColors)
+    expect(tree).not.toContain('rgb(62 99 221)'); // light primary must not leak in
   });
 
   it('renders with the light palette when the system scheme is light', async () => {
@@ -35,7 +35,7 @@ describe('ApiKeyCreateView theme', () => {
     const view = await render(<ApiKeyCreateView onBack={noop} onCreate={noop} onCopy={noop} />);
 
     const tree = JSON.stringify(view.toJSON());
-    expect(tree).toContain('rgb(29 91 255)'); // light primary (inline via useThemeColors)
-    expect(tree).not.toContain('rgb(96 165 250)'); // dark primary must not leak in
+    expect(tree).toContain('rgb(62 99 221)'); // light primary (inline via useThemeColors)
+    expect(tree).not.toContain('rgb(125 160 255)'); // dark primary must not leak in
   });
 });


### PR DESCRIPTION
## 1. Summary

Follow-up bugfix to the console visual redesign (#91, ticket #72, epic #67). After #91 merged, the deployed app still looked "bizarre" on a dark-mode OS: the **MCP builder rendered as a dark island** on an otherwise light app, and inline-styled spots (nav icons, etc.) mismatched their surroundings.

**Root cause — a split-brain theme:**
- `useThemeColors()` reads RN `useColorScheme()` → returns the **dark** inline palette when the OS is dark.
- The NativeWind className tokens (`bg-surface`, `text-ink`, … → CSS variables) only go dark if a `.dark` class is on the web root — and **nothing applied it**, so they stayed **light**.

So components styled inline (`style={{ backgroundColor: colors.muted }}` — the MCP builder has 28 such uses) went dark while className-styled components stayed light. Two independent theme signals, never synchronized.

Also surfaced: `theme-colors.ts` (the inline palette) still held the **old electric `#1D5BFF`** — #91 recalibrated only the CSS-variable side, leaving the inline copy stale.

## 2. Intent

> Make the two theme systems agree so the whole app switches light/dark together, and finish the palette recalibration on the inline side. Chosen over "force light-only" because the codebase has dark tokens + dark-mode tests — dark was intended, just never wired. Source of truth: #72 (ticket), #67 (epic); follows #91.

## 3. Scope

### In scope
- `theme/theme-colors.ts` — recalibrate **both** light + dark inline palettes to exactly match `packages/ui/tailwind-preset.js`.
- `app/_layout.tsx` — drive the NativeWind `.dark` class from `useColorScheme()` (`document.documentElement.classList.toggle('dark', …)`), so className tokens track the OS scheme in lockstep with the inline colors.
- Update the two theme tests to the recalibrated values (they still assert the anti-desync behavior — now more important).

### Out of scope
- No per-component restyling — this is purely the theme-wiring + palette-sync fix. The MCP builder's inline styles are now correct because the palette they read is correct and synced.

## 4. Verification

- [x] Automated tests
- [x] Manual (browser)

```bash
npx tsc --noEmit -p apps/self-service/tsconfig.json   # clean
pnpm --filter self-service test                       # 20 suites / 74 tests pass
```

Browser-verified via a temporary ungated preview route (removed before commit):
- **OS light** → app fully light; **MCP is no longer a dark island** (top bar, cards, background all light).
- **OS dark** → confirmed `matchMedia('(prefers-color-scheme: dark)')` = true, `.dark` class applied, `--color-surface` = dark; **the whole app renders consistently dark** (MCP + home checked: top bar, cards, toggles, buttons, text all one cohesive dark theme).

## 5. Screenshots / Evidence

Source of truth: #72 (ticket), #67 (epic). Before/after (MCP dark-island → consistent) and dark-mode home/MCP screenshots in the PR conversation.

## 6. Risk Assessment

Risk level: **Low-Medium**

- The `.dark` class toggle is guarded for non-DOM environments (`typeof document === 'undefined'`), so native/SSR is unaffected; this app ships web-only.
- Palette values are copied verbatim from `tailwind-preset.js`, keeping the inline + CSS-variable sources identical (a comment in `theme-colors.ts` records the sync requirement).
- Dark mode now actually engages app-wide — reviewers should sanity-check a couple of screens in OS dark mode, since previously dark was effectively never rendered whole.

## 7. AI Usage Declaration

AI was used for:
- [x] Diagnosing the split-brain theme root cause
- [x] Generating the wiring + palette-sync fix
- [x] Browser verification in both themes
- [x] Reviewing the diff

Human verification:
- [ ] I confirmed light + dark both render consistently on the SSO app
- [ ] I accept responsibility for this PR

> AI traced the "dark island" to two unsynchronized theme systems, wired the NativeWind class to `useColorScheme`, and recalibrated the stale inline palette — verifying both themes in the browser. @stephane-segning should sanity-check OS-dark on the real app before/after merge.

## 8. Reviewer Focus

- [x] The `_layout.tsx` `.dark` class effect (correctness + the non-DOM guard)
- [x] `theme-colors.ts` values match `tailwind-preset.js` exactly
- [x] Dark mode legibility across screens (now that it engages app-wide)
