### PR TITLE
docs: console theme & design-system upgrade (ADR 0007 + guide)

### DIFF
--- a/docs/adr/0007-console-visual-theme-system.md
+++ b/docs/adr/0007-console-visual-theme-system.md
@@ -1,0 +1,38 @@
+# ADR 0007: Console visual redesign — recalibrated palette, shared layout shell, unified theming
+
+## Status
+
+Accepted
+
+## Context
+
+The self-service console (Expo + React Native Web, shipped as a pure web product) accumulated visual inconsistencies that a screenshot-driven review — enabled by the deployed Storybook (epic #67, ticket #72) — made concrete:
+
+1. **No max-width container.** Every screen rendered `flex-1` with padding only, so content stretched edge-to-edge and read as broken on a desktop monitor.
+2. **An over-saturated accent used as large fills.** The primary was an electric `#1D5BFF`, slapped as full-width banners (home "Current Usage", usage "Total Cost") and solid selection chips — garish against the otherwise calm surfaces.
+3. **A split-brain theme.** Two theme signals were never synchronized:
+   - NativeWind **className tokens** (`bg-surface`, `text-ink`, … → CSS variables in `packages/ui/tailwind-preset.js`) only go dark when a `.dark` class sits on the web root — and nothing applied it, so they stayed **light**.
+   - The JS **`useThemeColors()`** inline palette (`apps/self-service/src/theme/theme-colors.ts`) read `useColorScheme()` and followed the **OS**.
+
+   On a dark-mode OS the inline-styled parts went dark while className-styled parts stayed light, so the MCP builder (28 inline `colors.*` uses) rendered as a **dark island** on a light app. The palette also lived in these **two unsynchronized sources** — the inline copy still held the pre-redesign electric values after the CSS-variable side was recalibrated.
+
+`packages/ui` is a uniform CVA + CSS-variable design system, so the correct fix was at the **token and shell level**, not per-screen restyling.
+
+## Decision
+
+Deliver a token-and-shell-level redesign plus a unified theme system:
+
+- **Recalibrate the palette** to a calm-but-confident `#3E63DD` accent with cool-slate neutrals and lightly desaturated semantic colours, with a matching dark ramp. The accent is reserved for actions / links / active state and is **never used as a full-bleed fill**. Soft tints (`brandSoft` = `bg-primary/10`, …) cascade from the base tokens.
+- **One centered content column.** A `maxContentWidth` design token (1040px); `Scroll` (opt-out `container` prop), `PageHeader`, and `Pagination` centre their content to it on desktop and stay edge-to-edge on mobile.
+- **Hero metric cards** (a new `display` text intent) replace the saturated banners — the number is the ink hero on a surface card with a small accent chip.
+- **Unify theming.** A single `ThemePreferenceProvider` owns the effective colour scheme (`preference → system`) **and** the NativeWind `.dark` class; `useThemeColors()` resolves from that same effective scheme. A Settings **Appearance** toggle (Light / Dark / System) persists the choice to `localStorage`.
+
+## Consequences
+
+- **The palette lives in two sources that MUST stay in sync**: the CSS variables in `packages/ui/tailwind-preset.js` (className tokens) and the inline copy in `apps/self-service/src/theme/theme-colors.ts` (used by `useThemeColors`). Both files carry a comment recording this, and `use-theme-colors` / `theme-preference` tests assert the values don't leak across themes. A future cleanup could generate one from the other.
+- **Dark mode now engages app-wide** for the first time (previously it was effectively never rendered whole). Any new screen must be checked in both themes.
+- **Inline `colors.*` and className tokens are now guaranteed consistent** because both derive from the single effective scheme owned by the provider.
+- Delivered across **#91** (redesign: palette + shell + hero cards + component cleanups), **#92** (theme unification + inline-palette recalibration), and **#93** (Settings toggle), under epic **#67** / ticket **#72**.
+- **Follow-ups:** proper i18n keys for the Appearance labels (currently `defaultValue` fallbacks); optionally collapse the two palette sources into one generated source; the MCP builder still uses inline styling internally (renders correctly under the synced tokens, so a full rewrite was deliberately deferred).
+
+See [design-system-theming.md](../knowledge/design-system-theming.md) for the practical developer guide.

--- a/docs/knowledge/coding-conventions.md
+++ b/docs/knowledge/coding-conventions.md
@@ -45,7 +45,7 @@ converse-frontends/
 │   ├── api-native/           # Native API utilities
 │   ├── hooks/                # Shared hooks (auth, usage, projects, accounts, API keys)
 │   ├── i18n/                 # Translation resources
-│   └── ui/                   # Shared design-system components
+│   └── ui/                   # Shared design-system components (see design-system-theming.md)
 ├── openapi/                  # OpenAPI specs — source of truth for backend
 ├── docs/knowledge/           # Agent-readable knowledge base
 └── charts/                   # Helm chart for Kubernetes deployment

--- a/docs/knowledge/design-system-theming.md
+++ b/docs/knowledge/design-system-theming.md
@@ -1,0 +1,77 @@
+# Design system & theming
+
+How colour, layout, and light/dark work in the self-service console, and how to build new UI that stays consistent. Decision record: [ADR 0007](../adr/0007-console-visual-theme-system.md).
+
+## Palette
+
+The palette is defined **twice** and the two copies **must stay identical**:
+
+| Source | File | Consumed by |
+| --- | --- | --- |
+| CSS variables (`--color-*`) | `packages/ui/tailwind-preset.js` | NativeWind className tokens — `bg-surface`, `text-ink`, `border-border`, `bg-primary/10`, … |
+| Inline JS palette | `apps/self-service/src/theme/theme-colors.ts` | `useThemeColors()` → `style={{ color: colors.x }}`, Ionicons `color={…}` |
+
+> ⚠️ **When you change a colour, change it in both files.** They drifted once (the inline copy kept the old accent after the CSS side was recalibrated), which is what produced the "dark island" bug. `theme-colors.ts` carries a sync comment; the theme tests assert values don't leak across themes.
+
+Tokens (light / dark):
+
+| Token | Light | Dark | Use |
+| --- | --- | --- | --- |
+| `primary` | `#3E63DD` | `#7DA0FF` | Actions, links, active state — **never** as a full-bleed fill |
+| `accent` | `#6B4FD6` | `#A48BF0` | Secondary emphasis |
+| `secondary` | `#DB7A34` | `#E0975A` | Warm accent |
+| `success` / `error` | `#2F9E6B` / `#DD4B4B` | `#46C58B` / `#F0736F` | Semantic only (kept separate from the accent) |
+| `ink` / `soft` / `subtle` | `#151A21` / `#5B6472` / `#9AA2AF` | `#E8EAED` / `#A2ABB8` / `#6B7280` | Text hierarchy |
+| `muted` / `surface` / `border` | `#F5F6F8` / `#FFFFFF` / `#E6E8EC` | `#0F1216` / `#181C22` / `#2A2F37` | Page ground / cards / hairlines |
+
+Soft tints (`brandSoft`, `accentSoft`, `successSoft`, …) are `bg-<token>/10` — they cascade automatically, so recalibrating a base token updates its tints.
+
+**Prefer className tokens** (`<Div tone="surface">`, `<Text intent="bodyStrong">`) over inline `colors.*`. Reach for `useThemeColors()` only where a value must be passed as a prop (e.g. an Ionicons `color`).
+
+## Layout — the centered shell
+
+Content sits in a centered column (max `1040px`, the `designTokens.layout.maxContentWidth` token) on desktop and goes edge-to-edge on mobile. This is wired into the shared primitives, so you get it for free:
+
+- **`<Scroll>`** centres its content by default. Opt out with `container={false}` for a screen that manages its own width.
+- **`<PageHeader>`** and **`<Pagination>`** centre their inner content to the same column, so header / body / footer align.
+
+Don't add per-screen `maxWidth`; compose these primitives.
+
+## Text intents
+
+`<Text intent="…">` — `eyebrow`, `title`, `body`, `bodyStrong`, `caption`, `value`, and **`display`** (the large ink hero number on metric cards). Surface-white variants (`inverse*`) exist but are for coloured grounds — after the redesign, prefer a **surface hero card** (`display` on `bg-surface`) over a saturated fill.
+
+## Theming (light / dark)
+
+One provider owns everything:
+
+- **`ThemePreferenceProvider`** (`apps/self-service/src/theme/theme-preference.tsx`) — wraps the app in `_layout.tsx`. It:
+  - resolves the **effective scheme** (`preference === 'system' ? OS : preference`),
+  - toggles the NativeWind `.dark` class on the web root from that scheme (this is what makes className tokens go dark),
+  - persists the preference to `localStorage` with a synchronous read at startup (no flash), guarded for non-web.
+- **`useThemeColors()`** resolves inline colours from the **same effective scheme** — so inline and className styling can never disagree.
+- **`useThemePreference()`** → `{ preference, setPreference, scheme }` for UI that reads or sets the theme.
+- **`useEffectiveColorScheme()`** → `'light' | 'dark'`; falls back to the OS scheme when no provider is mounted (keeps isolated renders/tests working).
+
+Users pick the theme via the **Appearance** control in Settings (`components/theme-toggle.tsx`, Light / Dark / System).
+
+### Verifying dark mode
+Dark is class-driven, not `prefers-color-scheme` directly. In the browser preview, `colorScheme: 'dark'` + reload flips the app (the provider effect reads `matchMedia`); confirm with `document.documentElement.classList.contains('dark')`.
+
+## Do / don't
+
+- ✅ Compose `Scroll` / `PageHeader` / `Pagination` — don't hand-roll containers or max-widths.
+- ✅ Use `tone` / `intent` className tokens; keep `useThemeColors()` for prop-passed colours only.
+- ✅ Check every new screen in **both** themes.
+- ❌ Don't use `primary` (or any accent) as a large solid fill — use a surface card with an accent chip.
+- ❌ Don't edit only one palette source.
+- ❌ Don't read `useColorScheme()` directly for styling — read the effective scheme so the theme toggle is honoured.
+
+## Upgrade notes (from the pre-#91 UI)
+
+Shipped in **#91** (palette + shell + hero cards + component cleanups), **#92** (theme unification + inline-palette recalibration), **#93** (Settings toggle). If you have branches predating these:
+
+- Replace any full-bleed `Div tone="brand"` banner with a surface hero card (`Card` + `Text intent="display"` + a soft accent chip).
+- Remove per-screen `maxWidth` wrappers; rely on `Scroll`/`PageHeader`.
+- Replace direct `useColorScheme()` styling with `useThemeColors()` / `useEffectiveColorScheme()`.
+- If you added palette values, mirror them in **both** `tailwind-preset.js` and `theme-colors.ts`.


### PR DESCRIPTION
## 1. Summary

Documents the console visual redesign + unified theming that shipped across #91, #92, and #93, so the design system and its non-obvious rules are captured for the next contributor. No code changes — docs only. Source of truth: #72 (ticket), #67 (epic).

- **`docs/adr/0007-console-visual-theme-system.md`** — the decision record: recalibrated palette (`#3E63DD` accent, cool-slate neutrals), the centered content shell, unified light/dark via a single provider, and the Settings theme toggle — with consequences, notably the **two-palette-source sync rule** that the "dark island" bug taught us.
- **`docs/knowledge/design-system-theming.md`** — the practical guide: palette tokens + the two synced sources (`tailwind-preset.js` ⇄ `theme-colors.ts`), the `Scroll`/`PageHeader`/`Pagination` centered shell, text intents (`display`), the `ThemePreferenceProvider` / `useThemeColors` model, a do/don't list, and upgrade notes for pre-redesign branches.
- Pointer to the guide from `coding-conventions.md`.

## 2. Intent

> Capture the "why" (ADR) and the "how to work with it" (guide) for the theme system while it's fresh — especially the gotcha that the palette lives in two files that must stay in sync, and that dark mode now engages app-wide.

## 3. Scope

### In scope
- One new ADR (0007), one new knowledge guide, one cross-reference line.

### Out of scope
- No code changes. Follow-ups noted in the ADR (i18n keys for the toggle; possibly generating one palette source from the other) are not done here.

## 4. Verification

- [x] Manual review

Docs-only change. Verified the Markdown renders and the relative links resolve:
- ADR 0007 → `../knowledge/design-system-theming.md`
- guide → `../adr/0007-console-visual-theme-system.md`
- `coding-conventions.md` → `design-system-theming.md`

All described behaviour matches the merged code in #91 / #92 / #93 (token values cross-checked against `tailwind-preset.js` and `theme-colors.ts`).

## 5. Screenshots / Evidence

Source of truth: #72 (ticket), #67 (epic). Describes work merged in #91, #92, #93.

## 6. Risk Assessment

Risk level: **Low** — documentation only; no runtime impact.

## 7. AI Usage Declaration

AI was used for:
- [x] Writing the ADR and the developer guide
- [x] Cross-checking documented token values against the code

Human verification:
- [ ] I read the ADR and guide and they match the shipped behaviour
- [ ] I accept responsibility for this PR

> AI wrote the ADR + guide from the work it implemented in #91/#92/#93, cross-checking token values against source. @stephane-segning should confirm the docs read true before merge.

## 8. Reviewer Focus

- [x] Accuracy of the token table + the two-source sync rule
- [x] That the upgrade notes are actionable for someone on an older branch
