### PR TITLE
feat(auth): persist session via offline_access + IdP (Keycloak) logout

### DIFF
--- a/apps/self-service/src/__tests__/keycloak-login.test.tsx
+++ b/apps/self-service/src/__tests__/keycloak-login.test.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+// The end_session_endpoint the mocked discovery advertises.
+const END_SESSION_ENDPOINT = 'https://kc.example.com/realms/x/protocol/openid-connect/logout';
+
+jest.mock('expo-web-browser', () => ({
+  openAuthSessionAsync: jest.fn(() => Promise.resolve({ type: 'success' })),
+  maybeCompleteAuthSession: jest.fn(),
+}));
+
+jest.mock('expo-auth-session', () => ({
+  fetchDiscoveryAsync: jest.fn(),
+  useAutoDiscovery: jest.fn(() => null),
+  makeRedirectUri: jest.fn(() => 'self-service://login'),
+  useAuthRequest: jest.fn(() => [{ codeVerifier: 'verifier' }, null, jest.fn()]),
+  exchangeCodeAsync: jest.fn(),
+  ResponseType: { Code: 'code' },
+  CodeChallengeMethod: { S256: 'S256' },
+}));
+
+// Isolate the unit under test from the persistence layer (TanStack DB /
+// IndexedDB / SecureStore), which is ESM and unrelated to what we're asserting.
+jest.mock('../../../../packages/hooks/src/auth/use-auth-session', () => ({
+  persistAuthSession: jest.fn(),
+}));
+jest.mock('../../../../packages/hooks/src/auth/auth-store', () => ({
+  setAuthSession: jest.fn(),
+}));
+
+import * as AuthSession from 'expo-auth-session';
+import * as WebBrowser from 'expo-web-browser';
+import {
+  endKeycloakSession,
+  useKeycloakLogin,
+} from '../../../../packages/hooks/src/auth/use-keycloak-login';
+
+const mockedFetchDiscovery = AuthSession.fetchDiscoveryAsync as jest.Mock;
+const mockedUseAuthRequest = AuthSession.useAuthRequest as jest.Mock;
+const mockedOpenAuthSession = WebBrowser.openAuthSessionAsync as jest.Mock;
+
+const CONFIG = {
+  issuer: 'https://kc.example.com/realms/x',
+  clientId: 'self-service',
+  scheme: 'self-service',
+};
+
+describe('endKeycloakSession', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedFetchDiscovery.mockResolvedValue({ endSessionEndpoint: END_SESSION_ENDPOINT });
+  });
+
+  it('opens the IdP end_session_endpoint with id_token_hint and post_logout_redirect_uri', async () => {
+    await endKeycloakSession(CONFIG, 'the-id-token');
+
+    expect(mockedOpenAuthSession).toHaveBeenCalledTimes(1);
+    const [logoutUrl, returnUrl] = mockedOpenAuthSession.mock.calls[0];
+    const url = new URL(logoutUrl);
+
+    expect(url.origin + url.pathname).toBe(END_SESSION_ENDPOINT);
+    expect(url.searchParams.get('client_id')).toBe('self-service');
+    expect(url.searchParams.get('id_token_hint')).toBe('the-id-token');
+    expect(url.searchParams.get('post_logout_redirect_uri')).toBe('self-service://login');
+    // The returnUrl handed to the browser must match the post-logout redirect
+    // so the session resolves when Keycloak redirects back.
+    expect(returnUrl).toBe('self-service://login');
+  });
+
+  it('omits id_token_hint when no id token is available', async () => {
+    await endKeycloakSession(CONFIG);
+
+    const [logoutUrl] = mockedOpenAuthSession.mock.calls[0];
+    expect(new URL(logoutUrl).searchParams.has('id_token_hint')).toBe(false);
+  });
+
+  it('prefers an explicit postLogoutRedirectUri over the derived redirect URI', async () => {
+    await endKeycloakSession(
+      { ...CONFIG, postLogoutRedirectUri: 'https://app.example.com/goodbye' },
+      'the-id-token'
+    );
+
+    const [logoutUrl, returnUrl] = mockedOpenAuthSession.mock.calls[0];
+    expect(new URL(logoutUrl).searchParams.get('post_logout_redirect_uri')).toBe(
+      'https://app.example.com/goodbye'
+    );
+    expect(returnUrl).toBe('https://app.example.com/goodbye');
+  });
+
+  it('does nothing at the IdP when the issuer exposes no end_session_endpoint', async () => {
+    const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    mockedFetchDiscovery.mockResolvedValue({});
+
+    await endKeycloakSession(CONFIG, 'the-id-token');
+
+    expect(mockedOpenAuthSession).not.toHaveBeenCalled();
+    expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('end_session_endpoint'));
+    consoleWarn.mockRestore();
+  });
+});
+
+describe('useKeycloakLogin scopes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  async function mount(config: Parameters<typeof useKeycloakLogin>[0]) {
+    function Probe() {
+      useKeycloakLogin(config);
+      return null;
+    }
+    await render(<Probe />);
+  }
+
+  it('requests offline_access by default so the session can be silently refreshed', async () => {
+    await mount(CONFIG);
+
+    expect(mockedUseAuthRequest).toHaveBeenCalled();
+    const [requestConfig] = mockedUseAuthRequest.mock.calls[0];
+    expect(requestConfig.scopes).toEqual(['openid', 'profile', 'email', 'offline_access']);
+  });
+
+  it('honors explicit scopes from config', async () => {
+    await mount({ ...CONFIG, scopes: ['openid', 'custom'] });
+
+    const [requestConfig] = mockedUseAuthRequest.mock.calls[0];
+    expect(requestConfig.scopes).toEqual(['openid', 'custom']);
+  });
+});

