### PR TITLE
ci: adorsys-gis-runner + Buildah + Turbo, drop Docker cache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,8 +5,8 @@
 .docker/keycloak-config
 node_modules
 **/node_modules
-dist
-**/dist
+# NOTE: apps/self-service/dist is intentionally NOT ignored — the web bundle is
+# built on the CI runner (turbo run build:web) and COPYed into the runtime image.
 .expo
 **/.expo
 .DS_Store

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,7 +15,10 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    # Rootless Buildah on the self-hosted runner (daemonless — no Docker/dind).
+    # The web bundle is built here via Turbo (hitting the runner's Turbo cache),
+    # then baked into a thin nginx image. Single-arch: every cluster node is amd64.
+    runs-on: adorsys-gis-runner
     permissions:
       contents: read
       packages: write
@@ -23,15 +26,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7.0.0
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Build the static web export on the runner. Turbo pulls from / writes to
+      # the runner's integrated Turbo cache — no Docker/BuildKit layer cache.
+      - name: Build web export (Turbo)
+        run: pnpm turbo run build:web
 
       - name: Extract metadata
         id: meta
@@ -44,26 +54,42 @@ jobs:
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build local image for scanning
-        run: docker build -t scan-target .
+      - name: Log in to GHCR (Buildah)
+        # Direct `buildah login` writes the podman/buildah auth.json the build +
+        # push steps read. (redhat-actions/podman-login mirrors creds to
+        # ~/.docker/config.json, which ENOENTs on daemonless runners.)
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | buildah login --username "${{ github.actor }}" --password-stdin "${{ env.REGISTRY }}"
+
+      - name: Build image (Buildah, amd64, no layer cache)
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          LABELS: ${{ steps.meta.outputs.labels }}
+        run: |
+          set -euo pipefail
+          label_args=(); while IFS= read -r l; do [ -n "$l" ] && label_args+=(--label "$l"); done <<<"$LABELS"
+          tag_args=();   while IFS= read -r t; do [ -n "$t" ] && tag_args+=(-t "$t");      done <<<"$TAGS"
+          # No --layers / --cache-from / --cache-to: the Docker build is deliberately
+          # uncached (caching lives in Turbo). Single amd64 platform.
+          buildah build --format docker --platform linux/amd64 \
+            -f Dockerfile "${label_args[@]}" "${tag_args[@]}" .
+          # Export the first tag as a tarball so Trivy can scan it daemonless.
+          primary="$(head -n1 <<<"$TAGS")"
+          buildah push "$primary" docker-archive:/tmp/image.tar
 
       - name: Run Trivy vulnerability scanner on image
         uses: aquasecurity/trivy-action@v0.36.0
         with:
-          image-ref: 'scan-target'
+          input: /tmp/image.tar
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true
           severity: 'HIGH,CRITICAL'
 
-      - name: Build and push multi-platform image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
+      - name: Push image (all tags)
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          while IFS= read -r t; do [ -n "$t" ] && buildah push "$t"; done <<<"$TAGS"

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -7,10 +7,11 @@
 #
 # Source of truth: https://adorsys-gis.github.io/ai-governance/
 #
-# The reusable workflow is pinned to an immutable commit SHA (the v1.0.0 release), not
-# @main or a movable tag, so a future push — or a moved tag — to ai-governance cannot
-# change what runs here with write access. Bump the SHA deliberately when adopting a new
-# governance release.
+# The reusable workflow is pinned to an immutable commit SHA, not @main or a movable
+# tag, so a future push — or a moved tag — to ai-governance cannot change what runs
+# here with write access. Bump the SHA deliberately when adopting a new governance
+# release. (Pinned past v1.0.0 to a commit that supports the `runs-on` input, so this
+# check runs on the self-hosted adorsys-gis-runner like every other job in this repo.)
 name: AI Governance
 
 on:
@@ -19,12 +20,11 @@ on:
 
 jobs:
   governance:
