### PR TITLE
feat(ui): theme toggle in settings (Light / Dark / System)

### DIFF
--- a/apps/self-service/src/app/_layout.tsx
+++ b/apps/self-service/src/app/_layout.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Stack, usePathname, useRouter, useSegments } from 'expo-router';
-import { Alert, useColorScheme } from 'react-native';
+import { Alert } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { StatusBar } from 'expo-status-bar';
@@ -25,6 +25,7 @@ import { useClientInit } from '@lightbridge/api-rest';
 import { isWebPlatform } from '@lightbridge/api-native';
 import { RuntimeConfigProvider, useRuntimeConfig } from '../configs/runtime-config';
 import { AppSplashView } from '../views/app-splash-view';
+import { ThemePreferenceProvider } from '../theme/theme-preference';
 
 WebBrowser.maybeCompleteAuthSession();
 enableScreens();
@@ -162,20 +163,7 @@ function AppBootstrap() {
 export default function RootLayout() {
   const fontsLoaded = useAppFonts(APP_FONT_SOURCES);
   const [runtimeReady, setRuntimeReady] = useState(false);
-  const colorScheme = useColorScheme();
   const webFallback = isWebPlatform() ? <AppSplashView /> : null;
-
-  // Keep the NativeWind class-based dark theme (className tokens → CSS variables)
-  // in lockstep with useColorScheme, which also drives useThemeColors' inline
-  // colors. Without this the two desync on web — the class is never applied, so
-  // className tokens stay light while inline colors follow the OS, producing the
-  // "half-dark" split (e.g. the MCP builder rendering as a dark island).
-  useEffect(() => {
-    if (typeof document === 'undefined') {
-      return;
-    }
-    document.documentElement.classList.toggle('dark', colorScheme === 'dark');
-  }, [colorScheme]);
 
   const handleRuntimeReady = React.useCallback(() => {
     setRuntimeReady(true);
@@ -189,13 +177,15 @@ export default function RootLayout() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <I18nProvider>
-        <RuntimeConfigProvider fallback={webFallback} onReady={handleRuntimeReady}>
-          <QueryClientProvider client={queryClient}>
-            {fontsLoaded ? <AppBootstrap /> : webFallback}
-          </QueryClientProvider>
-        </RuntimeConfigProvider>
-      </I18nProvider>
+      <ThemePreferenceProvider>
+        <I18nProvider>
+          <RuntimeConfigProvider fallback={webFallback} onReady={handleRuntimeReady}>
+            <QueryClientProvider client={queryClient}>
+              {fontsLoaded ? <AppBootstrap /> : webFallback}
+            </QueryClientProvider>
+          </RuntimeConfigProvider>
+        </I18nProvider>
+      </ThemePreferenceProvider>
     </GestureHandlerRootView>
   );
 }

--- a/apps/self-service/src/components/theme-toggle.tsx
+++ b/apps/self-service/src/components/theme-toggle.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useTranslation } from '@lightbridge/i18n';
+import { SegmentedControl, Stack, Text } from '@lightbridge/ui';
+
+import { useThemePreference, type ThemePreference } from '../theme/theme-preference';
+
+/**
+ * Appearance control — lets the user pick Light / Dark / System, overriding the
+ * OS default. Persists via the ThemePreference context (localStorage-backed).
+ */
+export function ThemeToggle() {
+  const { t } = useTranslation();
+  const { preference, setPreference } = useThemePreference();
+
+  const options = [
+    { key: 'system', label: t('settings.appearance.system', { defaultValue: 'System' }) },
+    { key: 'light', label: t('settings.appearance.light', { defaultValue: 'Light' }) },
+    { key: 'dark', label: t('settings.appearance.dark', { defaultValue: 'Dark' }) },
+  ];
+
+  return (
+    <Stack gap="sm" width="full">
+      <Text intent="eyebrow">{t('settings.appearance.title', { defaultValue: 'Appearance' })}</Text>
+      <SegmentedControl
+        width="full"
+        options={options}
+        value={preference}
+        onChange={(key) => setPreference(key as ThemePreference)}
+      />
+    </Stack>
+  );
+}

--- a/apps/self-service/src/hooks/use-theme-colors.ts
+++ b/apps/self-service/src/hooks/use-theme-colors.ts
@@ -1,8 +1,9 @@
-import { useColorScheme } from 'react-native';
-
 import { getThemeColors } from '../theme/theme-colors';
+import { useEffectiveColorScheme } from '../theme/theme-preference';
 
 export function useThemeColors() {
-  const scheme = useColorScheme();
+  // Resolve from the *effective* scheme (user preference → system), so inline
+  // colors honour the theme toggle and stay in sync with the className tokens.
+  const scheme = useEffectiveColorScheme();
   return getThemeColors(scheme);
 }

--- a/apps/self-service/src/theme/__tests__/theme-preference.test.tsx
+++ b/apps/self-service/src/theme/__tests__/theme-preference.test.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { Pressable, Text } from 'react-native';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+
+jest.mock('react-native/Libraries/Utilities/useColorScheme', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+import useColorScheme from 'react-native/Libraries/Utilities/useColorScheme';
+import {
+  ThemePreferenceProvider,
+  useEffectiveColorScheme,
+  useThemePreference,
+} from '../theme-preference';
+
+const mockUseColorScheme = useColorScheme as jest.Mock;
+
+// The jest-expo env is node (no jsdom) → no `localStorage`. The provider guards
+// for that; here we give it a minimal in-memory one so persistence is testable.
+class MemoryStorage {
+  private store = new Map<string, string>();
+  getItem(key: string) {
+    return this.store.has(key) ? (this.store.get(key) as string) : null;
+  }
+  setItem(key: string, value: string) {
+    this.store.set(key, String(value));
+  }
+  removeItem(key: string) {
+    this.store.delete(key);
+  }
+  clear() {
+    this.store.clear();
+  }
+}
+(globalThis as { localStorage?: Storage }).localStorage = new MemoryStorage() as unknown as Storage;
+
+function Probe() {
+  const { preference, setPreference, scheme } = useThemePreference();
+  return (
+    <>
+      <Text testID="scheme">{scheme}</Text>
+      <Text testID="pref">{preference}</Text>
+      <Pressable testID="set-dark" onPress={() => setPreference('dark')}>
+        <Text>dark</Text>
+      </Pressable>
+      <Pressable testID="set-light" onPress={() => setPreference('light')}>
+        <Text>light</Text>
+      </Pressable>
+      <Pressable testID="set-system" onPress={() => setPreference('system')}>
+        <Text>system</Text>
+      </Pressable>
+    </>
+  );
+}
+
+function FallbackProbe() {
+  return <Text testID="scheme">{useEffectiveColorScheme()}</Text>;
+}
+
+beforeEach(() => {
+  mockUseColorScheme.mockReset();
+  if (typeof localStorage !== 'undefined') {
+    localStorage.clear();
+  }
+});
+
+describe('ThemePreference', () => {
+  it('resolves system → the OS scheme', async () => {
+    mockUseColorScheme.mockReturnValue('dark');
+    await render(
+      <ThemePreferenceProvider>
+        <Probe />
+      </ThemePreferenceProvider>
+    );
+
+    expect(screen.getByTestId('pref').props.children).toBe('system');
+    expect(screen.getByTestId('scheme').props.children).toBe('dark');
+  });
+
+  it('lets an explicit choice override the OS scheme, and persists it', async () => {
+    mockUseColorScheme.mockReturnValue('light');
+    await render(
+      <ThemePreferenceProvider>
+        <Probe />
+      </ThemePreferenceProvider>
+    );
+
+    expect(screen.getByTestId('scheme').props.children).toBe('light');
+
+    await fireEvent.press(screen.getByTestId('set-dark'));
+
+    expect(screen.getByTestId('scheme').props.children).toBe('dark');
+    expect(localStorage.getItem('lightbridge.theme-preference')).toBe('dark');
+
+    await fireEvent.press(screen.getByTestId('set-system'));
+    expect(screen.getByTestId('scheme').props.children).toBe('light'); // back to OS (light)
+  });
+
+  it('hydrates the persisted preference on mount', async () => {
+    localStorage.setItem('lightbridge.theme-preference', 'dark');
+    mockUseColorScheme.mockReturnValue('light');
+
+    await render(
+      <ThemePreferenceProvider>
+        <Probe />
+      </ThemePreferenceProvider>
+    );
+
+    expect(screen.getByTestId('pref').props.children).toBe('dark');
+    expect(screen.getByTestId('scheme').props.children).toBe('dark');
+  });
+
+  it('useEffectiveColorScheme falls back to the OS scheme without a provider', async () => {
+    mockUseColorScheme.mockReturnValue('dark');
+    await render(<FallbackProbe />);
+
+    expect(screen.getByTestId('scheme').props.children).toBe('dark');
+  });
+});

--- a/apps/self-service/src/theme/theme-preference.tsx
+++ b/apps/self-service/src/theme/theme-preference.tsx
@@ -1,0 +1,87 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { useColorScheme } from 'react-native';
+
+export type ThemePreference = 'system' | 'light' | 'dark';
+export type EffectiveColorScheme = 'light' | 'dark';
+
+const STORAGE_KEY = 'lightbridge.theme-preference';
+
+function isThemePreference(value: unknown): value is ThemePreference {
+  return value === 'system' || value === 'light' || value === 'dark';
+}
+
+// Read synchronously at first render so the initial paint already carries the
+// user's choice — no flash of the wrong theme. localStorage is web-only (this
+// app ships as a pure web product); the guard keeps native/SSR safe.
+function readStoredPreference(): ThemePreference {
+  if (typeof localStorage === 'undefined') {
+    return 'system';
+  }
+  const stored = localStorage.getItem(STORAGE_KEY);
+  return isThemePreference(stored) ? stored : 'system';
+}
+
+type ThemePreferenceContextValue = {
+  preference: ThemePreference;
+  setPreference: (preference: ThemePreference) => void;
+  /** The resolved scheme after applying `system` → OS. */
+  scheme: EffectiveColorScheme;
+};
+
+const ThemePreferenceContext = createContext<ThemePreferenceContextValue | null>(null);
+
+export function ThemePreferenceProvider({ children }: Readonly<{ children: React.ReactNode }>) {
+  const systemScheme = useColorScheme();
+  const [preference, setPreferenceState] = useState<ThemePreference>(readStoredPreference);
+
+  const setPreference = useCallback((next: ThemePreference) => {
+    setPreferenceState(next);
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(STORAGE_KEY, next);
+    }
+  }, []);
+
+  const scheme: EffectiveColorScheme =
+    preference === 'system' ? (systemScheme === 'dark' ? 'dark' : 'light') : preference;
+
+  // Single owner of the NativeWind `.dark` class, driven by the *effective*
+  // scheme — this keeps className tokens (CSS variables) in lockstep with the
+  // inline `colors.*` palette that useThemeColors resolves from the same scheme.
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+    document.documentElement.classList.toggle('dark', scheme === 'dark');
+  }, [scheme]);
+
+  const value = useMemo(
+    () => ({ preference, setPreference, scheme }),
+    [preference, setPreference, scheme]
+  );
+
+  return (
+    <ThemePreferenceContext.Provider value={value}>{children}</ThemePreferenceContext.Provider>
+  );
+}
+
+export function useThemePreference(): ThemePreferenceContextValue {
+  const ctx = useContext(ThemePreferenceContext);
+  if (!ctx) {
+    throw new Error('useThemePreference must be used within a ThemePreferenceProvider');
+  }
+  return ctx;
+}
+
+/**
+ * The effective light/dark scheme. Reads the ThemePreference context when
+ * present; falls back to the raw OS scheme otherwise so isolated renders (e.g.
+ * unit tests that mount a view without the provider) still resolve a scheme.
+ */
+export function useEffectiveColorScheme(): EffectiveColorScheme {
+  const ctx = useContext(ThemePreferenceContext);
+  const systemScheme = useColorScheme();
+  if (ctx) {
+    return ctx.scheme;
+  }
+  return systemScheme === 'dark' ? 'dark' : 'light';
+}

