### PR TITLE
docs(knowledge): rewrite authz architecture docs for cratestack RPC migration

### DIFF
--- a/docs/knowledge/api-reference.md
+++ b/docs/knowledge/api-reference.md
@@ -46,7 +46,11 @@ Every call is `POST /rpc/{op_id}` — the op-id (a dotted string like `model.Acc
 `procedure.createApiKey`) is the dispatch key, carried in the URL path, not the HTTP verb or a
 REST-shaped path. There is no per-resource URL structure to document; instead, each op-id below
 takes a JSON (or CBOR, in prod) request body and returns the raw result object/array directly —
-no envelope wrapper. See `packages/authz-rpc/generated/sdk.ts` for the exact generated call sites.
+no envelope wrapper. The generated client (`packages/authz-rpc/generated/src/client.ts`) exposes
+this as a client-object API — `client.accounts`/`client.projects`/`client.apiKeys` (each with
+`list`/`get`/`update`/`delete`, plus `create` only where reachable — see below) and
+`client.procedures` (one method per procedure, e.g. `client.procedures.createApiKey({ args })`) —
+rather than free-standing functions.
 
 **Reachability is schema-driven, not uniform.** A model only gets a generic `create`/`update`/
 `delete`/`list`/`get` op-id if the schema declares a matching `@@allow("<verb>", ...)` for it — a

--- a/docs/knowledge/api-reference.md
+++ b/docs/knowledge/api-reference.md
@@ -48,8 +48,10 @@ REST-shaped path. There is no per-resource URL structure to document; instead, e
 takes a JSON (or CBOR, in prod) request body. `get`/`update`/`delete`/`create`/`procedure.*` return
 the raw result object directly — no envelope. **`list` is the one exception**: every model
 declares `@@paged` in the schema, so `model.<X>.list` returns a `Page<X>` envelope
-(`{ items: X[], pageInfo?: { limit, offset, hasNext, nextOffset, total } }`), not a bare array —
-callers must read `.items`. The generated client (`packages/authz-rpc/generated/src/client.ts`)
+(`{ items: X[], totalCount: number | null, pageInfo: { limit: number | null, offset: number | null,
+hasNextPage: boolean, hasPreviousPage: boolean } }` — this mirrors `cratestack-core::page::{Page,
+PageInfo}` field-for-field, not an independently-designed client type), not a bare array — callers
+must read `.items`. The generated client (`packages/authz-rpc/generated/src/client.ts`)
 exposes this as a client-object API — `client.accounts`/`client.projects`/`client.apiKeys` (each
 with `list`/`get`/`update`/`delete`, plus `create` only where reachable — see below) and
 `client.procedures` (one method per procedure, e.g. `client.procedures.createApiKey({ args })`) —

--- a/docs/knowledge/api-reference.md
+++ b/docs/knowledge/api-reference.md
@@ -1,22 +1,26 @@
 # API Reference — Converse-frontends
 
-> Source of truth: `openapi/api-key.backend.json` (v0.6.5), `openapi/usage.backend.yaml` (v0.6.6)
+> Source of truth: `packages/authz-rpc/schema/authz.cstack` (AuthZ API), `openapi/usage.backend.yaml` (v0.6.6, Usage API)
 > Full schema details: see `api-usage-backend.md` (usage API) and `auth-and-identity.md` (API key schemas)
 
 This document is a **complete endpoint index** for both LightBridge APIs consumed by the self-service frontend.
+The two APIs use different transports — AuthZ moved to cratestack RPC (ADR-0003 in `lightbridge-authz`),
+Usage stays plain REST/OpenAPI.
 
 ---
 
 ## Overview
 
-| API | Base URL (runtime config) | Content-Type | Version |
-|-----|--------------------------|--------------|---------|
-| LightBridge AuthZ API | `EXPO_PUBLIC_BACKEND_URL` | `application/json` | v0.6.5 |
-| LightBridge Usage API | `EXPO_PUBLIC_USAGE_URL` | `application/json` | v0.6.6 |
+| API                   | Base URL (runtime config) | Transport                 | Content-Type                                             |
+| --------------------- | ------------------------- | ------------------------- | -------------------------------------------------------- |
+| LightBridge AuthZ API | `EXPO_PUBLIC_BACKEND_URL` | RPC (`POST /rpc/{op_id}`) | `application/json` (dev/CI) or `application/cbor` (prod) |
+| LightBridge Usage API | `EXPO_PUBLIC_USAGE_URL`   | REST                      | `application/json`                                       |
 
 **Character encoding:** UTF-8
 
-**Versioning:** URL path (`/api/v1/`, `/usage/v1/`)
+**Versioning:** the AuthZ API has no URL-path version — its contract is the `authz.cstack` schema
+file itself (versioned via the file, not a URL segment). The Usage API keeps URL-path versioning
+(`/usage/v1/`).
 
 ---
 
@@ -24,8 +28,8 @@ This document is a **complete endpoint index** for both LightBridge APIs consume
 
 All endpoints require a Bearer JWT token issued by Keycloak:
 
-| Method | Header | Format |
-|--------|--------|--------|
+| Method             | Header          | Format                  |
+| ------------------ | --------------- | ----------------------- |
 | Bearer Token (JWT) | `Authorization` | `Bearer <access_token>` |
 
 ```http
@@ -38,89 +42,110 @@ Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...
 
 ## LightBridge AuthZ API Endpoints
 
+Every call is `POST /rpc/{op_id}` — the op-id (a dotted string like `model.Account.list` or
+`procedure.createApiKey`) is the dispatch key, carried in the URL path, not the HTTP verb or a
+REST-shaped path. There is no per-resource URL structure to document; instead, each op-id below
+takes a JSON (or CBOR, in prod) request body and returns the raw result object/array directly —
+no envelope wrapper. See `packages/authz-rpc/generated/sdk.ts` for the exact generated call sites.
+
+**Reachability is schema-driven, not uniform.** A model only gets a generic `create`/`update`/
+`delete`/`list`/`get` op-id if the schema declares a matching `@@allow("<verb>", ...)` for it — a
+missing `@@allow("create", ...)` means that verb doesn't exist at all (fail-closed by policy), and
+creation goes through a dedicated procedure instead. This is why `Account` and `ApiKey` have no
+generic `create`, but `Project` does.
+
+### Request envelope shapes
+
+| Op-id shape                          | Request body                                                                                                                                                                                                                           |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `model.<X>.list`                     | `{ limit?, offset?, fields?, include?, includeFields?, sort?, where?, or?, filters?: [{ key, value }] }` — every field optional; `filters` carries equality predicates (e.g. `{ key: "accountId", value: "acc_123" }` to scope a list) |
+| `model.<X>.get` / `model.<X>.delete` | `{ id }`                                                                                                                                                                                                                               |
+| `model.<X>.update`                   | `{ id, patch: {...} }` — `patch` is a partial `Update<X>Input`                                                                                                                                                                         |
+| `model.<X>.create`                   | the `Create<X>Input` struct directly (no wrapper)                                                                                                                                                                                      |
+| `procedure.<name>`                   | `{ args: {...} }`                                                                                                                                                                                                                      |
+
 ### Accounts
 
-| Method | Path | Operation ID | Description |
-|--------|------|-------------|-------------|
-| `GET` | `/api/v1/accounts` | `list_accounts` | List accounts (paginated: `offset`, `limit` query params required) |
-| `POST` | `/api/v1/accounts` | `create_account` | Create a new account |
-| `GET` | `/api/v1/accounts/{account_id}` | `get_account` | Get account by ID |
-| `PATCH` | `/api/v1/accounts/{account_id}` | `update_account` | Update account fields |
-| `DELETE` | `/api/v1/accounts/{account_id}` | `delete_account` | Delete account (returns 204 No Content) |
-
-#### `GET /api/v1/accounts` — Query Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `offset` | `integer` (int32, ≥ 0) | **Yes** | Pagination offset |
-| `limit` | `integer` (int32, ≥ 0) | **Yes** | Page size |
+| Op-id                                                          | Description                                                                                                                                                                                                                                                                                     |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `model.Account.list`                                           | List accounts the caller is a member of (list input above; no explicit account-scoping filter needed — membership already scopes the result)                                                                                                                                                    |
+| `model.Account.get`                                            | Get account by ID (`{ id }`)                                                                                                                                                                                                                                                                    |
+| `model.Account.update`                                         | Update account fields (`{ id, patch: UpdateAccountInput }`)                                                                                                                                                                                                                                     |
+| `model.Account.delete`                                         | Delete account                                                                                                                                                                                                                                                                                  |
+| `procedure.createAccount`                                      | Create an account — **the only way to create one.** There is no `model.Account.create`: the generic verb would insert only the `accounts` row without seeding the creator's membership, locking them out of every membership-scoped policy check. `createAccount` does both in one transaction. |
+| `procedure.disableAccount` / `procedure.enableAccount`         | Suspend/restore an account (`{ args: { accountId } }`)                                                                                                                                                                                                                                          |
+| `procedure.addAccountMember` / `procedure.removeAccountMember` | Manage membership (`{ args: { accountId, subject } }`)                                                                                                                                                                                                                                          |
 
 #### `Account` Response Schema
 
-| Field | Type | Nullable | Description |
-|-------|------|----------|-------------|
-| `id` | `string` | No | Account identifier |
-| `billing_identity` | `string` | No | Billing reference |
-| `created_at` | `string` (date-time) | No | Creation timestamp |
-| `updated_at` | `string` (date-time) | No | Last update timestamp |
-| `owners_admins` | `string[]` | **Yes** | List of owner/admin user IDs |
+| Field             | Type                 | Description                 |
+| ----------------- | -------------------- | --------------------------- |
+| `id`              | `string`             | Account identifier          |
+| `billingIdentity` | `string`             | Billing reference           |
+| `status`          | `string`             | `"active"` or `"suspended"` |
+| `createdAt`       | `string` (date-time) | Creation timestamp          |
+| `updatedAt`       | `string` (date-time) | Last update timestamp       |
 
 ```json
 {
   "id": "acc_abc123",
-  "billing_identity": "billing-ref-001",
-  "created_at": "2025-01-15T10:00:00Z",
-  "updated_at": "2025-03-01T08:30:00Z",
-  "owners_admins": ["user_xyz789"]
+  "billingIdentity": "billing-ref-001",
+  "status": "active",
+  "createdAt": "2025-01-15T10:00:00Z",
+  "updatedAt": "2025-03-01T08:30:00Z"
 }
 ```
+
+Note: unlike the pre-migration REST response, there is **no `owners_admins` field** — the schema
+doesn't expose a members list on `Account` at all (`AccountMembership` is read-self-only, with no
+listing op-id). See the account-settings members UI for the resulting known gap.
 
 ---
 
 ### Projects
 