--- a/apps/self-service/src/__tests__/use-sign-out.test.tsx
+++ b/apps/self-service/src/__tests__/use-sign-out.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+jest.mock('../../../../packages/hooks/src/auth/use-auth-session', () => ({
+  clearPersistedAuthSession: jest.fn(() => Promise.resolve()),
+  getLatestAuthSession: jest.fn(() => ({ tokens: { idToken: 'idt-1' } })),
+}));
+jest.mock('../../../../packages/hooks/src/auth/use-keycloak-login', () => ({
+  endKeycloakSession: jest.fn(() => Promise.resolve()),
+}));
+
+import { useSignOut } from '../../../../packages/hooks/src/auth/use-sign-out';
+import {
+  clearPersistedAuthSession,
+  getLatestAuthSession,
+} from '../../../../packages/hooks/src/auth/use-auth-session';
+import { endKeycloakSession } from '../../../../packages/hooks/src/auth/use-keycloak-login';
+
+const mockClear = clearPersistedAuthSession as jest.Mock;
+const mockGetLatest = getLatestAuthSession as jest.Mock;
+const mockEndSession = endKeycloakSession as jest.Mock;
+
+const CONFIG = {
+  issuer: 'https://kc.example.com/realms/x',
+  clientId: 'self-service',
+  scheme: 'self-service',
+};
+
+async function mountSignOut(config?: Parameters<typeof useSignOut>[0]) {
+  const box: { current: ReturnType<typeof useSignOut> } = {
+    current: undefined as never,
+  };
+  function Probe() {
+    box.current = useSignOut(config);
+    return null;
+  }
+  await render(<Probe />);
+  return box;
+}
+
+describe('useSignOut', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetLatest.mockReturnValue({ tokens: { idToken: 'idt-1' } });
+    mockEndSession.mockResolvedValue(undefined);
+    mockClear.mockResolvedValue(undefined);
+  });
+
+  it('ends the Keycloak session with the current id token, then clears local state', async () => {
+    const box = await mountSignOut(CONFIG);
+    await box.current.signOut();
+
+    expect(mockEndSession).toHaveBeenCalledWith(CONFIG, 'idt-1');
+    expect(mockClear).toHaveBeenCalledTimes(1);
+    // IdP end-session must run before the local token object is cleared, so the
+    // id token is still available as the id_token_hint.
+    expect(mockEndSession.mock.invocationCallOrder[0]).toBeLessThan(
+      mockClear.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('still clears local state when the IdP end-session fails', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockEndSession.mockRejectedValue(new Error('keycloak unreachable'));
+
+    const box = await mountSignOut(CONFIG);
+    await expect(box.current.signOut()).resolves.toBeUndefined();
+
+    expect(mockClear).toHaveBeenCalledTimes(1);
+    consoleError.mockRestore();
+  });
+
+  it('skips the IdP round-trip when no issuer config is provided', async () => {
+    const box = await mountSignOut();
+    await box.current.signOut();
+
+    expect(mockEndSession).not.toHaveBeenCalled();
+    expect(mockClear).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/self-service/src/screens/home-screen.tsx
+++ b/apps/self-service/src/screens/home-screen.tsx
@@ -75,11 +75,11 @@ export function HomeScreen() {
   const { data: projects = [] } = useProjects(currentAccount?.id);
   const { data: currentProject } = useCurrentProject();
   const { data: apiKeys = [] } = useApiKeys(currentProject?.id);
-  const { signOut } = useSignOut();
+  const config = useRuntimeConfig();
+  const { signOut } = useSignOut(config.keycloak);
   const [isSigningOut, setIsSigningOut] = useState(false);
   const isSigningOutRef = useRef(false);
   const isMountedRef = useRef(true);
-  const config = useRuntimeConfig();
 
   const [, setDayStamp] = useState(() => getUtcDayStamp(new Date()));
 

--- a/packages/hooks/src/auth-session.ts
+++ b/packages/hooks/src/auth-session.ts
@@ -8,4 +8,5 @@ export {
   clearPersistedAuthSession,
 } from './auth/use-auth-session';
 export { useSignOut } from './auth/use-sign-out';
+export type { SignOutConfig } from './auth/use-sign-out';
 export type { AuthSession, AuthTokens, AuthUser } from './auth/auth-types';

--- a/packages/hooks/src/auth/use-keycloak-login.ts
+++ b/packages/hooks/src/auth/use-keycloak-login.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import * as AuthSession from 'expo-auth-session';
 import { CodeChallengeMethod } from 'expo-auth-session';
+import * as WebBrowser from 'expo-web-browser';
 
 import type { AuthSession as StoredSession, AudienceConfig } from './auth-types';
 import { persistAuthSession } from './use-auth-session';
@@ -40,9 +41,7 @@ function extractAndValidateAudience(
     });
 
     const rawAud = result.payload?.aud;
-    const audience = rawAud
-      ? (Array.isArray(rawAud) ? rawAud : [rawAud])
-      : undefined;
+    const audience = rawAud ? (Array.isArray(rawAud) ? rawAud : [rawAud]) : undefined;
 
     return {
       audience,
@@ -93,7 +92,10 @@ export async function refreshAccessToken(
     const audienceResult = extractAndValidateAudience(tokenResult.access_token, config.audience);
 
     if (!audienceResult.valid) {
-      console.error('[Auth] JWT audience validation failed during token refresh:', audienceResult.errors);
+      console.error(
+        '[Auth] JWT audience validation failed during token refresh:',
+        audienceResult.errors
+      );
       // Block authentication - audience mismatch means token is not intended for this client
       throw createAudienceError(audienceResult.errors);
     }
@@ -149,6 +151,56 @@ export async function refreshAccessToken(
   }
 }
 
+/**
+ * Performs an RP-initiated logout against the Keycloak issuer.
+ *
+ * Opens the IdP `end_session_endpoint` (discovered from the issuer) with an
+ * `id_token_hint` and a `post_logout_redirect_uri`, so the Keycloak SSO
+ * session itself is terminated — not just the local token copy.
+ *
+ * NOTE(keycloak): the `post_logout_redirect_uri` must be registered on the
+ * client under "Valid post logout redirect URIs" (a wildcard like
+ * `self-service://*` / `https://app.example.com/*` covers it), otherwise
+ * Keycloak refuses the redirect. Callers should still clear the local session
+ * regardless of the outcome here.
+ */
+export async function endKeycloakSession(
+  config: Pick<KeycloakConfig, 'issuer' | 'clientId' | 'scheme' | 'redirectUri'> & {
+    postLogoutRedirectUri?: string;
+  },
+  idToken?: string
+): Promise<void> {
+  const discovery = await AuthSession.fetchDiscoveryAsync(config.issuer);
+
+  if (!discovery.endSessionEndpoint) {
+    console.warn('[Auth] Issuer exposes no end_session_endpoint; skipping IdP logout.');
+    return;
+  }
+
+  const postLogoutRedirectUri =
+    config.postLogoutRedirectUri ??
+    config.redirectUri ??
+    AuthSession.makeRedirectUri({
+      scheme: config.scheme,
+      path: 'login',
+    });
+
+  const params = new URLSearchParams({
+    client_id: config.clientId,
+    post_logout_redirect_uri: postLogoutRedirectUri,
+  });
+
+  // Keycloak requires either an id_token_hint or client_id to identify the
+  // session; we send both when the id token is available.
+  if (idToken) {
+    params.set('id_token_hint', idToken);
+  }
+
+  const logoutUrl = `${discovery.endSessionEndpoint}?${params.toString()}`;
+
+  await WebBrowser.openAuthSessionAsync(logoutUrl, postLogoutRedirectUri);
+}
+
 export function useKeycloakLogin(config: KeycloakConfig) {
   const discovery = AuthSession.useAutoDiscovery(config.issuer);
   const redirectUri = useMemo(
@@ -169,7 +221,10 @@ export function useKeycloakLogin(config: KeycloakConfig) {
     {
       clientId: config.clientId,
       redirectUri,
-      scopes: config.scopes ?? ['openid', 'profile', 'email'],
+      // `offline_access` asks Keycloak for an offline refresh token that
+      // outlives the SSO session, so the persisted session can be silently
+      // refreshed indefinitely and the user is not prompted to log in again.
+      scopes: config.scopes ?? ['openid', 'profile', 'email', 'offline_access'],
       responseType: AuthSession.ResponseType.Code,
       usePKCE: true,
       codeChallengeMethod: CodeChallengeMethod.S256,
@@ -209,7 +264,10 @@ export function useKeycloakLogin(config: KeycloakConfig) {
         const audienceResult = extractAndValidateAudience(tokenResult.accessToken, config.audience);
 
         if (!audienceResult.valid) {
-          console.error('[Auth] JWT audience validation failed during login:', audienceResult.errors);
+          console.error(
+            '[Auth] JWT audience validation failed during login:',
+            audienceResult.errors
+          );
           // Block authentication - audience mismatch means token is not intended for this client
           throw createAudienceError(audienceResult.errors);
         } else if (audienceResult.audience) {

--- a/packages/hooks/src/auth/use-sign-out.ts
+++ b/packages/hooks/src/auth/use-sign-out.ts
@@ -1,8 +1,34 @@
-import { clearPersistedAuthSession } from './use-auth-session';
+import { clearPersistedAuthSession, getLatestAuthSession } from './use-auth-session';
+import { endKeycloakSession, type KeycloakConfig } from './use-keycloak-login';
 
-export function useSignOut() {
+/**
+ * Config needed to also terminate the Keycloak SSO session on sign-out.
+ * When omitted, `signOut` only clears the locally persisted session.
+ */
+export type SignOutConfig = Pick<
+  KeycloakConfig,
+  'issuer' | 'clientId' | 'scheme' | 'redirectUri'
+> & {
+  postLogoutRedirectUri?: string;
+};
+
+export function useSignOut(config?: SignOutConfig) {
   const signOut = async () => {
-    await clearPersistedAuthSession();
+    // Capture the id token before we wipe the local session — Keycloak uses it
+    // as the `id_token_hint` to identify which session to end.
+    const idToken = getLatestAuthSession().tokens?.idToken;
+
+    try {
+      if (config?.issuer) {
+        await endKeycloakSession(config, idToken);
+      }
+    } catch (error) {
+      // Never let an IdP round-trip failure strand the user in a logged-in
+      // state locally — fall through and clear the persisted session below.
+      console.error('[Auth] IdP end-session failed during sign-out:', error);
+    } finally {
+      await clearPersistedAuthSession();
+    }
   };
 
   return { signOut };

--- a/packages/hooks/src/keycloak-login.ts
+++ b/packages/hooks/src/keycloak-login.ts
@@ -1,2 +1,6 @@
-export { useKeycloakLogin, refreshAccessToken } from './auth/use-keycloak-login';
+export {
+  useKeycloakLogin,
+  refreshAccessToken,
+  endKeycloakSession,
+} from './auth/use-keycloak-login';
 export type { KeycloakConfig } from './auth/use-keycloak-login';


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds `offline_access` to the default login scopes so Keycloak issues an **offline refresh token** that outlives the SSO session.
- Adds `endKeycloakSession` — an RP-initiated logout that hits the issuer's `end_session_endpoint` with `id_token_hint` + `post_logout_redirect_uri`.
- Rewires `useSignOut` to end the Keycloak SSO session and then **always** clear the locally persisted token object.

It solves:

- #96 — users are periodically bounced to login, and logout was local-only (Keycloak SSO session left alive).

---

## 2. Intent

> The token object is already persisted (web: IndexedDB via `idb-keyval`; native: SecureStore) and silently refreshed on boot — but login never requested `offline_access`, so the refresh token died with the SSO session and forced re-login. Requesting `offline_access` closes that gap so the persisted session refreshes indefinitely and the user is not disturbed again. Separately, logout must terminate the IdP session (security/UX), not just delete the local copy.

---

## 3. Scope

### In Scope

- `offline_access` scope at login (`use-keycloak-login.ts`).
- `endKeycloakSession` helper + `useSignOut` performing IdP end-session then local clear.
- Passing runtime Keycloak config into `useSignOut` at the logout call site (`home-screen.tsx`).

### Out of Scope

- Switching web storage from `idb-keyval` to Dexie (deliberately kept — already IndexedDB-backed).
- Token revocation (`revoke`) endpoint.
- Login/logout UI changes.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests (9 new unit tests + full suite green; typecheck / lint / format)
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [x] Testing error cases (IdP end-session failure still clears local session — `finally` block)
- [x] Testing permissions/security behavior (IdP session termination on logout)
- [ ] Testing rollback or failure behavior, if relevant

Automated tests added (`apps/self-service/src/__tests__/`):

- `keycloak-login.test.tsx` — `endKeycloakSession` end_session URL construction (id_token_hint present/absent, explicit `postLogoutRedirectUri` override, no-endpoint early return) + `useKeycloakLogin` requests `offline_access` by default and honors explicit scopes.
- `use-sign-out.test.tsx` — `useSignOut` ends the IdP session before clearing local state, still clears local state when the IdP round-trip fails, and skips the IdP round-trip when no issuer config is provided.

Commands run:

```bash
pnpm exec jest                # in apps/self-service (full suite)
pnpm exec tsc --noEmit        # in apps/self-service
pnpm exec eslint <changed files>
pnpm exec prettier -c <changed files>
```

Results:

```text
jest: 23 suites / 87 tests passed (incl. 2 new suites, 9 new tests)
tsc --noEmit: exit 0 (clean)
eslint: 0 errors (only pre-existing/structural warnings, unrelated to logic)
prettier: All matched files use Prettier code style!
```

**Known limitation:** the live OIDC round-trip (login acquiring an offline token; logout redirecting through Keycloak) requires a running Keycloak realm + device/browser and was not driven headlessly. Recommended manual pass on web + native: log in → reload/reopen (stays signed in) → log out (Keycloak logout redirect, persisted entry removed).

---

## 5. Screenshots / Evidence

- Static-check output: see Verification above.
- Manual OIDC evidence: pending live-IdP run.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* Post-logout redirect URI not whitelisted on the Keycloak client → IdP rejects the redirect.
* `offline_access` not assigned to the client → scope ignored/refused.

Mitigation:

* Local session is always cleared in a `finally`, so a failed IdP round-trip never strands the user logged-in. Documented in the `endKeycloakSession` docstring.
* Keycloak client must whitelist the post-logout redirect URI (e.g. `self-service://*`, `https://<app-origin>/*`) and have `offline_access` as a default/optional client scope (default for new clients) — called out in the ticket.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [x] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [x] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [x] Product intent
* [x] Edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