--- a/apps/self-service/src/views/settings/__tests__/settings-category-list-view.test.tsx
+++ b/apps/self-service/src/views/settings/__tests__/settings-category-list-view.test.tsx
@@ -4,14 +4,19 @@ import { initI18n } from '@lightbridge/i18n';
 
 import { SettingsCategoryListView } from '../settings-category-list-view';
 import { settingsCategories } from '../../../navigation/settings-categories';
+import { ThemePreferenceProvider } from '../../../theme/theme-preference';
 
 beforeAll(() => {
   initI18n('en');
 });
 
+// The view now embeds <ThemeToggle/>, which reads the ThemePreference context.
+const renderView = (ui: React.ReactElement) =>
+  render(ui, { wrapper: ThemePreferenceProvider });
+
 describe('SettingsCategoryListView', () => {
   it('renders each category label', async () => {
-    await render(
+    await renderView(
       <SettingsCategoryListView categories={settingsCategories} onSelect={() => undefined} />
     );
 
@@ -20,7 +25,9 @@ describe('SettingsCategoryListView', () => {
 
   it('calls onSelect with the pressed category', async () => {
     const onSelect = jest.fn();
-    await render(<SettingsCategoryListView categories={settingsCategories} onSelect={onSelect} />);
+    await renderView(
+      <SettingsCategoryListView categories={settingsCategories} onSelect={onSelect} />
+    );
 
     await fireEvent.press(screen.getByText('Account'));
 
@@ -28,7 +35,7 @@ describe('SettingsCategoryListView', () => {
   });
 
   it('marks the active category as selected in rail variant', async () => {
-    await render(
+    await renderView(
       <SettingsCategoryListView
         categories={settingsCategories}
         activeKey="account"
@@ -41,7 +48,7 @@ describe('SettingsCategoryListView', () => {
   });
 
   it('does not mark any category as selected in list variant (no activeKey)', async () => {
-    await render(
+    await renderView(
       <SettingsCategoryListView categories={settingsCategories} onSelect={() => undefined} />
     );
 

--- a/apps/self-service/src/views/settings/settings-category-list-view.tsx
+++ b/apps/self-service/src/views/settings/settings-category-list-view.tsx
@@ -3,6 +3,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from '@lightbridge/i18n';
 import { Card, designTokens, Div, Heading, Scroll, Stack, Text } from '@lightbridge/ui';
 import { useThemeColors } from '../../hooks/use-theme-colors';
+import { ThemeToggle } from '../../components/theme-toggle';
 import type { SettingsCategory, SettingsCategoryKey } from '../../navigation/settings-categories';
 
 type SettingsCategoryListViewProps = {
@@ -67,6 +68,7 @@ export function SettingsCategoryListView({
         <Stack gap="md">
           <Text intent="eyebrow">{t('settings.title')}</Text>
           {content}
+          <ThemeToggle />
         </Stack>
       </Div>
     );
@@ -86,6 +88,9 @@ export function SettingsCategoryListView({
         {/* Group the categories into a single card so the index reads as an
             intentional list rather than a lone row floating in the column. */}
         <Card size="sm">{content}</Card>
+        <Card size="sm">
+          <ThemeToggle />
+        </Card>
       </Stack>
     </Scroll>
   );


### PR DESCRIPTION
## 1. Summary

Adds a user-facing **theme toggle** (Light / Dark / System) in Settings, building directly on the theme-wiring fix (#92). Now that light/dark render consistently app-wide, users can override the OS default instead of being locked to it. Source of truth: #72 (ticket), #67 (epic); follows #91 (redesign) and #92 (wiring).

## 2. Intent

> Let users pick their theme and have it persist, without reintroducing the old desync. A single `ThemePreferenceProvider` owns both the effective scheme and the NativeWind `.dark` class, and `useThemeColors` reads the same effective scheme — so inline colors and className tokens can never disagree.

## 3. Scope

### In scope
- **`theme/theme-preference.tsx`** — `ThemePreferenceProvider` + `useThemePreference` / `useEffectiveColorScheme`. Resolves `preference → system`, owns the `.dark` class, and persists to `localStorage` with a **synchronous init read (no flash)**, guarded for non-web (`typeof localStorage/document === 'undefined'`). Supersedes the raw-`useColorScheme` `.dark` effect that #92 put in `_layout`.
- **`hooks/use-theme-colors.ts`** — now resolves from the effective scheme.
- **`components/theme-toggle.tsx`** — a `SegmentedControl` (System/Light/Dark), added to the settings index in **both** layouts (mobile list + desktop rail). Also fills out the previously-sparse settings page.
- Tests: `theme-preference` (resolution / persistence / provider-less fallback, probe pattern); settings-view test now mounts within the provider.

### Out of scope
- i18n: labels use `defaultValue` fallbacks (matches existing repo pattern, e.g. Pagination); proper keys can follow.
- Native persistence: web-only product → `localStorage`; the guard keeps native builds safe (falls back to `system`).

## 4. Verification

- [x] Automated tests
- [x] Manual (browser)

```bash
npx tsc --noEmit -p apps/self-service/tsconfig.json   # clean
pnpm --filter self-service test                       # 21 suites / 78 tests pass
```

Browser-verified via a temporary ungated preview route (removed before commit):
- Settings shows the **Appearance** control (System active by default).
- Clicking **Dark** with OS on light → whole app flips to dark instantly (`.dark` class applied, `--color-surface` dark, `localStorage = "dark"`).
- **Reload → still dark** (synchronous hydrate, no flash).
- **System** → returns to following the OS.

## 5. Screenshots / Evidence

Source of truth: #72 (ticket), #67 (epic). Settings light + dark screenshots in the PR conversation.

## 6. Risk Assessment

Risk level: **Low**

- Additive: a provider + one settings control. The provider consolidates the `.dark` wiring that #92 introduced (no behavioural regression — `system` reproduces #92's OS-following behaviour).
- `useEffectiveColorScheme` falls back to the OS scheme when no provider is mounted, so isolated renders/tests still resolve a scheme (covered by a test).
- `localStorage`/`document` access is guarded for non-web.

## 7. AI Usage Declaration

AI was used for:
- [x] Designing + implementing the provider, hook, and toggle
- [x] Browser verification (switch + persistence)
- [x] Writing the tests
- [x] Reviewing the diff

Human verification:
- [ ] I exercised the toggle (Light/Dark/System + reload) on the SSO app
- [ ] I accept responsibility for this PR

> AI built the persisted theme-preference provider, wired useThemeColors + the settings toggle to it, and verified switching + persistence in the browser. @stephane-segning should try the toggle on the real app before merge.

## 8. Reviewer Focus

- [x] `ThemePreferenceProvider` — effective-scheme resolution, `.dark` ownership, the no-flash synchronous hydrate + guards
- [x] That inline colors + className tokens stay synced through the single effective scheme
- [x] Toggle placement in both settings layouts