-| Method | Path | Operation ID | Description |
-|--------|------|-------------|-------------|
-| `GET` | `/api/v1/accounts/{account_id}/projects` | `list_projects` | List projects for an account (paginated) |
-| `POST` | `/api/v1/accounts/{account_id}/projects` | `create_project` | Create a project under an account |
-| `GET` | `/api/v1/projects/{project_id}` | `get_project` | Get project by ID |
-| `PATCH` | `/api/v1/projects/{project_id}` | `update_project` | Update project fields |
-| `DELETE` | `/api/v1/projects/{project_id}` | `delete_project` | Delete project (returns 204 No Content) |
+| Op-id                                                  | Description                                                                                                                                                                         |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `model.Project.list`                                   | List projects (scope to an account via `filters: [{ key: "accountId", value }]`)                                                                                                    |
+| `model.Project.get`                                    | Get project by ID                                                                                                                                                                   |
+| `model.Project.create`                                 | Create a project — reachable directly (unlike Account/ApiKey). The **caller generates the id** (`cuid2`, client-side) and must supply `defaultLimits` (required, even if just `{}`) |
+| `model.Project.update`                                 | Update project fields                                                                                                                                                               |
+| `model.Project.delete`                                 | Delete project                                                                                                                                                                      |
+| `procedure.disableProject` / `procedure.enableProject` | Suspend/restore a project (`{ args: { projectId } }`)                                                                                                                               |
 
 #### `Project` Response Schema
 
-| Field | Type | Nullable | Description |
-|-------|------|----------|-------------|
-| `id` | `string` | No | Project identifier |
-| `account_id` | `string` | No | Parent account ID |
-| `name` | `string` | No | Project name |
-| `billing_plan` | `string` | No | Billing plan identifier |
-| `created_at` | `string` (date-time) | No | Creation timestamp |
-| `updated_at` | `string` (date-time) | No | Last update timestamp |
-| `allowed_models` | `string[] \| null` | **Yes** | Allowlist of model names (null = all models allowed) |
-| `default_limits` | `DefaultLimits \| null` | **Yes** | Default rate limits for this project |
+| Field           | Type                     | Nullable | Description                                                                                                               |
+| --------------- | ------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `id`            | `string`                 | No       | Project identifier                                                                                                        |
+| `accountId`     | `string`                 | No       | Parent account ID                                                                                                         |
+| `name`          | `string`                 | No       | Project name                                                                                                              |
+| `billingPlan`   | `string`                 | No       | Billing plan identifier                                                                                                   |
+| `status`        | `string`                 | No       | `"active"` or `"suspended"`                                                                                               |
+| `createdAt`     | `string` (date-time)     | No       | Creation timestamp                                                                                                        |
+| `updatedAt`     | `string` (date-time)     | No       | Last update timestamp                                                                                                     |
+| `allowedModels` | `JsonValue \| undefined` | **Yes**  | Allowlist of model names (absent = all models allowed)                                                                    |
+| `defaultLimits` | `JsonValue`              | No       | Default rate limits for this project (opaque JSON blob, e.g. `{ requestsPerSecond, requestsPerDay, concurrentRequests }`) |
 
-#### `DefaultLimits` Schema
-
-| Field | Type | Nullable | Description |
-|-------|------|----------|-------------|
-| `concurrent_requests` | `integer \| null` | **Yes** | Max concurrent requests |
-| `requests_per_day` | `integer \| null` | **Yes** | Max requests per day |
-| `requests_per_second` | `integer \| null` | **Yes** | Max requests per second |
+`allowedModels`/`defaultLimits` are cratestack `Json` columns: on the wire they're externally
+tagged (`{}` → `{"Map": {}}`, `["x"]` → `{"List": [{"String": "x"}]}`), but
+`packages/authz-rpc`'s `tagValue`/`untagValue` (`src/value.ts`) convert transparently at the SDK
+boundary — hooks/views never see the tagged form, just plain JS values typed `JsonValue`.
 
 ```json
 {
   "id": "proj_def456",
-  "account_id": "acc_abc123",
+  "accountId": "acc_abc123",
   "name": "My AI Project",
-  "billing_plan": "standard",
-  "created_at": "2025-02-01T09:00:00Z",
-  "updated_at": "2025-03-10T12:00:00Z",
-  "allowed_models": ["gpt-4o", "claude-3-5-sonnet"],
-  "default_limits": {
-    "concurrent_requests": 10,
-    "requests_per_day": 1000,
-    "requests_per_second": 5
+  "billingPlan": "standard",
+  "status": "active",
+  "createdAt": "2025-02-01T09:00:00Z",
+  "updatedAt": "2025-03-10T12:00:00Z",
+  "allowedModels": ["gpt-4o", "claude-3-5-sonnet"],
+  "defaultLimits": {
+    "concurrentRequests": 10,
+    "requestsPerDay": 1000,
+    "requestsPerSecond": 5
   }
 }
 ```
@@ -129,76 +154,74 @@ Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...
 
 ### API Keys
 