-    # ADORSYS-GIS/ai-governance @ v1.0.0
-    uses: ADORSYS-GIS/ai-governance/.github/workflows/governance-check.yml@959d8565041ddef86d3a10001b64393a6d4a60a2
-    # Runs on GitHub-hosted ubuntu-latest by default. To run on your own runners,
-    # bump the pinned SHA to a release that supports the `runs-on` input and add:
-    #   with:
-    #     runs-on: <your-self-hosted-runner-label>
+    # ADORSYS-GIS/ai-governance governance-check.yml — pinned past v1.0.0 to the
+    # commit that added the `runs-on` input (PR #17, 2026-07-06).
+    uses: ADORSYS-GIS/ai-governance/.github/workflows/governance-check.yml@52043b9d900013dd89b281bcd3d94ad559c3193d
+    with:
+      runs-on: adorsys-gis-runner
     permissions:
       pull-requests: write
       contents: read

--- a/.github/workflows/publish-charts-oci.yml
+++ b/.github/workflows/publish-charts-oci.yml
@@ -44,7 +44,7 @@ env:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: adorsys-gis-runner
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.0

--- a/.github/workflows/qwen-dispatch.yml
+++ b/.github/workflows/qwen-dispatch.yml
@@ -26,7 +26,7 @@ jobs:
   debugger:
     if: |-
      ${{ fromJSON(vars.DEBUG || vars.ACTIONS_STEP_DEBUG || false) }}
-    runs-on: 'ubuntu-latest'
+    runs-on: adorsys-gis-runner
     permissions:
       contents: 'read'
     steps:
@@ -58,7 +58,7 @@ jobs:
         startsWith(github.event.comment.body || github.event.review.body || github.event.issue.body, '@qwen-code') &&
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || github.event.review.author_association || github.event.issue.author_association)
       )
-    runs-on: 'ubuntu-latest'
+    runs-on: adorsys-gis-runner
     permissions:
       contents: 'read'
       issues: 'write'
@@ -173,7 +173,7 @@ jobs:
       - 'invoke'
     if: |-
       ${{ always() && !cancelled() && (failure() || needs.dispatch.outputs.command == 'fallthrough') }}
-    runs-on: 'ubuntu-latest'
+    runs-on: adorsys-gis-runner
     permissions:
       contents: 'read'
       issues: 'write'

