### PR TITLE
fix(ci): image build + chart publish on the daemonless runner

### DIFF
--- a/.github/workflows/publish-charts-oci.yml
+++ b/.github/workflows/publish-charts-oci.yml
@@ -57,7 +57,21 @@ jobs:
           version: v3.15.4
 
       - name: Set up yq
-        uses: mikefarah/yq@v4
+        # Install the yq binary directly instead of mikefarah/yq@v4, which is a
+        # Docker-container action — the daemonless adorsys-gis-runner has no Docker
+        # socket, so the container action can't run.
+        run: |
+          set -euo pipefail
+          if command -v yq >/dev/null 2>&1; then
+            echo "yq already present: $(yq --version)"
+            exit 0
+          fi
+          mkdir -p "$RUNNER_TEMP/bin"
+          curl -fsSL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
+            -o "$RUNNER_TEMP/bin/yq"
+          chmod +x "$RUNNER_TEMP/bin/yq"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/bin/yq" --version
 
       - name: Add upstream chart repos (for `helm dependency build`)
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,11 @@
 #
 # Built and pushed with rootless Buildah on the adorsys-gis-runner (see
 # .github/workflows/docker-image.yml).
-FROM nginx:1.30.0-alpine3.23-slim
+#
+# Fully-qualified (docker.io/library/…) so rootless Buildah resolves it without
+# `unqualified-search-registries` configured on the runner (a bare `nginx:…`
+# short-name fails there with "did not resolve to an alias").
+FROM docker.io/library/nginx:1.30.0-alpine3.23-slim
 
 # Update Alpine packages to the latest security patches.
 RUN apk update && \


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `Dockerfile`: fully-qualify the base image `FROM docker.io/library/nginx:1.30.0-alpine3.23-slim` (was the short-name `nginx:…`).
- `publish-charts-oci.yml`: install the `yq` binary in a shell step instead of the `mikefarah/yq@v4` Docker-container action.

It solves:

- Two regressions from the runner migration (#102), caught on the first `main` run of the merged workflows.

---

## 2. Intent

The intent of this PR is:

> Make the two workflows that broke on the daemonless `adorsys-gis-runner` actually pass. Rootless Buildah has no `unqualified-search-registries`, so `FROM nginx:…` failed with *"short-name did not resolve to an alias"* — a fully-qualified `docker.io/library/nginx` fixes it portably (no runner config needed). And `mikefarah/yq@v4` is a **Docker-container action**; with no Docker socket on the runner it can't be pulled — installing the yq binary directly avoids Docker entirely.

---

## 3. Scope

### In Scope

- The Dockerfile base-image qualification + the yq install step.

### Out of Scope

- **Gitleaks (Security Audit)** — red since `18db675a`, *before* this migration. It's a JS action that ran correctly on the runner (the `runs-on` input resolved fine); it fails for a pre-existing reason (a flagged string, likely in the skill docs added in that commit). Separate fix.
- Qwen bot workflows (podman-based; validate separately).

---

## 4. Verification

I verified this change by:

- [x] Checking logs (the failing run)
- [x] Running manual tests

Evidence (failing run, commit `0ff5b29`):

```text
docker-image → Build image (Buildah): STEP 1/12: FROM nginx:1.30.0-alpine3.23-slim
  Error: creating build container: short-name "nginx:…" did not resolve to an alias
  and no unqualified-search registries are defined  → exit 125
publish-charts-oci → Pull mikefarah/yq:4-githubaction: failed to connect to the docker
  API at unix:///var/run/docker.sock … no such file or directory  → exit 1
```

What *did* pass on the runner in that same run (so this is the last mile):
`turbo run build:web` ✅, `buildah login` ✅, `docker/metadata-action` ✅, and the
`aquasecurity/trivy-action` Trivy scan ✅ (in Security Audit). YAML validated;
grep confirms no other bare short-name `FROM` remains.

The buildah build itself is exercised by this PR's CI on the runner (no Docker daemon locally).

---

## 5. Screenshots / Evidence

* Failing run: `docker-image` + `publish-charts-oci` on `main@0ff5b29`.

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* `docker.io` anonymous pull rate limits could throttle the base-image pull (independent of this change).
* `yq` install uses the `latest` release binary (matches the previous floating `@v4`); pin a version if reproducibility is needed.

Mitigation:

* Both changes are the minimal fix for a hard failure; CI on this PR confirms green before merge.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Reviewing the diff

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

Diagnosed from the live failing run logs; fixes are the standard daemonless-Buildah remedies (fully-qualified base image, binary tool install over container actions).

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