-| Method | Path | Operation ID | Description |
-|--------|------|-------------|-------------|
-| `GET` | `/api/v1/projects/{project_id}/api-keys` | `list_api_keys` | List API keys for a project (paginated) |
-| `POST` | `/api/v1/projects/{project_id}/api-keys` | `create_api_key` | Create a new API key — returns secret once |
-| `GET` | `/api/v1/api-keys/{key_id}` | `get_api_key` | Get API key metadata by ID |
-| `PATCH` | `/api/v1/api-keys/{key_id}` | `update_api_key` | Update API key name or expiry |
-| `DELETE` | `/api/v1/api-keys/{key_id}` | `delete_api_key` | Delete API key (returns 204 No Content) |
-| `POST` | `/api/v1/api-keys/{key_id}/revoke` | `revoke_api_key` | Revoke API key (sets status to `revoked`) |
-| `POST` | `/api/v1/api-keys/{key_id}/rotate` | `rotate_api_key` | Rotate API key — returns new secret once |
+| Op-id                    | Description                                                                                                                                                                                                                                                                     |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `model.ApiKey.list`      | List API keys (scope to a project via `filters: [{ key: "projectId", value }]`)                                                                                                                                                                                                 |
+| `model.ApiKey.get`       | Get API key metadata by ID                                                                                                                                                                                                                                                      |
+| `model.ApiKey.update`    | Update **only** `name`/`expiresAt` — every other field is `@readonly` (schema-enforced)                                                                                                                                                                                         |
+| `model.ApiKey.delete`    | Soft-delete (sets `deletedAt`, `@@soft_delete` in the schema — every generated read excludes soft-deleted rows automatically)                                                                                                                                                   |
+| `procedure.createApiKey` | Create a new API key — returns the secret once. No `model.ApiKey.create`: the server must generate the id, hash the secret, and validate the billing plan, none of which a caller may supply directly                                                                           |
+| `procedure.revokeApiKey` | Revoke (`{ args: { keyId } }`) — sets `status: "revoked"`                                                                                                                                                                                                                       |
+| `procedure.rotateApiKey` | Rotate — returns a new secret. **Capability change from the pre-migration REST API**: the old `RotateApiKey` body accepted optional `name`/`expiresAt`/`gracePeriodSeconds` overrides; the new `RotateApiKeyInput` is just `{ keyId }` — no override fields exist in the schema |
 
-#### `POST /api/v1/projects/{project_id}/api-keys` Request Body (`CreateApiKey`)
+#### `procedure.createApiKey` Request (`CreateApiKeyInput`)
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `name` | `string` | **Yes** | Human-readable label for the key |
-| `expires_at` | `string \| null` (date-time) | No | Optional expiry timestamp |
+| Field         | Type                              | Required | Description                          |
+| ------------- | --------------------------------- | -------- | ------------------------------------ |
+| `projectId`   | `string`                          | **Yes**  | Project the key belongs to           |
+| `name`        | `string`                          | **Yes**  | Human-readable label for the key     |
+| `expiresAt`   | `string \| undefined` (date-time) | No       | Optional expiry timestamp            |
+| `billingPlan` | `string`                          | **Yes**  | Billing plan to create the key under |
 
 #### `ApiKeySecret` Response (creation and rotation only)
 
 > **The `secret` field is returned ONCE and never again. Display it immediately to the user.**
 
+Unlike the pre-migration REST response, this is **flat** — not nested under an `api_key` key (see
+`auth-and-identity.md` for why):
+
 ```json
 {
-  "api_key": {
-    "id": "key_ghi789",
-    "project_id": "proj_def456",
-    "name": "My App Key",
-    "key_prefix": "lb_ghi789...",
-    "status": "active",
-    "created_at": "2025-03-30T10:00:00Z",
-    "expires_at": null,
-    "last_used_at": null,
-    "last_ip": null,
-    "revoked_at": null
-  },
-  "secret": "lb_ghi789fullsecretstringshownonce"
+  "id": "key_ghi789",
+  "projectId": "proj_def456",
+  "name": "My App Key",
+  "keyPrefix": "lb_ghi789...",
+  "status": "active",
+  "billingPlan": "standard",
+  "createdAt": "2025-03-30T10:00:00Z",
+  "updatedAt": "2025-03-30T10:00:00Z",
+  "secret": "lb_ghi789fullsecretstringshownonce",
+  "oauth2Url": null
 }
 ```
 
 #### `ApiKey` Schema (all other operations)
 
-| Field | Type | Nullable | Description |
-|-------|------|----------|-------------|
-| `id` | `string` | No | Key identifier |
-| `project_id` | `string` | No | Owning project ID |
-| `name` | `string` | No | Human-readable label |
-| `key_prefix` | `string` | No | Visible prefix of the secret |
-| `status` | `ApiKeyStatus` | No | `"active"` or `"revoked"` |
-| `created_at` | `string` (date-time) | No | Creation timestamp |
-| `expires_at` | `string \| null` (date-time) | **Yes** | Expiry timestamp |
-| `last_used_at` | `string \| null` (date-time) | **Yes** | Last time key was used |
-| `last_ip` | `string \| null` | **Yes** | IP address of last caller |
-| `revoked_at` | `string \| null` (date-time) | **Yes** | Revocation timestamp |
+| Field         | Type                              | Nullable | Description                            |
+| ------------- | --------------------------------- | -------- | -------------------------------------- |
+| `id`          | `string`                          | No       | Key identifier                         |
+| `projectId`   | `string`                          | No       | Owning project ID                      |
+| `name`        | `string`                          | No       | Human-readable label                   |
+| `keyPrefix`   | `string`                          | No       | Visible prefix of the secret           |
+| `status`      | `string`                          | No       | `"active"` or `"revoked"`              |
+| `billingPlan` | `string`                          | No       | Billing plan the key was created under |
+| `createdAt`   | `string` (date-time)              | No       | Creation timestamp                     |
+| `updatedAt`   | `string` (date-time)              | No       | Last update timestamp                  |
+| `expiresAt`   | `string \| undefined` (date-time) | **Yes**  | Expiry timestamp                       |
+| `lastUsedAt`  | `string \| undefined` (date-time) | **Yes**  | Last time key was used                 |
+| `lastIp`      | `string \| undefined`             | **Yes**  | IP address of last caller              |
+| `revokedAt`   | `string \| undefined` (date-time) | **Yes**  | Revocation timestamp                   |
+| `deletedAt`   | `string \| undefined` (date-time) | **Yes**  | Soft-delete timestamp                  |
 
-#### `POST /api/v1/api-keys/{key_id}/rotate` Request Body (`RotateApiKey`)
-
-All fields are optional:
-
-| Field | Type | Nullable | Description |
-|-------|------|----------|-------------|
-| `name` | `string \| null` | **Yes** | New name for the rotated key |
-| `expires_at` | `string \| null` (date-time) | **Yes** | New expiry for the rotated key |
-| `grace_period_seconds` | `integer \| null` (int64) | **Yes** | Seconds the old key remains valid after rotation |
+`keyHash` exists in the schema but is `@server_only` — it's never emitted on the wire and has no
+place in this table at all, on any operation.
 
 ---
 
 ## LightBridge Usage API Endpoints
 
-| Method | Path | Operation ID | Description |
-|--------|------|-------------|-------------|
+| Method | Path                    | Operation ID  | Description                  |
+| ------ | ----------------------- | ------------- | ---------------------------- |
 | `POST` | `/usage/v1/usage/query` | `query_usage` | Query time-series usage data |
 
 For the full request/response schema, worked examples, and enum definitions, see **`api-usage-backend.md`**.
@@ -207,8 +230,29 @@ For the full request/response schema, worked examples, and enum definitions, see
 
 ## Error Codes
 
-### AuthZ API (400 responses)
-The AuthZ API does not define a structured error response schema in `api-key.backend.json`. Non-2xx responses should be handled as generic HTTP errors.
+### AuthZ API
+
+Two distinct error body shapes exist, depending on which layer rejects the request
+(`packages/authz-rpc/src/transport.ts` handles both):
+
+1. **The app's own RBAC gate** (runs before the RPC dispatcher, denies unmapped/policy-forbidden
+   op-ids — e.g. `model.Account.create`, `model.ApiKey.create`, `/rpc/batch`, all denied
+   unconditionally):
+   ```json
+   { "error": "string describing why the call was denied" }
+   ```
+2. **cratestack's own `RpcErrorBody`** (dispatcher-level errors — bad input, not-found, handler
+   errors):
+   ```json
+   { "code": "not_found", "message": "string", "details": null }
+   ```
+
+| HTTP Status | Meaning                                                                           |
+| ----------- | --------------------------------------------------------------------------------- |
+| `400`       | Invalid argument — malformed op-id body                                           |
+| `401`       | Missing or invalid Bearer token                                                   |
+| `403`       | Authenticated but not authorized (RBAC gate, or a schema `@@allow` policy denial) |
+| `404`       | Resource not found (account, project, or API key does not exist)                  |
 
 ### Usage API (400 responses)
 