--- a/.github/workflows/qwen-invoke.yml
+++ b/.github/workflows/qwen-invoke.yml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   invoke:
-    runs-on: 'ubuntu-latest'
+    runs-on: adorsys-gis-runner
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -69,7 +69,7 @@ jobs:
               },
               "mcpServers": {
                 "github": {
-                  "command": "docker",
+                  "command": "podman",
                   "args": [
                     "run",
                     "-i",

--- a/.github/workflows/qwen-review.yml
+++ b/.github/workflows/qwen-review.yml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   review:
-    runs-on: 'ubuntu-latest'
+    runs-on: adorsys-gis-runner
     timeout-minutes: 7
     permissions:
       contents: 'read'
@@ -71,7 +71,7 @@ jobs:
               },
               "mcpServers": {
                 "github": {
-                  "command": "docker",
+                  "command": "podman",
                   "args": [
                     "run",
                     "-i",

--- a/.github/workflows/qwen-scheduled-triage.yml
+++ b/.github/workflows/qwen-scheduled-triage.yml
@@ -27,7 +27,7 @@ defaults:
 
 jobs:
   triage:
-    runs-on: 'ubuntu-latest'
+    runs-on: adorsys-gis-runner
     timeout-minutes: 7
     permissions:
       contents: 'read'
@@ -124,7 +124,7 @@ jobs:
           prompt: '/qwen-scheduled-triage'
 
   label:
-    runs-on: 'ubuntu-latest'
+    runs-on: adorsys-gis-runner
     needs:
       - 'triage'
     if: |-

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   triage:
-    runs-on: 'ubuntu-latest'
+    runs-on: adorsys-gis-runner
     timeout-minutes: 7
     outputs:
       available_labels: '${{ steps.get_labels.outputs.available_labels }}'
@@ -92,7 +92,7 @@ jobs:
           prompt: '/qwen-triage'
 
   label:
-    runs-on: 'ubuntu-latest'
+    runs-on: adorsys-gis-runner
     needs:
       - 'triage'
     if: |-

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,8 +11,11 @@ permissions:
 
 jobs:
   scan:
-    uses: ADORSYS-GIS/ai-ops/.github/workflows/security-gates.yml@v1.0.0
+    # v1.1.0 adds the `runs-on` input (ADORSYS-GIS/ai-ops#148) so the shared
+    # gitleaks + trivy gates run on our self-hosted pool like every other job.
+    uses: ADORSYS-GIS/ai-ops/.github/workflows/security-gates.yml@v1.1.0
     secrets: inherit
     with:
       trivy-scan-type: 'fs'
       trivy-target: '.'
+      runs-on: adorsys-gis-runner

--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   build:
     name: Build Storybook
-    runs-on: ubuntu-latest
+    runs-on: adorsys-gis-runner
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.0
@@ -37,8 +37,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build Storybook
-        run: pnpm --filter @lightbridge/ui build-storybook
+      - name: Build Storybook (turbo)
+        run: pnpm turbo run build-storybook
 
       - name: Set up GitHub Pages
         uses: actions/configure-pages@v5
@@ -51,7 +51,7 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: adorsys-gis-runner
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   test:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: adorsys-gis-runner
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ node_modules/
 packages/api-rest/openapi-ts-error-*.log
 .expo/
 dist/
+# Turborepo — local task logs + cache. MUST be ignored, otherwise turbo counts
+# its own run logs as task inputs and the cache never hits.
+.turbo/
 npm-debug.*
 *.jks
 *.p8

--- a/DOCKER_BUILD_SETUP.md
+++ b/DOCKER_BUILD_SETUP.md
@@ -1,6 +1,18 @@
 # Docker Build Configuration - Complete Setup
 
-This document explains the complete configuration for building the Expo app with pnpm in Docker.
+This document explains the complete configuration for building the Expo app with pnpm.
+
+> **Architecture update.** The web bundle is no longer built *inside* the Docker
+> image. CI (`docker-image.yml`, on `adorsys-gis-runner`) runs `pnpm install` +
+> `turbo run build:web` **on the runner** — producing `apps/self-service/dist`,
+> cached by the runner's Turbo cache — and then Buildah builds a **thin nginx
+> runtime image** that just `COPY`s that prebuilt `dist`. There is no multi-stage
+> build, no pnpm/BuildKit cache mount, and no Docker layer cache anymore.
+>
+> The Metro / Babel / `.npmrc` / i18n configuration below is **still relevant** —
+> it governs how `expo export` resolves the pnpm-symlinked monorepo, whether the
+> build runs on the runner or in a container. Only the "Dockerfile" and caching
+> parts have changed; see `docs/knowledge/ci-cd.md` for the current pipeline.
 
 ## Problem Summary
 
@@ -102,78 +114,37 @@ export { useTranslation } from 'react-i18next'; // Re-export for app usage
 
 **Monorepo best practice:** Workspace packages should re-export their dependencies so apps don't import transitive dependencies directly.
 
-### 5. `Dockerfile`
+### 5. `Dockerfile` (runtime-only, thin)
+
+The web bundle is built on the CI runner (`turbo run build:web`) **before** the
+image build; the Dockerfile is now a single runtime stage that just copies the
+prebuilt `apps/self-service/dist`. No build stage, no Node/pnpm, no cache mounts:
+
 ```dockerfile
-FROM --platform=$BUILDPLATFORM node:22-alpine AS build
-
-ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
-
-RUN corepack enable
-
-WORKDIR /app
-
-# Copy dependency files
-COPY pnpm-lock.yaml pnpm-workspace.yaml package.json .npmrc ./
-COPY apps/self-service/package.json apps/self-service/
-COPY packages/*/package.json packages/
-
-# Copy OpenAPI specs for codegen
-COPY openapi ./openapi
-COPY packages/api-rest/openapi-ts.config.ts packages/api-rest/
-
-# Fetch and install dependencies
-RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
-    pnpm fetch
-
-RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
-    pnpm install --offline --frozen-lockfile
-
-# Copy source files
-COPY . .
-
-# Build the web export
-RUN pnpm --dir apps/self-service exec expo export --platform web --output-dir dist
-
-# Runtime stage
-# Using Alpine 3.23 which has the latest security patches
 FROM nginx:1.30.0-alpine3.23-slim
 
-# Update Alpine packages to latest security patches
-RUN apk update && \
-    apk upgrade --no-cache && \
-    rm -rf /var/cache/apk/*
+RUN apk update && apk upgrade --no-cache && rm -rf /var/cache/apk/*
 
 WORKDIR /usr/share/nginx/html
-
 COPY .docker/nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY --chmod=755 .docker/nginx/entrypoint.sh /docker-entrypoint.d/40-runtime-config.sh
 
-COPY --from=build /app/apps/self-service/dist/ /usr/share/nginx/html/
-COPY --from=build /app/apps/self-service/example.config.json /usr/share/nginx/html/config.template.json
+# Prebuilt on the runner via turbo — NOT built here.
+COPY apps/self-service/dist/ /usr/share/nginx/html/
+COPY apps/self-service/example.config.json /usr/share/nginx/html/config.template.json
 
-# Set permissions for Kubernetes compatibility
-# Use group permissions so any UID in the root group (GID 0) can access files
-# This is the OpenShift/Kubernetes pattern for arbitrary UIDs
-RUN chgrp -R 0 /usr/share/nginx/html && \
-    chmod -R g=u /usr/share/nginx/html && \
-    chgrp -R 0 /var/cache/nginx && \
-    chmod -R g=u /var/cache/nginx && \
-    chgrp -R 0 /var/log/nginx && \
-    chmod -R g=u /var/log/nginx && \
-    chgrp -R 0 /etc/nginx/conf.d && \
-    chmod -R g=u /etc/nginx/conf.d && \
-    touch /var/run/nginx.pid && \
-    chgrp 0 /var/run/nginx.pid && \
-    chmod g=u /var/run/nginx.pid
+RUN chown -R 101:101 /usr/share/nginx/html /var/cache/nginx /var/log/nginx /etc/nginx/conf.d && \
+    chmod -R 755 /usr/share/nginx/html /var/cache/nginx /var/log/nginx && \
+    touch /var/run/nginx.pid && chown 101:101 /var/run/nginx.pid
 
-# Use a non-root user by default (can be overridden by K8s securityContext)
 USER 101
-
 EXPOSE 8080
-
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 CMD wget -q -O /dev/null http://127.0.0.1:8080/ || exit 1
 ```
+
+(The runtime `Dockerfile` in the repo is the source of truth — the above is
+abridged. Because `apps/self-service/dist` is `.gitignore`d, it is un-ignored in
+`.dockerignore` so Buildah can copy it from the build context.)
 
 **Key points:**
 - Uses pnpm with proper caching

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,44 +1,13 @@
-FROM --platform=$BUILDPLATFORM node:22-alpine AS build
-
-ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
-
-RUN corepack enable
-
-WORKDIR /app
-
-# Copy dependency files
-COPY pnpm-lock.yaml pnpm-workspace.yaml package.json .npmrc ./
-COPY apps/self-service/package.json apps/self-service/
-COPY packages/api-native/package.json packages/api-native/
-COPY packages/api-rest/package.json packages/api-rest/
-COPY packages/hooks/package.json packages/hooks/
-COPY packages/i18n/package.json packages/i18n/
-COPY packages/ui/package.json packages/ui/
-
-# Copy OpenAPI specs for codegen
-COPY openapi ./openapi
-COPY packages/api-rest/openapi-ts.config.ts packages/api-rest/
-
-# Fetch and install dependencies
-# Changed cache id from pnpm-store to pnpm-store-v2 to force re-fetch after lockfile override changes
-RUN --mount=type=cache,id=pnpm-store-v2,target=/pnpm/store \
-    pnpm fetch
-
-RUN --mount=type=cache,id=pnpm-store-v2,target=/pnpm/store \
-    pnpm install --offline --frozen-lockfile
-
-# Copy source files
-COPY . .
-
-# Build the web export
-RUN pnpm --dir apps/self-service exec expo export --platform web --output-dir dist
-
-# Runtime stage
-# Using Alpine 3.23 which has the latest security patches
+# Runtime-only image. The web bundle (apps/self-service/dist) is produced on the
+# CI runner by `turbo run build:web` and COPYed in here — there is NO build stage,
+# no Node/pnpm, and no BuildKit cache mounts. Layer/dependency caching is handled
+# by the runner's Turbo cache, not by the Docker build.
+#
+# Built and pushed with rootless Buildah on the adorsys-gis-runner (see
+# .github/workflows/docker-image.yml).
 FROM nginx:1.30.0-alpine3.23-slim
 
-# Update Alpine packages to latest security patches
+# Update Alpine packages to the latest security patches.
 RUN apk update && \
     apk upgrade --no-cache && \
     rm -rf /var/cache/apk/*
@@ -48,10 +17,11 @@ WORKDIR /usr/share/nginx/html
 COPY .docker/nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY --chmod=755 .docker/nginx/entrypoint.sh /docker-entrypoint.d/40-runtime-config.sh
 
-COPY --from=build /app/apps/self-service/dist/ /usr/share/nginx/html/
-COPY --from=build /app/apps/self-service/example.config.json /usr/share/nginx/html/config.template.json
+# Prebuilt static web export + the runtime-config template (rendered at startup).
+COPY apps/self-service/dist/ /usr/share/nginx/html/
+COPY apps/self-service/example.config.json /usr/share/nginx/html/config.template.json
 
-# Set ownership and permissions for nginx user (101:101)
+# Set ownership and permissions for the nginx user (101:101).
 RUN chown -R 101:101 /usr/share/nginx/html && \
     chmod -R 755 /usr/share/nginx/html && \
     chown -R 101:101 /var/cache/nginx && \

--- a/apps/self-service/package.json
+++ b/apps/self-service/package.json
@@ -13,6 +13,7 @@
     "start": "expo start",
     "prebuild": "expo prebuild",
     "web": "expo start --web",
+    "build:web": "expo export --platform web --output-dir dist",
     "test": "jest"
   },
   "dependencies": {

--- a/docs/knowledge/ci-cd.md
+++ b/docs/knowledge/ci-cd.md
@@ -6,29 +6,33 @@
 
 ## Pipeline Overview
 
-CI/CD is implemented with **GitHub Actions**. There are two categories of workflows:
+CI/CD is implemented with **GitHub Actions**. All Linux jobs run on the
+self-hosted **`adorsys-gis-runner`** pool (not GitHub-hosted `ubuntu-latest`).
+That runner bakes rootless **Buildah/Podman** (no Docker daemon / dind) and is
+integrated with a **Turbo remote cache**, so builds run through `turbo` and reuse
+cached outputs across runs. There are two categories of workflows:
 
 ### 1. Docker Image Build & Push (`docker-image.yml`)
 
-This is the primary delivery pipeline.
+This is the primary delivery pipeline. The web bundle is built **on the runner**
+via Turbo, then baked into a thin nginx image with Buildah — the image has no
+build stage, no Node/pnpm, and no Docker/BuildKit layer cache (caching lives in
+Turbo). Single-arch **`linux/amd64`** (every cluster node is amd64).
 
 ```
 Trigger: push to main / tagged branch / v* tag / workflow_dispatch
        │
-       ▼
-   Checkout code
+       ▼  (on adorsys-gis-runner)
+   Checkout → pnpm install (runs codegen) → turbo run build:web   # → apps/self-service/dist, Turbo-cached
        │
        ▼
-   Set up Docker Buildx (multi-platform)
+   Extract metadata (tags, labels) · buildah login to ghcr.io
        │
        ▼
-   Log in to GHCR (ghcr.io)
+   buildah build (amd64, no layer cache)  →  export tar  →  Trivy scan (HIGH/CRITICAL gate)
        │
        ▼
-   Extract metadata (tags, labels)
-       │
-       ▼
-   Build & push multi-platform image (linux/amd64, linux/arm64)
+   buildah push (all tags)
 ```
 
 ### 1b. Helm Chart Publish (`publish-charts-oci.yml`)
@@ -69,14 +73,16 @@ No required status checks are enforced at the workflow level (branch protection 
 
 ## Caching Strategy
 
-The Docker build workflow uses **GitHub Actions cache** for Docker layer caching:
+Caching is handled by **Turborepo**, not by the Docker build. `turbo run build:web`
+(and `build-storybook`) hash their inputs and restore outputs from the
+`adorsys-gis-runner`'s integrated **Turbo remote cache** — an unchanged input tree
+replays instantly (`>>> FULL TURBO`) instead of re-running `expo export`.
 
-```yaml
-cache-from: type=gha
-cache-to: type=gha,mode=max
-```
-
-This caches Docker build layers between runs. The pnpm dependency install step in the Dockerfile uses a `--mount=type=cache` (BuildKit cache mount) targeting `/pnpm/store` to cache the package store across builds.
+The Docker build itself is deliberately **uncached**: the old GHA layer cache
+(`cache-from/to: type=gha`) and the Dockerfile's BuildKit `--mount=type=cache`
+pnpm-store mount were both removed. Buildah builds a thin runtime image with no
+`--layers`/`--cache-from`. (Note: `.turbo/` must stay in `.gitignore` — otherwise
+turbo counts its own run logs as task inputs and never hits the cache.)
 
 ---
 
@@ -88,7 +94,8 @@ This caches Docker build layers between runs. The pnpm dependency install step i
   - `v*` — for version tags (semver)
   - `sha-<short>` — for every build (commit SHA)
   - `latest` — only on pushes to the default branch (`main`)
-- Images are built as **multi-platform** manifests (`linux/amd64`, `linux/arm64`)
+- Images are built **single-arch** (`linux/amd64`) — every cluster node is amd64
+- Built with rootless **Buildah**; a **Trivy** scan (HIGH/CRITICAL, `ignore-unfixed`) gates the push
 - **No SBOM or signing** is configured in the current workflows
 
 ---

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "android": "pnpm --filter self-service android",
     "ios": "pnpm --filter self-service ios",
     "web": "pnpm --filter self-service web",
+    "build": "turbo run build:web",
+    "build-storybook": "turbo run build-storybook",
     "lint": "eslint \"**/*.{js,jsx,ts,tsx}\" && prettier -c \"**/*.{js,jsx,ts,tsx,json,css,md}\"",
     "format": "eslint \"**/*.{js,jsx,ts,tsx}\" --fix && prettier \"**/*.{js,jsx,ts,tsx,json,css,md}\" --write",
     "test": "pnpm -r --if-present run test"
@@ -26,6 +28,7 @@
     "eslint-config-prettier": "^10.1.8",
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.7.4",
+    "turbo": "^2.5.0",
     "typescript": "~5.9.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       prettier-plugin-tailwindcss:
         specifier: ^0.7.4
         version: 0.7.4(prettier@3.8.3)
+      turbo:
+        specifier: ^2.5.0
+        version: 2.10.4
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -2434,6 +2437,36 @@ packages:
   '@tootallnate/once@2.0.1':
     resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
     engines: {node: '>= 10'}
+
+  '@turbo/darwin-64@2.10.4':
+    resolution: {integrity: sha512-m1MUEI4MJ69r5CwfMYxmHi0H0rrgiYCBOp0tgBZ9x/YVvOb5uu/lRIDyDwdtH054R2yWeQaIigUGu6aCX9f8cA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@turbo/darwin-arm64@2.10.4':
+    resolution: {integrity: sha512-VQ1Yxs5zkPT+2z7t1P4mvn6JmcKLkOCAsPuK9XbOvuVj0DlTlETfIXNisX0771v/vTWHOQqiwoGi+TtAUq8efw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@turbo/linux-64@2.10.4':
+    resolution: {integrity: sha512-IzV1QovmwX7mfGnVinmE++2IB8tbeo38weltiuH5zNqwCTBjLs/DytyRKx+bmnhHdXIq9SheR8p0Nip/LBUPHg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@turbo/linux-arm64@2.10.4':
+    resolution: {integrity: sha512-rfujSQkP5aYiRn0PgTM7F00WkJCP/bKDVZbOx3WmrZwa/vHA0bplhCl328kpX7VI9HH2vI90ISGwuSVgJgoqTw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@turbo/windows-64@2.10.4':
+    resolution: {integrity: sha512-NnspP7Wd5fa3Wwnqv9bKfhegqZzuHBgbPxdZU/idTLQcazx/vgKu95JlCx2YHY0hdvKCnPcARrDwM+KEUmaO7A==}
+    cpu: [x64]
+    os: [win32]
+
+  '@turbo/windows-arm64@2.10.4':
+    resolution: {integrity: sha512-Iv02YgOpaEShc2OkG7mgCJ2pEw1RUKiKbs0h8W5wAf4jZ5vpmraTEjuGTgHRuOORQnC1GN3KHo5WB+hu1abRMA==}
+    cpu: [arm64]
+    os: [win32]
 
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
@@ -6396,6 +6429,10 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  turbo@2.10.4:
+    resolution: {integrity: sha512-GQpduILaKjoaGljw097ScsSyKTtZSY7cZ3bJktzfTkPMyCf3ShKLuXK2IaOEN2Plziml+ArR7WJ1m+V4VbnaKQ==}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -9087,6 +9124,24 @@ snapshots:
       '@testing-library/dom': 10.4.1
 
   '@tootallnate/once@2.0.1': {}
+
+  '@turbo/darwin-64@2.10.4':
+    optional: true
+
+  '@turbo/darwin-arm64@2.10.4':
+    optional: true
+
+  '@turbo/linux-64@2.10.4':
+    optional: true
+
+  '@turbo/linux-arm64@2.10.4':
+    optional: true
+
+  '@turbo/windows-64@2.10.4':
+    optional: true
+
+  '@turbo/windows-arm64@2.10.4':
+    optional: true
 
   '@tybys/wasm-util@0.10.2':
     dependencies:
@@ -13699,6 +13754,15 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  turbo@2.10.4:
+    optionalDependencies:
+      '@turbo/darwin-64': 2.10.4
+      '@turbo/darwin-arm64': 2.10.4
+      '@turbo/linux-64': 2.10.4
+      '@turbo/linux-arm64': 2.10.4
+      '@turbo/windows-64': 2.10.4
+      '@turbo/windows-arm64': 2.10.4
 
   type-check@0.4.0:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "ui": "stream",
+  "tasks": {
+    "build:web": {
+      "dependsOn": ["^build:web"],
+      "outputs": ["dist/**"]
+    },
+    "build-storybook": {
+      "outputs": ["storybook-static/**"]
+    }
+  }
+}


### PR DESCRIPTION
## 1. Summary

This PR changes:

- **Runners** — every `ubuntu-latest` job moves to the self-hosted `adorsys-gis-runner`. `qwen-review`/`qwen-invoke` run the GitHub MCP server via `podman` instead of `docker` (the runner is daemonless).
- **Docker → Buildah** — `docker-image.yml` builds + pushes with rootless Buildah, single-arch `linux/amd64`, Trivy HIGH/CRITICAL gate preserved (scans an exported tar).
- **Turbo + no Docker cache** — introduces Turborepo; the web bundle builds on the runner via `turbo run build:web` (Turbo-cached) and the Dockerfile becomes a thin runtime image copying the prebuilt `dist`. Removed the GHA layer cache and the Dockerfile BuildKit pnpm-store mount.

It solves:

- #102

---

## 2. Intent

The intent of this PR is:

> Run CI on the self-hosted `adorsys-gis-runner` (daemonless Buildah/Podman, integrated Turbo remote cache) instead of GitHub-hosted `ubuntu-latest`, and shift build caching from the Docker layer/BuildKit cache to Turbo. The web bundle now builds on the runner (where the Turbo cache lives) and the image is a thin nginx runtime that just serves the prebuilt static export — smaller image, no build toolchain in the final image, and cache reuse via Turbo.

---

## 3. Scope

### In Scope

- All workflow `runs-on` → `adorsys-gis-runner`; `docker`→`podman` in the two qwen MCP configs.
- `docker-image.yml` rewrite (Buildah, amd64, Trivy-via-tar, no cache).
- Turborepo: `turbo.json`, `build:web`/`build-storybook` tasks, root `build` scripts, `storybook-pages.yml` via turbo.
- Thin `Dockerfile`; `.dockerignore` un-ignores `dist`; `.gitignore` adds `.turbo/`.
- Docs (`ci-cd.md`, `DOCKER_BUILD_SETUP.md`).

### Out of Scope

- ~~`governance.yml` runner~~ — **now included**: bumped the pinned SHA past v1.0.0 to the commit adding the `runs-on` input (PR #17) and pass `runs-on: adorsys-gis-runner`. (Takes effect after merge — `pull_request` runs the base branch's caller.)
- Multi-arch — dropped `linux/arm64` (every cluster node is amd64; confirmed via `kubectl get nodes`).
- SBOM / image signing (unchanged; still none).

---

## 4. Verification

I verified this change by:

- [x] Running manual tests

Commands run:

```bash
pnpm install --frozen-lockfile
pnpm turbo run build:web            # cold, then again for cache
python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"
```

Results:

```text
turbo run build:web → apps/self-service/dist (index.html, _expo/, assets/) — exit 0
re-run → "cache hit, replaying logs" / Cached: 1, Time 43ms >>> FULL TURBO; dist restored
all workflow YAML + turbo.json + package.json parse OK
Dockerfile COPY sources all present and not .dockerignore-excluded
```

Notes:
- The **Buildah build + Trivy scan + push** run only on `adorsys-gis-runner` (needs Buildah + `packages: write`), so they're exercised by this PR's CI, not locally (no Docker daemon here).
- Fixed a real Turbo footgun found during verification: `.turbo/` was not git-ignored, so turbo counted its own run logs as task inputs and never cached — adding `.turbo/` to `.gitignore` makes it `>>> FULL TURBO`.

---

## 5. Screenshots / Evidence

* Buildah pattern mirrored from `ADORSYS-GIS/webank-mobile` (`build-bff.yml`).
* Turbo pattern from `ADORSYS-GIS/lightbridge-code-intelligence`.

---

## 6. Risk Assessment

Risk level:

* [x] Medium

Potential risks:

* The `adorsys-gis-runner` must provide Buildah/Podman + Node/pnpm and be wired to the Turbo cache; if Buildah/podman is absent, the image job and the qwen MCP break.
* `trivy-action` scanning an exported tar (`input:`) instead of a daemon image — daemonless, but a behavior change worth a green-check confirmation.
* The qwen bots + `podman` MCP shell-out should be validated on the runner.

Mitigation:

* All heavy steps are exercised by this PR's own CI on the runner before merge — watch the checks.
* Rollback = revert; the previous `docker buildx` + `ubuntu-latest` flow is a single revert away.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Refactoring
* [x] Drafting documentation
* [x] Reviewing the diff

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

AI (Claude Code) mirrored the org's proven Buildah (`webank-mobile`) and Turbo (`lightbridge-code-intelligence`) patterns, ran the web build + Turbo cache locally to verify, and found/fixed the `.turbo` gitignore cache bug. Runner capabilities (Buildah/podman/Turbo-cache wiring) were taken as given per the request and will show green/red in CI.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Architecture
* [x] Security
* [x] Product intent