### PR TITLE
ci(helm): publish chart to shared adorsys-gis/charts OCI namespace

### DIFF
--- a/.github/workflows/publish-charts-oci.yml
+++ b/.github/workflows/publish-charts-oci.yml
@@ -3,12 +3,14 @@ name: publish-charts-oci
 # Publish this repo's Helm chart(s) to GHCR as OCI artifacts on merge to main.
 # Replaces the classic gh-pages / index.yaml Helm repo — charts now live at
 #
-#   oci://ghcr.io/adorsys-gis/converse-frontends/charts/<name>
+#   oci://ghcr.io/adorsys-gis/charts/<name>
 #
-# (i.e. under this repo's own GHCR namespace, prefixed with `charts/`, alongside
-# the container image at ghcr.io/adorsys-gis/converse-frontends). Consumers such
-# as ai-helm's `converse-ui` Application float on a semver range and pick up the
-# newest published version on the next reconcile.
+# i.e. the org-wide charts namespace (the same one ai-helm publishes to). Each
+# chart is a distinct GHCR package named `charts/<name>`, created and owned by
+# whichever repo first pushes it — `charts/converse-frontend` is unique to this
+# repo, so its `packages: write` GITHUB_TOKEN can create and own it. Consumers
+# such as ai-helm's `converse-ui` Application float on a semver range and pick up
+# the newest published version on the next reconcile.
 #
 # Versioning is monotonic + clean X.Y.Z, DERIVED AT PUBLISH TIME (never committed
 # back into Chart.yaml — so this workflow can't re-trigger itself):
@@ -37,8 +39,8 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  # Repo-scoped charts namespace (lowercased owner — GHCR paths are case-sensitive).
-  OCI_REPO: oci://ghcr.io/adorsys-gis/converse-frontends/charts
+  # Org-wide charts namespace (lowercased owner — GHCR paths are case-sensitive).
+  OCI_REPO: oci://ghcr.io/adorsys-gis/charts
 
 jobs:
   publish:

--- a/charts/converse-frontend/README.md
+++ b/charts/converse-frontend/README.md
@@ -8,7 +8,7 @@ On every merge to `main`, this chart is packaged and pushed to GHCR as an OCI
 artifact (there is no gh-pages Helm repo):
 
 ```
-oci://ghcr.io/adorsys-gis/converse-frontends/charts/converse-frontend
+oci://ghcr.io/adorsys-gis/charts/converse-frontend
 ```
 
 Versions are `MAJOR.MINOR` from `Chart.yaml` plus a patch derived from the commit
@@ -16,9 +16,9 @@ count touching the chart directory (monotonic, clean `X.Y.Z`). Pull a specific
 version with `--version`, or omit it to get the latest:
 
 ```bash
-helm show chart oci://ghcr.io/adorsys-gis/converse-frontends/charts/converse-frontend
+helm show chart oci://ghcr.io/adorsys-gis/charts/converse-frontend
 helm upgrade --install -n ai converse-frontend \
-  oci://ghcr.io/adorsys-gis/converse-frontends/charts/converse-frontend \
+  oci://ghcr.io/adorsys-gis/charts/converse-frontend \
   -f my-values.yaml
 ```
 

--- a/docs/knowledge/ci-cd.md
+++ b/docs/knowledge/ci-cd.md
@@ -35,7 +35,7 @@ Trigger: push to main / tagged branch / v* tag / workflow_dispatch
 
 On merge to `main` (paths `charts/**`), each application chart under `charts/` is
 packaged and pushed to GHCR as an OCI artifact at