@@ -218,10 +262,10 @@ The AuthZ API does not define a structured error response schema in `api-key.bac
 }
 ```
 
-| HTTP Status | Meaning |
-|-------------|---------|
-| `400` | Validation error — `error` field contains a description |
-| `401` | Missing or invalid Bearer token |
-| `403` | Authenticated but not authorized for the requested resource |
-| `404` | Resource not found (account, project, or API key does not exist) |
-| `204` | Success — no body (DELETE operations) |
+| HTTP Status | Meaning                                                          |
+| ----------- | ---------------------------------------------------------------- |
+| `400`       | Validation error — `error` field contains a description          |
+| `401`       | Missing or invalid Bearer token                                  |
+| `403`       | Authenticated but not authorized for the requested resource      |
+| `404`       | Resource not found (account, project, or API key does not exist) |
+| `204`       | Success — no body (DELETE operations)                            |

--- a/docs/knowledge/api-reference.md
+++ b/docs/knowledge/api-reference.md
@@ -45,10 +45,13 @@ Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...
 Every call is `POST /rpc/{op_id}` — the op-id (a dotted string like `model.Account.list` or
 `procedure.createApiKey`) is the dispatch key, carried in the URL path, not the HTTP verb or a
 REST-shaped path. There is no per-resource URL structure to document; instead, each op-id below
-takes a JSON (or CBOR, in prod) request body and returns the raw result object/array directly —
-no envelope wrapper. The generated client (`packages/authz-rpc/generated/src/client.ts`) exposes
-this as a client-object API — `client.accounts`/`client.projects`/`client.apiKeys` (each with
-`list`/`get`/`update`/`delete`, plus `create` only where reachable — see below) and
+takes a JSON (or CBOR, in prod) request body. `get`/`update`/`delete`/`create`/`procedure.*` return
+the raw result object directly — no envelope. **`list` is the one exception**: every model
+declares `@@paged` in the schema, so `model.<X>.list` returns a `Page<X>` envelope
+(`{ items: X[], pageInfo?: { limit, offset, hasNext, nextOffset, total } }`), not a bare array —
+callers must read `.items`. The generated client (`packages/authz-rpc/generated/src/client.ts`)
+exposes this as a client-object API — `client.accounts`/`client.projects`/`client.apiKeys` (each
+with `list`/`get`/`update`/`delete`, plus `create` only where reachable — see below) and
 `client.procedures` (one method per procedure, e.g. `client.procedures.createApiKey({ args })`) —
 rather than free-standing functions.
 

--- a/docs/knowledge/architecture-conventions.md
+++ b/docs/knowledge/architecture-conventions.md
@@ -31,9 +31,11 @@ converse-frontends/
 
 The AuthZ API (accounts/projects/api-keys) has no OpenAPI spec — it's schema-first cratestack RPC.
 Its source of truth is `packages/authz-rpc/schema/authz.cstack` (copied from the backend repo),
-and `packages/authz-rpc/codegen/generate.mjs` turns it into the generated client under
-`packages/authz-rpc/generated/` (gitignored, regenerated via `pnpm --filter @lightbridge/authz-rpc
-codegen`, wired into the workspace `codegen:all`/`postinstall`).
+turned into the generated client under `packages/authz-rpc/generated/` by the official
+`cratestack generate-typescript` CLI (`cratestack-cli`, a Rust binary — not an npm dependency).
+Regeneration is a manual local step (`pnpm --filter @lightbridge/authz-rpc codegen:cratestack`,
+committed to git afterward) — deliberately **not** wired into `codegen:all`/`postinstall`, since
+the CI runner has no Rust toolchain to run the CLI with.
 
 **Rule:** Never place application-specific business logic in `packages/`. Packages export reusable, app-agnostic code only.
 
@@ -69,7 +71,7 @@ packages/api-rest/            → generated HTTP client (OpenAPI)
 app/api-keys/new.tsx                → renders <ApiKeyCreateScreen />
 screens/api-key-create-screen.tsx   → renders views, assembles state
 views/api-key-create-view.tsx       → calls hooks, renders UI
-packages/hooks/src/api-keys.ts      → calls createApiKey()
+packages/hooks/src/api-keys.ts      → calls client.procedures.createApiKey({ args })
 packages/authz-rpc/                 → generated RPC client (POST /rpc/procedure.createApiKey)
 ```
 

--- a/docs/knowledge/architecture-conventions.md
+++ b/docs/knowledge/architecture-conventions.md
@@ -16,17 +16,24 @@ converse-frontends/
 ├── apps/             # Deployable applications
 │   └── self-service/ # The LightBridge self-service web/mobile app
 ├── packages/         # Shared libraries consumed by apps
-│   ├── api-rest/     # Generated API client (do not hand-edit)
+│   ├── authz-rpc/    # Generated cratestack RPC client for accounts/projects/api-keys
+│   │                 # (do not hand-edit packages/authz-rpc/generated/ — codegen output)
+│   ├── api-rest/     # Generated REST client for the Usage API only (do not hand-edit)
 │   ├── api-native/   # Native API client utilities
 │   ├── hooks/        # Shared React hooks (auth, usage, projects, etc.)
 │   ├── i18n/         # Internationalisation resources
 │   └── ui/           # Shared design-system components
-├── openapi/          # OpenAPI specs (source of truth for backend APIs)
-│   ├── api-key.backend.json
+├── openapi/          # OpenAPI spec for the Usage API only
 │   └── usage.backend.yaml
 └── docs/
     └── knowledge/    # Agent-readable knowledge base (this directory)
 ```
+
+The AuthZ API (accounts/projects/api-keys) has no OpenAPI spec — it's schema-first cratestack RPC.
+Its source of truth is `packages/authz-rpc/schema/authz.cstack` (copied from the backend repo),
+and `packages/authz-rpc/codegen/generate.mjs` turns it into the generated client under
+`packages/authz-rpc/generated/` (gitignored, regenerated via `pnpm --filter @lightbridge/authz-rpc
+codegen`, wired into the workspace `codegen:all`/`postinstall`).
 
 **Rule:** Never place application-specific business logic in `packages/`. Packages export reusable, app-agnostic code only.
 
@@ -36,23 +43,34 @@ converse-frontends/
 
 Within `apps/self-service/src/`, follow this strict layering:
 
-| Layer | Directory | Responsibility |
-|-------|-----------|---------------|
-| **Routes** | `src/app/` | Expo Router file-based routes. Thin — only renders the corresponding Screen. |
-| **Screens** | `src/screens/` | Assembles Views. May select which View to show but contains no business logic. |
-| **Views** | `src/views/` | Presentational components. Calls hooks for data; renders UI. Contains layout logic. |
-| **Hooks** | `packages/hooks/` | All data fetching, state management, and business logic. No JSX. |
-| **API Client** | `packages/api-rest/` | Auto-generated from OpenAPI specs. Never edit by hand. |
+| Layer          | Directory                                                                        | Responsibility                                                                                                                    |
+| -------------- | -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| **Routes**     | `src/app/`                                                                       | Expo Router file-based routes. Thin — only renders the corresponding Screen.                                                      |
+| **Screens**    | `src/screens/`                                                                   | Assembles Views. May select which View to show but contains no business logic.                                                    |
+| **Views**      | `src/views/`                                                                     | Presentational components. Calls hooks for data; renders UI. Contains layout logic.                                               |
+| **Hooks**      | `packages/hooks/`                                                                | All data fetching, state management, and business logic. No JSX.                                                                  |
+| **API Client** | `packages/authz-rpc/` (accounts/projects/api-keys), `packages/api-rest/` (usage) | Auto-generated. Never edit by hand — `packages/authz-rpc/generated/` and `packages/api-rest/src/client/` are both codegen output. |
 
 **Dependency direction:** Routes → Screens → Views → Hooks → API Client
 
