### PR TITLE
fix(nav): desktop settings two-pane + compact icon rail

### DIFF
--- a/apps/self-service/src/navigation/responsive-tab-bar.tsx
+++ b/apps/self-service/src/navigation/responsive-tab-bar.tsx
@@ -35,13 +35,11 @@ export function ResponsiveTabBar({ state, descriptors, navigation }: Readonly<Bo
   if (isDesktop) {
     return (
       <NavContainer placement="sidebar">
-        <Stack gap="xs" align="stretch">
+        <Stack gap="sm" align="center">
           {state.routes.map((route, index) => {
             const label = getLabel(route.key, route.name);
             const isFocused = state.index === index;
             const iconName = getIconName(route.name, isFocused);
-            // Match the caption colours: filled pill → surface icon, otherwise
-            // the same `soft` tone as the label beneath it.
             const iconColor = isFocused ? colors.surface : colors.soft;
 
             return (
@@ -50,11 +48,11 @@ export function ResponsiveTabBar({ state, descriptors, navigation }: Readonly<Bo
                 placement="sidebar"
                 active={isFocused}
                 label={label}
-                showLabel
+                showLabel={false}
                 accessibilityLabel={label}
                 icon={
                   iconName ? (
-                    <Ionicons name={iconName} size={designTokens.icon.nav} color={iconColor} />
+                    <Ionicons name={iconName} size={designTokens.icon.rail} color={iconColor} />
                   ) : null
                 }
                 onPress={() => navigation.navigate(route.name)}

--- a/apps/self-service/src/views/settings/settings-category-list-view.tsx
+++ b/apps/self-service/src/views/settings/settings-category-list-view.tsx
@@ -62,9 +62,14 @@ export function SettingsCategoryListView({
     return (
       <Div
         tone="surface"
-        width="full"
         pad="md"
-        style={{ borderRightWidth: 1, borderRightColor: colors.border, minWidth: 220 }}>
+        style={{
+          width: 300,
+          flexShrink: 0,
+          alignSelf: 'stretch',
+          borderRightWidth: 1,
+          borderRightColor: colors.border,
+        }}>
         <Stack gap="md">
           <Text intent="eyebrow">{t('settings.title')}</Text>
           {content}

--- a/packages/ui/src/components/nav-container/cva.tsx
+++ b/packages/ui/src/components/nav-container/cva.tsx
@@ -3,7 +3,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 export const navContainerVariants = cva('', {
   variants: {
     placement: {
-      sidebar: 'absolute left-0 top-0 h-full w-[88px] border-r border-border bg-surface px-2 py-6',
+      sidebar: 'absolute left-0 top-0 h-full w-[68px] border-r border-border bg-surface px-2 py-5',
       bottom: 'flex-row items-center justify-around border-t border-border bg-surface px-6 py-3',
     },
   },

--- a/packages/ui/src/components/nav-item/cva.tsx
+++ b/packages/ui/src/components/nav-item/cva.tsx
@@ -3,7 +3,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 export const navItemVariants = cva('flex-row items-center justify-center bg-transparent', {
   variants: {
     placement: {
-      sidebar: 'h-11 w-11 rounded-lg p-0',
+      sidebar: 'h-10 w-10 rounded-lg p-0',
       bottom: 'rounded-full px-2 py-2',
     },
     active: {
@@ -16,13 +16,6 @@ export const navItemVariants = cva('flex-row items-center justify-center bg-tran
     },
   },
   compoundVariants: [
-    // Labelled side-rail item: stack the icon over its caption in a full-width
-    // pill (overrides the bare 44×44 icon square from the `sidebar` variant).
-    {
-      placement: 'sidebar',
-      labelVisible: true,
-      className: 'h-auto w-full flex-col gap-1 px-1 py-2',
-    },
     { placement: 'sidebar', active: true, className: 'bg-ink' },
     { placement: 'sidebar', active: false, className: 'bg-transparent' },
     { placement: 'bottom', active: true, className: 'bg-transparent' },
@@ -38,9 +31,7 @@ export const navItemVariants = cva('flex-row items-center justify-center bg-tran
 export const navLabelVariants = cva('text-sm font-semibold', {
   variants: {
     placement: {
-      // Rail caption: smaller + centred so two-word titles ("API Keys") sit
-      // tidily under the icon.
-      sidebar: 'text-[11px] font-medium leading-tight text-center',
+      sidebar: '',
       bottom: '',
     },
     active: {

--- a/packages/ui/src/design/tokens.ts
+++ b/packages/ui/src/design/tokens.ts
@@ -3,10 +3,9 @@ export const designTokens = {
     desktop: 1024,
   },
   layout: {
-    // Desktop side rail is a labelled icon rail (icon + caption stacked), so it
-    // needs a little more width than a bare icon strip. Keep in sync with the
-    // `sidebar` width in components/nav-container/cva.tsx.
-    navRailWidth: 88,
+    // Desktop side rail is a compact icon rail. Keep in sync with the `sidebar`
+    // width in components/nav-container/cva.tsx.
+    navRailWidth: 68,
     topBarMinHeight: 58,
     bottomNavClearance: 100,
     formFooterClearance: 140,
@@ -16,6 +15,9 @@ export const designTokens = {
   },
   icon: {
     nav: 22,
+    // Desktop side-rail glyph — a touch smaller than the bottom-tab `nav` icon
+    // so the rail reads as compact, not chunky.
+    rail: 19,
     action: 20,
     prominent: 24,
   },


### PR DESCRIPTION
## 1. Summary

This PR changes:

- **fix(settings): desktop account settings was unreachable.** The desktop settings two-pane (`SettingsScreen` → category rail + embedded `AccountSettingsScreen`) rendered its category rail with `width="full"`, so in the flex row it consumed 100% width and collapsed the Account settings detail pane to zero width. On desktop you saw only the category list; the account settings form (billing identity, owners/admins, auth) was invisible — reachable only via the mobile push flow. Fixed by giving the rail a fixed 300px column (`flexShrink: 0`, `alignSelf: stretch`) so the two-pane splits correctly.
- **revert(ui): compact icon-only desktop rail.** The labelled rail introduced in #95 read as noisy/oversized in a side rail. Reverted to an icon-only rail with smaller glyphs (new `designTokens.icon.rail = 19` vs `nav = 22`), a 40px pill (`h-10`), and rail width `88 → 68`.

It solves:

- Direct feedback on the deployed build: "sidenav icons too big, label useless there; on larger screens account settings is accessible only on smaller screens." (Follow-up to #95.)

---

## 2. Intent

The intent of this PR is:

> Correct two regressions/latent bugs visible on the deployed desktop build: the desktop settings two-pane was collapsing the account-settings detail (a pre-existing layout bug surfaced by real usage), and the labelled side rail from #95 was visually heavy. Restore a calm, compact desktop rail and make account settings reachable on desktop.

---

## 3. Scope

### In Scope

- `settings-category-list-view.tsx`: rail is a fixed-width column instead of `width="full"`; widened to 300px so the appearance toggle (System/Light/Dark) no longer truncates.
- Rail styling: `responsive-tab-bar.tsx` (icon-only, `icon.rail` size), `nav-item`/`nav-container` CVA (pill 40px, width 68), `tokens.ts` (`icon.rail`, `navRailWidth`).

### Out of Scope

- The imperative sheets and `Stack.Protected` auth guard from #95 (unchanged).
- Restructuring where the appearance toggle lives (kept in the settings rail; just given room).
- Mobile settings layout (unchanged).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
pnpm --filter @lightbridge/ui exec tsc --noEmit   # clean
pnpm --filter self-service exec tsc --noEmit       # clean
pnpm --filter self-service test                    # 21 suites, 78 tests
pnpm exec prettier --write <changed files>         # clean
```

Results:

```text
Test Suites: 21 passed, 21 total
Tests:       78 passed, 78 total

Web (expo start --web), desktop shell rendered via a temporary diagnostic route:
- BEFORE fix: settings two-pane showed only the full-width category rail; account
  settings detail was absent (zero width).
- AFTER fix: two-pane splits into [300px category rail | Account settings detail]
  with Billing identity / Owners & admins / Authentication all visible; appearance
  toggle shows "System / Light / Dark" untruncated.
- Icon rail: compact icon-only, active item as a light pill (no labels).
```

---

## 5. Screenshots / Evidence

* Desktop shell after fix: compact icon rail + settings two-pane with account settings detail fully rendered (captured during web verification).

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* The desktop settings rail is now a fixed 300px; at the 1024px desktop breakpoint the detail pane gets ~656px (comfortable).

Mitigation:

* Fixed width + `flexShrink: 0` prevents the collapse; verified the split renders and the toggle fits. Typecheck + 78 tests pass.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

> Author: please tick after review, and attach the source-of-truth ticket.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [x] Product intent
* [x] Edge cases

Specifically: the desktop settings two-pane split at the 1024px breakpoint, and the rail proportions.