-`oci://ghcr.io/adorsys-gis/converse-frontends/charts/<name>` (no gh-pages Helm
+`oci://ghcr.io/adorsys-gis/charts/<name>` (no gh-pages Helm
 repo). The chart version is derived at publish time — `MAJOR.MINOR` from
 `Chart.yaml` plus a patch equal to the commit count touching the chart dir — so it
 is monotonic and never committed back. Publishing is idempotent (skips a version
@@ -102,7 +102,7 @@ This caches Docker build layers between runs. The pnpm dependency install step i
 
 Deployment to Kubernetes is driven by a separate GitOps process (ArgoCD in the
 `ai-helm` repo). Its `converse-ui` Application consumes the chart published to
-`oci://ghcr.io/adorsys-gis/converse-frontends/charts/converse-frontend` and floats
+`oci://ghcr.io/adorsys-gis/charts/converse-frontend` and floats
 on a semver range, while `argocd-image-updater` tracks the container image tag.
 For local/manual work, install the chart from `charts/converse-frontend/`.
 

--- a/docs/knowledge/infrastructure.md
+++ b/docs/knowledge/infrastructure.md
@@ -21,7 +21,7 @@ No staging environment is defined in the codebase. Production is the only declar
 The frontend is deployed to Kubernetes via a **Helm chart** located at `charts/converse-frontend/`.
 
 On merge to `main`, the chart is published to GHCR as an OCI artifact at
-`oci://ghcr.io/adorsys-gis/converse-frontends/charts/converse-frontend` (see the
+`oci://ghcr.io/adorsys-gis/charts/converse-frontend` (see the
 `publish-charts-oci.yml` workflow — there is no gh-pages Helm repo). GitOps
 consumers (e.g. ai-helm's `converse-ui` Application) float on a semver range and
 pull the newest published version.
@@ -29,7 +29,7 @@ pull the newest published version.
 ```bash
 # Example: install/upgrade from the published OCI chart
 helm upgrade --install converse-frontend \
-  oci://ghcr.io/adorsys-gis/converse-frontends/charts/converse-frontend \
+  oci://ghcr.io/adorsys-gis/charts/converse-frontend \
   --set conversefrontend.controllers.main.containers.frontend.image.tag=<tag> \
   --set conversefrontend.controllers.main.containers.frontend.env.EXPO_PUBLIC_BACKEND_URL=<url> \
   ...


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Repoints the Helm chart OCI publish target from `oci://ghcr.io/adorsys-gis/converse-frontends/charts` (repo-scoped) to `oci://ghcr.io/adorsys-gis/charts` (org-wide, the same namespace ai-helm publishes to).
- Updates the chart README and knowledge docs to the new path.

It solves:

- Follow-up to #99 / #100 — align chart distribution with the org-wide `adorsys-gis/charts` OCI namespace.

---

## 2. Intent

The intent of this PR is:

> Publish `converse-frontend` alongside the other org charts at `oci://ghcr.io/adorsys-gis/charts/converse-frontend`. GHCR container packages are per-package (a package named `charts/converse-frontend`), and this name is not owned by ai-helm — so it is created and linked to this repo on first push, and the repo's own `packages: write` GITHUB_TOKEN can publish it without any org-level grant. Versioning, idempotency, and the workflow logic are unchanged.

---

## 3. Scope

### In Scope

- The `OCI_REPO` env change + header comment.
- Doc references (README, ci-cd.md, infrastructure.md).

### Out of Scope

- Consumer wiring — the ai-helm `converse-ui` `repoURL` and the home-os ArgoCD repo-credential `url` are updated in their own PRs (ADORSYS-GIS/ai-helm #622, WhyThatFunction/home-os #102).
- Deleting the now-stale `converse-frontends/charts/converse-frontend` package from the first namespace (manual GHCR cleanup, if desired).

---

## 4. Verification

I verified this change by:

- [x] Running manual tests

Commands run:

```bash
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish-charts-oci.yml'))"
grep -rn 'converse-frontends/charts' charts/ docs/    # expect: none remain
```

Results:

```text
workflow YAML: OK
no repo-scoped path remains; all references now oci://ghcr.io/adorsys-gis/charts/converse-frontend
```

On merge, the workflow publishes `charts/converse-frontend:0.1.10` to the new namespace (patch count unchanged; idempotent skip only applies within a namespace, so the first push to `adorsys-gis/charts` proceeds).

---

## 5. Screenshots / Evidence

* Paired PRs: `ADORSYS-GIS/ai-helm#622`, `WhyThatFunction/home-os#102`
* Original publish workflow: #100 (merged)

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* If org policy blocked package creation, the first push would 403 — but this token already created `converse-frontends/charts/converse-frontend`, proving it can create org packages.
* The old repo-scoped package `charts/converse-frontend` under `converse-frontends/` is left orphaned (harmless; private).

Mitigation:

* No consumer points at the new package until the paired PRs merge, so a failed first publish can't break a running deployment.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Drafting documentation
* [x] Reviewing the diff

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Product intent