-**Example chain for the Usage feature:**
+**Example chain for the Usage feature (REST):**
+
 ```
 app/(tabs)/usage.tsx          → renders <UsageScreen />
 screens/usage-screen.tsx      → renders <UsageView />
 views/usage-view.tsx          → calls hooks, renders UI
-packages/hooks/src/usage.ts   → calls usageBackendQueryUsage()
-packages/api-rest/            → generated HTTP client
+packages/hooks/src/usage.ts   → calls queryUsage()
+packages/api-rest/            → generated HTTP client (OpenAPI)
+```
+
+**Example chain for the API Keys feature (cratestack RPC):**
+
+```
+app/api-keys/new.tsx                → renders <ApiKeyCreateScreen />
+screens/api-key-create-screen.tsx   → renders views, assembles state
+views/api-key-create-view.tsx       → calls hooks, renders UI
+packages/hooks/src/api-keys.ts      → calls createApiKey()
+packages/authz-rpc/                 → generated RPC client (POST /rpc/procedure.createApiKey)
 ```
 
 ---
@@ -88,14 +106,14 @@ const { t } = useTranslation();
 
 ## Naming Conventions
 
-| Subject | Convention | Example |
-|---------|-----------|---------|
-| Files (modules, components) | `kebab-case` | `usage-view.tsx`, `auth-storage.ts` |
-| Variables / functions | `camelCase` | `useQueryUsage`, `loadStoredSession` |
-| Types / Interfaces / Classes | `PascalCase` | `AuthSession`, `UsageQueryParams` |
-| True constants | `SCREAMING_SNAKE_CASE` | `STORAGE_KEY`, `WEB_DB_NAME` |
-| Interface names | No `I` prefix | `UserService`, **not** `IUserService` |
-| Boolean variables | `is`, `has`, `should`, `can` prefix | `isAuthenticated`, `isLoading` |
+| Subject                      | Convention                          | Example                               |
+| ---------------------------- | ----------------------------------- | ------------------------------------- |
+| Files (modules, components)  | `kebab-case`                        | `usage-view.tsx`, `auth-storage.ts`   |
+| Variables / functions        | `camelCase`                         | `useQueryUsage`, `loadStoredSession`  |
+| Types / Interfaces / Classes | `PascalCase`                        | `AuthSession`, `UsageQueryParams`     |
+| True constants               | `SCREAMING_SNAKE_CASE`              | `STORAGE_KEY`, `WEB_DB_NAME`          |
+| Interface names              | No `I` prefix                       | `UserService`, **not** `IUserService` |
+| Boolean variables            | `is`, `has`, `should`, `can` prefix | `isAuthenticated`, `isLoading`        |
 
 **Do not use `_` to denote private members.** Use native JS private fields (`#`) in classes.
 
@@ -160,6 +178,7 @@ export function UsageView() {
 ```
 
 The data-fetching hook (`useQueryUsage` in `packages/hooks/src/usage.ts`) **is** fully implemented and functional, but the view has not yet been wired to display the data. The hook:
+
 - Defaults to `scope = "project"`, last 30 days, `bucket = "1 day"`
 - Only fires when a current project is selected and the user is authenticated
 - Stores results reactively in `usageCollection` (TanStack DB live store)

--- a/docs/knowledge/architecture-conventions.md
+++ b/docs/knowledge/architecture-conventions.md
@@ -33,9 +33,10 @@ The AuthZ API (accounts/projects/api-keys) has no OpenAPI spec — it's schema-f
 Its source of truth is `packages/authz-rpc/schema/authz.cstack` (copied from the backend repo),
 turned into the generated client under `packages/authz-rpc/generated/` by the official
 `cratestack generate-typescript` CLI (`cratestack-cli`, a Rust binary — not an npm dependency).
-Regeneration is a manual local step (`pnpm --filter @lightbridge/authz-rpc codegen:cratestack`,
-committed to git afterward) — deliberately **not** wired into `codegen:all`/`postinstall`, since
-the CI runner has no Rust toolchain to run the CLI with.
+`generated/` is gitignored, same as every other package's codegen output (e.g. `api-rest`'s
+`src/client/`) — it's a build artifact, not source. Regenerate it locally with
+`pnpm --filter @lightbridge/authz-rpc codegen:cratestack`; CI (`test.yml`, `docker-image.yml`)
+installs a cached `cratestack-cli` and runs the same command before tests/build.
 
 **Rule:** Never place application-specific business logic in `packages/`. Packages export reusable, app-agnostic code only.
 

--- a/docs/knowledge/architecture.md
+++ b/docs/knowledge/architecture.md
@@ -102,11 +102,13 @@ LightBridge Backend
 ### API key management flow
 
 1. Authenticated user navigates to API Keys tab
-2. `useQuery` hook calls `listApiKeys()` (`packages/authz-rpc`), which dispatches
-   `POST /rpc/model.ApiKey.list` with `{ limit, offset, filters: [{ key: "projectId", value }] }`
-3. User creates key → `createApiKey()` dispatches `POST /rpc/procedure.createApiKey` with
-   `{ args: { projectId, name, expiresAt?, billingPlan } }` — the server generates the id, hashes
-   the secret, and validates the billing plan; the client never constructs these itself
+2. `useQuery` hook calls `client.apiKeys.list(...)` (`packages/authz-rpc`, generated client
+   instance), which dispatches `POST /rpc/model.ApiKey.list` with
+   `{ limit, offset, filters: [{ key: "projectId", value }] }`
+3. User creates key → `client.procedures.createApiKey({ args })` dispatches
+   `POST /rpc/procedure.createApiKey` with `{ args: { projectId, name, expiresAt?, billingPlan } }`
+   — the server generates the id, hashes the secret, and validates the billing plan; the client
+   never constructs these itself
 4. Response is a flat `ApiKeySecret` — the one-time `secret` field sits alongside the key's own
    fields, shown to the user immediately
 5. User copies secret for use in their external AI client

--- a/docs/knowledge/architecture.md
+++ b/docs/knowledge/architecture.md
@@ -9,6 +9,7 @@
 This repository is a **pnpm monorepo** containing the LightBridge self-service frontend — a React / React Native (Expo) application that serves as the self-service portal for Converse, an AI gateway platform.
 
 The system is a **static frontend** (no server-side rendering, no backend logic):
+
 - Compiled to a static web bundle via `expo export --platform web`
 - Served by nginx as a static site
 - All business logic lives in the browser; the backend is LightBridge (external Rust service)
@@ -18,21 +19,27 @@ The system is a **static frontend** (no server-side rendering, no backend logic)
 ## Component Diagram
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                    self-service (Expo App)                       │
-│                                                                  │
-│  app/ (routes)                                                   │
-│    └─ screens/                                                   │
-│         └─ views/  ──── @lightbridge/ui (design system)         │
-│              └─ @lightbridge/hooks ──── @lightbridge/api-rest    │
-│                   └─ @lightbridge/i18n  └─ (generated from       │
-│                                             openapi/*.yaml)      │
-└─────────────────────────────────────────────────────────────────┘
+┌───────────────────────────────────────────────────────────────────────┐
+│                      self-service (Expo App)                          │
+│                                                                        │
+│  app/ (routes)                                                        │
+│    └─ screens/                                                        │
+│         └─ views/  ──── @lightbridge/ui (design system)               │
+│              └─ @lightbridge/hooks ──┬─── @lightbridge/authz-rpc      │
+│                   └─ @lightbridge/i18n│    (generated from             │
+│                                       │     authz.cstack, RPC)         │
+│                                       └─── @lightbridge/api-rest       │
+│                                            (generated from             │
+│                                             usage.backend.yaml, REST)  │
+└───────────────────────────────────────────────────────────────────────┘
            │                                │
-           │ Bearer JWT                     │ Bearer JWT
+           │ POST /rpc/{op_id}              │ REST + Bearer JWT
+           │ Bearer JWT, CBOR (prod)/        │
+           │ JSON (dev)                      │
            ▼                                ▼
   LightBridge AuthZ API          LightBridge Usage API
-  (api-key.backend.json)         (usage.backend.yaml)
+  (cratestack-pg RPC transport;   (usage.backend.yaml)
+   schema: authz.cstack)
            │
            │ API Key issued to external clients
            ▼
@@ -43,14 +50,15 @@ The system is a **static frontend** (no server-side rendering, no backend logic)
 
 ## Key Components
 
-| Component | Package | Responsibility | Tech Stack |
-|-----------|---------|----------------|------------|
-| Self-service app | `apps/self-service` | Entry point, routing, screen assembly | Expo 54, React 19, Expo Router |
-| REST API client | `packages/api-rest` | Auto-generated HTTP client from OpenAPI | `@hey-api/openapi-ts` |
-| Shared hooks | `packages/hooks` | Data fetching, auth, business logic | TanStack Query, Zustand/TanStack DB |
-| Design system | `packages/ui` | Shared UI primitives, theming | React Native, `cva`, `cn` |
-| i18n | `packages/i18n` | Translation files and config | `react-i18next` |
-| Native API utils | `packages/api-native` | Mobile-specific API helpers | React Native |
+| Component         | Package               | Responsibility                                                    | Tech Stack                                               |
+| ----------------- | --------------------- | ----------------------------------------------------------------- | -------------------------------------------------------- |
+| Self-service app  | `apps/self-service`   | Entry point, routing, screen assembly                             | Expo 54, React 19, Expo Router                           |
+| AuthZ RPC client  | `packages/authz-rpc`  | Generated cratestack RPC client (accounts/projects/api-keys)      | Hand-authored `.cstack` codegen, `cborg` (CBOR), `fetch` |
+| Usage REST client | `packages/api-rest`   | Auto-generated HTTP client from OpenAPI (usage-tracking API only) | `@hey-api/openapi-ts`                                    |
+| Shared hooks      | `packages/hooks`      | Data fetching, auth, business logic                               | TanStack Query, Zustand/TanStack DB                      |
+| Design system     | `packages/ui`         | Shared UI primitives, theming                                     | React Native, `cva`, `cn`                                |
+| i18n              | `packages/i18n`       | Translation files and config                                      | `react-i18next`                                          |
+| Native API utils  | `packages/api-native` | Mobile-specific API helpers                                       | React Native                                             |
 
 ---
 
@@ -65,23 +73,26 @@ Views (views/)
   ↓ calls
 Hooks (packages/hooks/)
   ↓ calls
-API Client (packages/api-rest/)
-  ↓ HTTP
+API Client (packages/authz-rpc/ for accounts/projects/api-keys, packages/api-rest/ for usage)
+  ↓ HTTP (RPC or REST, per client)
 LightBridge Backend
 ```
 
 **Rules:**
+
 - Routes render exactly one Screen. No logic, no hooks.
 - Screens assemble one or more Views. No direct API calls.
 - Views call hooks for data. No `fetch()` calls directly.
 - Hooks use `@tanstack/react-query` for all server state. No API calls in `useEffect`.
-- The API client is **always** auto-generated. Never hand-edit `packages/api-rest/src/`.
+- Both API clients are **always** auto-generated. Never hand-edit `packages/api-rest/src/client/`
+  or `packages/authz-rpc/generated/`.
 
 ---
 
 ## Data Flow
 
 ### Authentication flow
+
 1. App loads → reads `AuthSession` from storage (`loadStoredSession`)
 2. If no session → show Login screen → trigger Keycloak OAuth2/PKCE redirect
 3. Keycloak redirects back with auth code → frontend exchanges code for tokens
@@ -89,13 +100,19 @@ LightBridge Backend
 5. All subsequent API calls include `Authorization: Bearer <accessToken>`
 
 ### API key management flow
+
 1. Authenticated user navigates to API Keys tab
-2. `useQuery` hook fetches from `GET /api/v1/projects/{project_id}/api-keys`
-3. User creates key → `POST /api/v1/projects/{project_id}/api-keys`
-4. Response includes one-time `ApiKeySecret.secret` — shown to user immediately
+2. `useQuery` hook calls `listApiKeys()` (`packages/authz-rpc`), which dispatches
+   `POST /rpc/model.ApiKey.list` with `{ limit, offset, filters: [{ key: "projectId", value }] }`
+3. User creates key → `createApiKey()` dispatches `POST /rpc/procedure.createApiKey` with
+   `{ args: { projectId, name, expiresAt?, billingPlan } }` — the server generates the id, hashes
+   the secret, and validates the billing plan; the client never constructs these itself
+4. Response is a flat `ApiKeySecret` — the one-time `secret` field sits alongside the key's own
+   fields, shown to the user immediately
 5. User copies secret for use in their external AI client
 
 ### Usage data flow
+
 1. User navigates to Usage tab (currently renders "coming soon" placeholder)
 2. `useQueryUsage` hook queries `POST /usage/v1/usage/query`
 3. Response `UsageSeriesPoint[]` stored in local reactive store (`usageCollection`)
@@ -105,25 +122,26 @@ LightBridge Backend
 
 ## Key Design Decisions
 
-| Decision | Rationale |
-|----------|-----------|
-| Expo Router (file-based routing) | Enables web + native from single codebase; routes map directly to file paths |
-| Auto-generated API client | OpenAPI spec is the single source of truth; codegen eliminates drift between frontend types and backend contracts |
-| TanStack Query for server state | Declarative, caching-aware, no global store pollution |
-| Platform-specific token storage | `expo-secure-store` on native (hardware-backed), IndexedDB on web — appropriate security per platform |
-| Static export + nginx | Simple, LTS-stable serving; no Node.js runtime required in production |
-| WireMock for local dev | Allows frontend development without running the real Rust/Postgres backend |
+| Decision                              | Rationale                                                                                                                                                                                      |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Expo Router (file-based routing)      | Enables web + native from single codebase; routes map directly to file paths                                                                                                                   |
+| Auto-generated API clients            | The schema (OpenAPI for usage, `authz.cstack` for accounts/projects/api-keys) is the single source of truth; codegen eliminates drift between frontend types and backend contracts             |
+| Schema-driven RPC for AuthZ, not REST | Backend migrated to `cratestack-pg` (ADR-0003 in `lightbridge-authz`), which has no OpenAPI generation — `packages/authz-rpc` hand-authors codegen against the copied `.cstack` schema instead |
+| TanStack Query for server state       | Declarative, caching-aware, no global store pollution                                                                                                                                          |
+| Platform-specific token storage       | `expo-secure-store` on native (hardware-backed), IndexedDB on web — appropriate security per platform                                                                                          |
+| Static export + nginx                 | Simple, LTS-stable serving; no Node.js runtime required in production                                                                                                                          |
+| WireMock for local dev                | Allows frontend development without running the real Rust/Postgres backend                                                                                                                     |
 
 ---
 
 ## External Dependencies
 
-| Service | Purpose | URL (prod) |
-|---------|---------|------------|
-| Keycloak | OAuth2/OIDC provider — issues Bearer tokens | Configured via `EXPO_PUBLIC_KEYCLOAK_ISSUER` |
-| LightBridge AuthZ API | Account, project, API key management | Configured via `EXPO_PUBLIC_BACKEND_URL` |
-| LightBridge Usage API | Time-series usage query | Configured via `EXPO_PUBLIC_USAGE_URL` |
-| Converse AI Gateway | LLM proxy (external clients only, not this frontend) | Configured via `EXPO_PUBLIC_GATEWAY_URL` |
+| Service               | Purpose                                              | URL (prod)                                   |
+| --------------------- | ---------------------------------------------------- | -------------------------------------------- |
+| Keycloak              | OAuth2/OIDC provider — issues Bearer tokens          | Configured via `EXPO_PUBLIC_KEYCLOAK_ISSUER` |
+| LightBridge AuthZ API | Account, project, API key management                 | Configured via `EXPO_PUBLIC_BACKEND_URL`     |
+| LightBridge Usage API | Time-series usage query                              | Configured via `EXPO_PUBLIC_USAGE_URL`       |
+| Converse AI Gateway   | LLM proxy (external clients only, not this frontend) | Configured via `EXPO_PUBLIC_GATEWAY_URL`     |
 
 ---
 
@@ -134,4 +152,7 @@ LightBridge Backend
 - **Secrets:** No secrets baked into the container image. All config injected at runtime via environment variables.
 - **TLS:** Not terminated by the app or nginx — expected at ingress/load-balancer level.
 - **CORS:** Handled by the LightBridge backend; the frontend never bypasses CORS.
-- **Input validation:** All API shapes are typed and validated via generated TypeScript types from OpenAPI.
+- **Input validation:** Usage API shapes are typed via generated TypeScript types from OpenAPI
+  (`@hey-api/openapi-ts` + `zod`). AuthZ API shapes (accounts/projects/api-keys) are typed via
+  `packages/authz-rpc`'s codegen against `authz.cstack` — no runtime schema validation on the
+  frontend for this surface (the backend's `cratestack-pg` policy layer is the enforcement point).

--- a/docs/knowledge/auth-and-identity.md
+++ b/docs/knowledge/auth-and-identity.md
@@ -1,11 +1,13 @@
 # Authentication and Identity
 
 > Sources:
+>
 > - `packages/hooks/src/auth/auth-storage.ts`
 > - `packages/hooks/src/auth/auth-types.ts`
 > - `packages/hooks/src/auth/use-keycloak-login.ts`
 > - `packages/hooks/src/auth/use-auth-session.ts`
-> - `openapi/api-key.backend.json` (security scheme)
+> - `packages/authz-rpc/src/transport.ts` (bearer header + refresh wiring)
+> - `packages/authz-rpc/schema/authz.cstack` (API-key schema)
 
 ---
 
@@ -14,12 +16,12 @@
 These are two completely separate credential types with different purposes and lifetimes:
 
 | Credential       | Type                     | Issued By           | Used By             | Purpose                                                  |
-|------------------|--------------------------|---------------------|---------------------|----------------------------------------------------------|
+| ---------------- | ------------------------ | ------------------- | ------------------- | -------------------------------------------------------- |
 | **Bearer Token** | Short-lived JWT          | Keycloak            | This frontend       | Authenticate the logged-in user with LightBridge backend |
 | **API Key**      | Long-lived secret string | LightBridge backend | External AI clients | Authenticate with the Converse AI gateway                |
 
-> The frontend **never** uses API keys to make requests. API keys are managed *through* the frontend but consumed
-*outside* it.
+> The frontend **never** uses API keys to make requests. API keys are managed _through_ the frontend but consumed
+> _outside_ it.
 > The Converse AI gateway is **never** called by this frontend. External AI clients call it directly using their API
 > key.
 
@@ -80,7 +82,7 @@ AuthSession stored (see Token Storage below)
 Defined in `packages/hooks/src/auth/auth-types.ts`:
 
 | Field          | Type     | Required | Description                                                 |
-|----------------|----------|----------|-------------------------------------------------------------|
+| -------------- | -------- | -------- | ----------------------------------------------------------- |
 | `accessToken`  | `string` | **Yes**  | Bearer token sent in `Authorization` header to LightBridge  |
 | `refreshToken` | `string` | No       | Used to obtain new access tokens without re-login           |
 | `idToken`      | `string` | No       | OIDC identity token (Keycloak-issued, contains user claims) |
@@ -95,7 +97,7 @@ Defined in `packages/hooks/src/auth/auth-types.ts`:
 Populated from Keycloak's `/userinfo` endpoint:
 
 | Field   | Type     | Required | Description                                                 |
-|---------|----------|----------|-------------------------------------------------------------|
+| ------- | -------- | -------- | ----------------------------------------------------------- |
 | `id`    | `string` | **Yes**  | Keycloak subject (`sub` claim)                              |
 | `name`  | `string` | No       | Display name (`name` or `preferred_username` from userinfo) |
 | `email` | `string` | No       | Email address                                               |
@@ -108,9 +110,9 @@ The full session stored in persistent storage:
 
 ```typescript
 type AuthSession = {
-    id: 'current';         // always the literal string 'current'
-    user: AuthUser | null; // null if userinfo fetch failed
-    tokens: AuthTokens | null;
+  id: 'current'; // always the literal string 'current'
+  user: AuthUser | null; // null if userinfo fetch failed
+  tokens: AuthTokens | null;
 };
 ```
 
@@ -140,7 +142,7 @@ Platform-specific storage is implemented in `packages/hooks/src/auth/auth-storag
 ### Storage API
 
 | Function                     | Platform | Effect                        |
-|------------------------------|----------|-------------------------------|
+| ---------------------------- | -------- | ----------------------------- |
 | `loadStoredSession()`        | Both     | Returns `AuthSession \| null` |
 | `saveStoredSession(session)` | Both     | Persists the session          |
 | `clearStoredSession()`       | Both     | Deletes the persisted session |
@@ -155,17 +157,19 @@ Once authenticated, all frontend requests to the LightBridge AuthZ and Usage API
 Authorization: Bearer <accessToken>
 ```
 
-The `api-key.backend.json` security scheme confirms this:
+The AuthZ API's `cratestack::AuthProvider` implementation (`CratestackAuthProvider`, backend-side)
+extracts and validates this same bearer/JWKS token exactly as before the RPC migration — it just
+sits in front of the RPC dispatcher instead of REST handlers now. On the frontend, the header is
+attached by `packages/authz-rpc/src/transport.ts`'s `rpcCall()`, which mirrors the previous REST
+client's proactive-refresh / 401-retry-once behavior:
 
-```yaml
-securitySchemes:
-  bearer_auth:
-    type: http
-    scheme: bearer
-    bearerFormat: JWT
-security:
-  - bearer_auth: [ ]
+```typescript
+// packages/authz-rpc/src/transport.ts (abridged)
+headers.authorization = `Bearer ${token}`;
 ```
+
+The Usage API is unaffected — it still authenticates the same way over plain REST, via
+`@lightbridge/api-rest`'s generated OpenAPI security scheme.
 
 ---
 
@@ -173,29 +177,48 @@ security:
 
 API keys are issued by the LightBridge backend and are separate from authentication tokens.
 
-From `openapi/api-key.backend.json`:
+From `packages/authz-rpc/schema/authz.cstack` (model `ApiKey`, generated type in
+`packages/authz-rpc/generated/models.ts`) — note these are the wire field names as of the
+cratestack RPC migration, **camelCase**, not the pre-migration REST API's snake_case:
 
-| Field          | Type                           | Nullable | Description                                          |
-|----------------|--------------------------------|----------|------------------------------------------------------|
-| `id`           | `string`                       | No       | Unique key identifier                                |
-| `project_id`   | `string`                       | No       | Project the key belongs to                           |
-| `name`         | `string`                       | No       | Human-readable label                                 |
-| `key_prefix`   | `string`                       | No       | Visible prefix of the secret (e.g. `"lb_abc123..."`) |
-| `status`       | `ApiKeyStatus`                 | No       | `"active"` or `"revoked"`                            |
-| `created_at`   | `string` (date-time)           | No       | Creation timestamp                                   |
-| `expires_at`   | `string` (date-time) \| `null` | **Yes**  | Optional expiry                                      |
-| `last_used_at` | `string` (date-time) \| `null` | **Yes**  | Last usage timestamp                                 |
-| `last_ip`      | `string \| null`               | **Yes**  | IP of last caller                                    |
-| `revoked_at`   | `string` (date-time) \| `null` | **Yes**  | Revocation timestamp                                 |
+| Field         | Type                  | Nullable | Description                                           |
+| ------------- | --------------------- | -------- | ----------------------------------------------------- |
+| `id`          | `string`              | No       | Unique key identifier                                 |
+| `projectId`   | `string`              | No       | Project the key belongs to                            |
+| `name`        | `string`              | No       | Human-readable label                                  |
+| `keyPrefix`   | `string`              | No       | Visible prefix of the secret (e.g. `"lb_abc123..."`)  |
+| `status`      | `string`              | No       | `"active"` or `"revoked"`                             |
+| `billingPlan` | `string`              | No       | Billing plan the key was created under                |
+| `createdAt`   | `string` (date-time)  | No       | Creation timestamp                                    |
+| `updatedAt`   | `string` (date-time)  | No       | Last update timestamp                                 |
+| `expiresAt`   | `string \| undefined` | **Yes**  | Optional expiry                                       |
+| `lastUsedAt`  | `string \| undefined` | **Yes**  | Last usage timestamp                                  |
+| `lastIp`      | `string \| undefined` | **Yes**  | IP of last caller                                     |
+| `revokedAt`   | `string \| undefined` | **Yes**  | Revocation timestamp                                  |
+| `deletedAt`   | `string \| undefined` | **Yes**  | Soft-delete timestamp (`@@soft_delete` in the schema) |
 
-The secret is only returned **once**, at creation or rotation, in an `ApiKeySecret` object:
+Note: the schema also declares a `keyHash` column, but it's marked `@server_only` — it's never
+emitted on the wire and does not appear in the generated `ApiKey` TypeScript type at all.
+
+The secret is only returned **once**, at creation (`procedure.createApiKey`) or rotation
+(`procedure.rotateApiKey`), as an `ApiKeySecret` object. Unlike the pre-migration REST response,
+this is **flat** — the `ApiKey` fields and `secret` sit side by side, not nested under an `api_key`
+key (the schema's own comment explains why: `cratestack-pg` 0.4.9 can't reference a model type by
+name inside a `type` block, so `ApiKeySecret` inlines every `ApiKey` field as a scalar instead of
+nesting the model):
 
 ```json
 {
-  "api_key": {
-    /* ApiKey object */
-  },
-  "secret": "lb_full_secret_string_shown_once"
+  "id": "key_ghi789",
+  "projectId": "proj_def456",
+  "name": "My App Key",
+  "keyPrefix": "lb_ghi789...",
+  "status": "active",
+  "billingPlan": "standard",
+  "createdAt": "2025-03-30T10:00:00Z",
+  "updatedAt": "2025-03-30T10:00:00Z",
+  "secret": "lb_ghi789fullsecretstringshownonce",
+  "oauth2Url": null
 }
 ```
 

--- a/docs/knowledge/platform-overview.md
+++ b/docs/knowledge/platform-overview.md
@@ -20,10 +20,10 @@ LightBridge is a **separate service layer** built on top of the Converse AI gate
 
 LightBridge is implemented as a **Rust service backed by a PostgreSQL database**. It exposes two distinct APIs:
 
-| API                   | OpenAPI Spec                   | Purpose                                  |
-|-----------------------|--------------------------------|------------------------------------------|
-| LightBridge AuthZ API | `openapi/api-key.backend.json` | Account, project, and API key management |
-| LightBridge Usage API | `openapi/usage.backend.yaml`   | Time-series usage queries                |
+| API                   | Contract                                                                                                                        | Purpose                                  |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| LightBridge AuthZ API | Schema-first RPC (`cratestack-pg`), no OpenAPI — `POST /rpc/{op_id}`; schema copied to `packages/authz-rpc/schema/authz.cstack` | Account, project, and API key management |
+| LightBridge Usage API | `openapi/usage.backend.yaml`                                                                                                    | Time-series usage queries                |
 
 ---
 
@@ -102,7 +102,7 @@ What this frontend does NOT do:
 ## Key Distinction
 
 | Bearer Token                                           | API Key                                                                  |
-|--------------------------------------------------------|--------------------------------------------------------------------------|
+| ------------------------------------------------------ | ------------------------------------------------------------------------ |
 | Issued by Keycloak to the logged-in user               | Issued by LightBridge backend to an account/project                      |
 | Used by this frontend to authenticate with LightBridge | Used by external AI clients to authenticate with the Converse AI gateway |
 | Short-lived JWT; refreshed via OAuth2 token endpoint   | Long-lived; can be rotated or revoked via the frontend                   |


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Rewrites (not renames) five `docs/knowledge/*.md` files to describe the new cratestack RPC
  architecture for the AuthZ API (accounts/projects/api-keys), replacing descriptions of the
  deleted REST API (`openapi/api-key.backend.json`):
  - `auth-and-identity.md` — bearer-token flow, `ApiKey` field table, flat `ApiKeySecret` shape
  - `architecture-conventions.md` — monorepo structure, API-client layering, an added
    accounts/api-keys example chain alongside the existing usage one
  - `architecture.md` — component diagram, key-components table, layering, API-key data flow
    (now op-id based, not REST paths), input-validation note
  - `platform-overview.md` — service inventory table
  - `api-reference.md` — the AuthZ endpoint section rewritten wholesale: op-id tables instead of
    REST method/path tables, request-envelope shapes, camelCase field tables, and the real error
    body shapes (`RpcErrorBody` + the app's RBAC-gate error shape)

It solves:

- Follow-up from [#111](https://github.com/ADORSYS-GIS/converse-frontends/pull/111) (the
  cratestack RPC migration itself), which explicitly flagged these docs as out of scope for that
  diff since they needed a substantive rewrite, not a mechanical rename.

**Update (same PR):** `#111` reversed its decision to commit `packages/authz-rpc/generated/` to
git — it's now gitignored like every other package's codegen output, and CI regenerates it via a
cached `cratestack-cli` install instead. Corrected the one paragraph in
`architecture-conventions.md` that described the old committed-because-CI-lacks-Rust rationale.

---

## 2. Intent

`#111` migrates the frontend's accounts/projects/api-keys client off REST onto cratestack RPC.
These five docs are the agent-facing knowledge base for this repo's architecture and still
described the old REST contract in detail (HTTP verbs, path params, snake_case field tables,
endpoint-by-endpoint schemas) — accurate documentation here matters because it's what future
agent sessions (and humans) read first to understand how this repo talks to its backend. A
find-and-replace pass would have left the endpoint tables structurally wrong (REST-shaped tables
don't describe an op-id-dispatch RPC surface), so this is a real rewrite of the AuthZ-facing
sections, informed directly by `packages/authz-rpc/schema/authz.cstack` and the generated SDK.

---

## 3. Scope

### In Scope

- The five docs listed above, AuthZ-API-related sections only.

### Out of Scope

- The Usage API sections in these docs — untouched, since that API is unaffected by the RPC
  migration.
- Any other `docs/knowledge/*.md` files not listed (checked: none of the others reference the
  deleted `openapi/api-key.backend.json` or REST-shaped AuthZ endpoints).
- `#111` itself is not yet merged. These docs describe the target architecture as implemented
  there. **If the pending decision in `#111` (hand-rolled vs. official `cratestack
  generate-typescript` codegen — see [cratestack/cratestack#118](https://github.com/cratestack/cratestack/issues/118)
  and [#119](https://github.com/cratestack/cratestack/issues/119)) changes which package/codegen
  approach ships, the `packages/authz-rpc` references here may need a follow-up pass.** The wire
  contract itself (op-ids, envelope shapes, field names) is unaffected by that decision either way.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
npx prettier -c docs/knowledge/auth-and-identity.md docs/knowledge/architecture-conventions.md \
  docs/knowledge/architecture.md docs/knowledge/platform-overview.md docs/knowledge/api-reference.md
grep -rn "api-key.backend.json\|billing_identity\|project_id\|key_prefix\|created_at\|updated_at\|expires_at\|last_used_at\|last_ip\|revoked_at\|owners_admins\|account_id\|billing_plan\|allowed_models\|default_limits" docs/knowledge/*.md
```

Results:

```text
prettier: all 5 files pass (formatted with --write first)
grep: zero unintended hits — the one "owners_admins" match in api-reference.md is the
  intentional note explaining the field no longer exists, not a stale reference
```

This is a docs-only PR (no code paths to test); "not applicable" for the unchecked boxes above.

---

## 5. Screenshots / Evidence

N/A — markdown documentation only, no UI/runtime surface.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* Documents an architecture (`packages/authz-rpc`) that lives in an unmerged PR (`#111`). If that
  PR's approach changes materially before merge, these docs could describe something slightly
  different from what actually ships.

Mitigation:

* Called out explicitly in Scope above, with a pointer to the exact upstream issues gating that
  decision, so a reviewer can judge staleness risk at a glance.
* No code, config, or runtime behavior changes — worst case is a documentation lag, not a broken
  build or a regression.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [ ] Generating code
* [x] Drafting documentation
* [ ] Refactoring
* [ ] Generating tests
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

_(Human-verification checkboxes intentionally left unchecked — this PR was authored end-to-end by
Claude in an agentic session; @selast, please review before checking these off and merging.)_

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [ ] Product intent
* [ ] Edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

