### PR TITLE
fix(authz-rpc): re-copy schema, route account deletion through deleteAccountPermanently

### DIFF
--- a/packages/authz-rpc/schema/authz.cstack
+++ b/packages/authz-rpc/schema/authz.cstack
@@ -37,9 +37,13 @@ mixin AuditFields {
 model Account {
   @use(AuditFields)
 
-  id Cuid @id
+  id String @id
   billingIdentity String @unique
-  status String
+  // Server-managed lifecycle state: set only by the disable/enable procedures and the
+  // DB `DEFAULT 'active'` (migrations/20260714000001). `@readonly` drops it from the
+  // generated create/update inputs so a raw RPC caller cannot supply a born-suspended
+  // status, matching `ApiKey.status` below.
+  status String @readonly
   projects Project[] @relation(fields:[id],references:[accountId])
   memberships AccountMembership[] @relation(fields:[id],references:[accountId])
 
@@ -53,23 +57,36 @@ model Account {
   // `createAccount` procedure, which inserts the account and the creator's membership in
   // one transaction, and `model.Account.create` is also denied unconditionally at the
   // RBAC layer (crates/lightbridge-authz-rest/src/rpc_authorize.rs).
+  //
+  // NOTE: no `@@allow("delete", ...)` either, as of the membership-roles change. Account
+  // deletion is now owner-only, and cratestack's relation-quantifier policy predicates can't
+  // express a per-row compound condition ("the member row matching my subject must ALSO have
+  // role='owner'") -- `memberships.some.subject == auth().id && memberships.some.role ==
+  // "owner"` would compile to two independent EXISTS checks, not one joint check on the same
+  // row (confirmed by reading `cratestack-macros/src/policy/model/relation_path.rs`: each
+  // dotted policy path resolves to exactly one target field per relation hop, no support for
+  // multiple fields on one related row). So the role check moved into the `deleteAccountPermanently`
+  // procedure's hand-written SQL instead, and `model.Account.delete` is denied unconditionally
+  // at the RBAC layer, same pattern as create.
   @@audit
   @@paged
   @@allow("read", memberships.some.subject == auth().id)
   @@allow("update", memberships.some.subject == auth().id)
-  @@allow("delete", memberships.some.subject == auth().id)
 }
 
 model Project {
   @use(AuditFields)
 
-  id Cuid @id
-  accountId Cuid
+  id String @id
+  accountId String
   name String
   allowedModels Json?
   defaultLimits Json
   billingPlan String
-  status String
+  // Server-managed lifecycle state, same contract as `Account.status` above: mutated only
+  // by disable/enable procedures + DB `DEFAULT 'active'`, `@readonly` so it is absent from
+  // the generic `model.Project.create`/`update` inputs.
+  status String @readonly
   account Account @relation(fields:[accountId],references:[id])
   apiKeys ApiKey[] @relation(fields:[id],references:[projectId])
 
@@ -98,8 +115,8 @@ model Project {
 model ApiKey {
   @use(AuditFields)
 
-  id Cuid @id
-  projectId Cuid @readonly
+  id String @id
+  projectId String @readonly
   name String
   keyPrefix String @readonly
   keyHash String @unique @server_only
@@ -136,10 +153,25 @@ model ApiKey {
 // shape that does not match the hand-written migration. It exists solely so
 // `.some`/`.every`/`.none` policy predicates on Account/Project/ApiKey can
 // traverse into it.
+//
+// cratestack-pg 0.4.13 added parser/migrate-layer support for composite keys
+// (`@@id([accountId, subject])`, cratestack/cratestack#145), which would match this table's
+// real shape exactly and drop the synthetic `id` -- tried it, but codegen (query builders,
+// routing, generated clients) explicitly rejects it as not yet supported, tracked at
+// cratestack/cratestack#136. Revisit once that lands; the synthetic-`id` workaround stays
+// until then.
 model AccountMembership {
-  id Cuid @id
-  accountId Cuid
+  id String @id
+  accountId String
   subject String
+  // "owner" | "admin" | "member" (DB CHECK constraint, migrations/20260722000001_account_
+  // membership_roles.sql). Gates addAccountMember/removeAccountMember/disableAccount/
+  // enableAccount/deleteAccountPermanently/setAccountMemberRole via hand-written sqlx role checks in
+  // those procedures (see the compound-condition limitation noted on `Account` above for why
+  // this isn't expressed as an `@@allow` policy). Not independently mutable through generic
+  // CRUD -- there is no `@@allow("update", ...)` below, so role changes go exclusively through
+  // `setAccountMemberRole`.
+  role String
   createdAt DateTime
   account Account @relation(fields:[accountId],references:[id])
 
@@ -152,7 +184,7 @@ model AccountMembership {
 // Refresh is explicit (runtime.views().account_summary().refresh().await),
 // never automatic-on-write.
 view AccountSummary from Account, Project, ApiKey {
-  id Cuid @id @from(Account.id)
+  id String @id @from(Account.id)
   projectCount Int
   apiKeyCount Int
   activeApiKeyCount Int
@@ -163,34 +195,21 @@ view AccountSummary from Account, Project, ApiKey {
 }
 
 type RotateApiKeyInput {
-  keyId Cuid
+  keyId String
 }
 
-// Flattened deliberately -- cratestack-pg 0.4.9's codegen for `type` blocks
-// cannot reference a model type by name as a field (confirmed by a real
-// `include_server_schema!` compile: `type` structs are emitted inside
-// `cratestack_schema::types`, model structs inside the sibling
-// `cratestack_schema::models`, and the `type`-struct field-type generator
-// (`cratestack-macros/src/types.rs::generate_type_struct`) never emits the
-// `super::`/`super::models::` qualifier those cross-module references need
-// -- `type ApiKeySecret { apiKey ApiKey secret String }` fails with "cannot
-// find type `ApiKey` in this scope"). So this type inlines the ApiKey shape
-// as scalars instead of nesting the model, matching the real
-// `ApiKeySecret { api_key: ApiKey, secret: String, oauth2_url: Option<String> }`
-// DTO shape (crates/lightbridge-authz-core/src/dto.rs) field-by-field.
+// Nests the real `ApiKey` model directly, matching the real
+// `ApiKeySecret { api_key: ApiKey, secret: String, oauth2_url: Option<String> }` DTO shape
+// (crates/lightbridge-authz-core/src/dto.rs). Previously flattened as scalars, because
+// cratestack-pg 0.4.9-0.4.12's codegen for `type` blocks couldn't reference a model type by
+// name as a field (`type` structs were emitted inside `cratestack_schema::types`, model
+// structs in the sibling `cratestack_schema::models`, and the `type`-struct field generator
+// never emitted the `super::`/`super::models::` qualifier the cross-module reference needed --
+// confirmed by a real `include_server_schema!` compile failing with "cannot find type `ApiKey`
+// in this scope"). Fixed in cratestack-pg 0.4.13 (cratestack/cratestack#147); un-flattened here
+// now that it's adopted.
 type ApiKeySecret {
-  id Cuid
-  projectId Cuid
-  name String
-  keyPrefix String
-  status String
-  expiresAt DateTime?
-  lastUsedAt DateTime?
-  lastIp String?
-  revokedAt DateTime?
-  billingPlan String
-  createdAt DateTime
-  updatedAt DateTime
+  apiKey ApiKey
   secret String
   oauth2Url String?
 }
@@ -225,7 +244,7 @@ mutation procedure createAccount(args: CreateAccountInput): Account
 // hand-written sqlx in the ProcedureRegistry impl (reusing `AuthzStoreImpl::create_api_key`),
 // tenant-scoped by the `account_memberships` CTE exactly as `rotateApiKey` is.
 type CreateApiKeyInput {
-  projectId Cuid
+  projectId String
   name String
   expiresAt DateTime?
   billingPlan String
@@ -235,34 +254,61 @@ mutation procedure createApiKey(args: CreateApiKeyInput): ApiKeySecret
   @allow(auth() != null)
 
 type RevokeApiKeyInput {
-  keyId Cuid
+  keyId String
 }
 
 mutation procedure revokeApiKey(args: RevokeApiKeyInput): ApiKey
   @allow(auth() != null)
 
-// Membership mutations (ADR-0003 item 4). These are hand-written sqlx in the
-// ProcedureRegistry impl (not generated CRUD): `account_memberships` is a
-// relation-target-only model here (composite PK, no `id` column), so it has no
-// generated create/delete verb, and `removeAccountMember` must enforce the
-// "cannot remove the last member" invariant that generated CRUD cannot express.
-// The `@allow(auth() != null)` gate only asserts an authenticated caller; the
-// real membership authorization lives in the hand-written SQL (the acting
-// subject must already be a member), exactly as the pre-migration REST path did.
+// Membership mutations (ADR-0003 item 4; role gating added when membership roles landed). These
+// are hand-written sqlx in the ProcedureRegistry impl (not generated CRUD): `account_memberships`
+// is a relation-target-only model here (composite PK, no `id` column), so it has no generated
+// create/delete verb, `removeAccountMember` must enforce the "cannot remove the last member" (and
+// now "cannot remove the last owner") invariants generated CRUD can't express, and role gating
+// itself can't be expressed as an `@@allow` policy (see the compound-condition note on `Account`
+// above). The `@allow(auth() != null)` gate only asserts an authenticated caller; the real
+// authorization -- membership AND role -- lives in the hand-written SQL: adding or removing a
+// member requires the acting subject to be an owner or admin; granting the `owner` role requires
+// the acting subject to already be an owner (admins cannot mint new owners); an admin cannot
+// remove an owner.
 type AddAccountMemberInput {
-  accountId Cuid
+  accountId String
   subject String
+  // Optional; defaults to "member" if omitted. Granting "owner" requires the acting subject to
+  // already hold "owner" (see above).
+  role String?
 }
 
 mutation procedure addAccountMember(args: AddAccountMemberInput): Account
   @allow(auth() != null)
 
 type RemoveAccountMemberInput {
-  accountId Cuid
+  accountId String
   subject String
 }
 
 mutation procedure removeAccountMember(args: RemoveAccountMemberInput): Account
+  @allow(auth() != null)
+
+// Owner-only. Refuses to demote/reassign-away-from-owner the account's last remaining owner (same
+// lockout-avoidance shape as removeAccountMember's "cannot remove the last owner").
+type SetAccountMemberRoleInput {
+  accountId String
+  subject String
+  role String
+}
+
+mutation procedure setAccountMemberRole(args: SetAccountMemberRoleInput): Account
+  @allow(auth() != null)
+
+// Owner-only. Replaces the now-denied generic `model.Account.delete` verb (see the `Account`
+// model's `@@allow` comments). Cascades to projects/api-keys/memberships via the existing
+// `ON DELETE CASCADE` foreign keys, same as the pre-migration hand-written delete did.
+type DeleteAccountPermanentlyInput {
+  accountId String
+}
+
+mutation procedure deleteAccountPermanently(args: DeleteAccountPermanentlyInput): Account
   @allow(auth() != null)
 
 // Account / project suspension (data-plane authorization; see docs/rbac.md). Disabling sets
@@ -273,7 +319,7 @@ mutation procedure removeAccountMember(args: RemoveAccountMemberInput): Account
 // The `@allow(auth() != null)` gate only asserts an authenticated caller; the coarse
 // `account:disable` / `project:disable` capability is enforced by the RBAC layer.
 type AccountStatusInput {
-  accountId Cuid
+  accountId String
 }
 
 mutation procedure disableAccount(args: AccountStatusInput): Account
@@ -283,7 +329,7 @@ mutation procedure enableAccount(args: AccountStatusInput): Account
   @allow(auth() != null)
 
 type ProjectStatusInput {
-  projectId Cuid
+  projectId String
 }
 
 mutation procedure disableProject(args: ProjectStatusInput): Project

--- a/packages/hooks/src/accounts.ts
+++ b/packages/hooks/src/accounts.ts
@@ -136,7 +136,13 @@ export function useDeleteAccount() {
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
-    mutationFn: async ({ id }: { id: string }) => getAuthzRpcClient().accounts.delete(id),
+    // model.Account.delete is now unconditionally RBAC-denied server-side — account
+    // deletion is owner-only and goes exclusively through this procedure, which the
+    // generic policy predicate can't express (see the schema's own Account/AccountMembership
+    // doc comments for why: a compound "member row matching my subject AND role=owner"
+    // check isn't expressible as a single @@allow relation-quantifier).
+    mutationFn: async ({ id }: { id: string }): Promise<Account> =>
+      getAuthzRpcClient().procedures.deleteAccountPermanently({ args: { accountId: id } }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: accountsQueryKey });
     },


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Re-copies `packages/authz-rpc/schema/authz.cstack` from the backend
  (`crates/lightbridge-authz-api/schema/authz.cstack` in `lightbridge-authz`) and regenerates
  `packages/authz-rpc/generated/` (gitignored, so no diff there) against it with `--full-selection`.
- Fixes `packages/hooks/src/accounts.ts`'s `useDeleteAccount()`: it now calls the new
  `procedures.deleteAccountPermanently({ args: { accountId } })` instead of the generic
  `accounts.delete(id)`.

It solves:

- The backend added an account-membership-roles feature. `AccountMembership` gained a required
  `role` field (`"owner" | "admin" | "member"`, DB CHECK constraint,
  `migrations/20260722000001_account_membership_roles.sql`), plus two new procedures:
  `setAccountMemberRole` and `deleteAccountPermanently`. As part of that, `Account`'s
  `@@allow("delete", ...)` policy was removed entirely — a per-row compound condition ("the
  member row matching my subject must ALSO have `role == "owner"`") isn't expressible as a single
  cratestack relation-quantifier `@@allow` (confirmed against `cratestack-macros/src/policy/model/
  relation_path.rs`: each dotted policy path resolves to exactly one target field per relation
  hop). The owner-only check moved into `deleteAccountPermanently`'s hand-written SQL instead, and
  `model.Account.delete` is now unconditionally RBAC-denied server-side
  (`crates/lightbridge-authz-rest/src/rpc_authorize.rs`).

---

## 2. Intent

Without this fix, `useDeleteAccount()` would keep compiling and keep calling the generic
`accounts.delete(id)` RPC verb — which now always 403s against the real backend. This is the kind
of change that's invisible to every automated check available: `cratestack diff` (run against the
old vs. new schema before this PR) classifies the underlying `@@allow` change as **internal-only,
no tracked wire-shape effect** — policy/`@@allow` changes are an explicitly documented gap in its
breaking-change classification (see `cratestack-docs`'s own "Known gaps" note on the `diff`
subcommand), and this is a live example of exactly that gap. It's also invisible to `tsc`: the
generic `.delete()` verb is still generated and still type-checks regardless of policy (unlike
`.create()`, which cratestack fail-closes at *generation* time when no `@@allow("create", ...)`
exists — `.delete()` apparently doesn't get the same treatment). The only way to catch this was
reading the updated schema's own doc comments and manually confirming both the old and new
generated `client.ts` against the actual RBAC behavior described there.

---

## 3. Scope

### In Scope

- `packages/authz-rpc/schema/authz.cstack` — re-copied 1:1 from the backend.
- `packages/hooks/src/accounts.ts` — `useDeleteAccount()` fixed to call the new procedure. No
  change to the hook's public signature (`mutateAsync({ id })`) — `delete-account-sheet.tsx` and
  every other consumer needed zero changes.

### Out of Scope / follow-ups noted but not built

- **`setAccountMemberRole` and `AccountMembership.role` are available but unused.** No
  product/UX decision has been made on exposing role management in the account-settings "Members"
  section (which, per an existing known gap, still can't even list members — there's no listing
  RPC). Wiring up role management before that gap is closed would be building UI for data the
  screen can't otherwise show. Left for a follow-up ticket.
- **Two other schema changes turned out to be no-ops for this client**, verified by inspecting
  both the actual call sites and the regenerated output rather than assuming:
  - id/FK fields (`Account.id`, `Project.id`/`accountId`, `ApiKey.id`/`projectId`,
    `AccountMembership.id`/`accountId`) changed type from `Cuid` back to `String` in the schema.
    `cratestack diff` flags this as 8 separate breaking changes, but the TypeScript generator maps
    both `String` and `Cuid` to `string` (`cratestack-client-typescript/src/types.rs::ts_type`) —
    zero effect on generated types or this client's code.
  - `type ApiKeySecret` changed from flattened `ApiKey` scalars to nesting the real `ApiKey` model
    (`{ apiKey: ApiKey, secret: string, oauth2Url?: string | null }` — a cratestack-pg 0.4.13 fix,
    #147, that made cross-module type-block references possible). This client's only two call
    sites (`rotate-api-key-sheet.tsx`, `api-key-create-screen.tsx`) read nothing but `.secret`,
    present unchanged in both shapes — confirmed by grep before assuming this was safe to ignore.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
cratestack diff packages/authz-rpc/schema/authz.cstack \
  ~/dev/gis/lightbridge-authz/crates/lightbridge-authz-api/schema/authz.cstack
  # structured breaking/additive/internal-only report — first real use of the diff subcommand
  # this migration asked cratestack to add

cp ~/dev/gis/lightbridge-authz/crates/lightbridge-authz-api/schema/authz.cstack \
   packages/authz-rpc/schema/authz.cstack
pnpm --filter @lightbridge/authz-rpc run codegen:cratestack   # --full-selection
grep -n "delete(id" packages/authz-rpc/generated/src/client.ts
  # confirmed model.Account.delete is STILL generated (unlike model.Account.create, which
  # cratestack fail-closes at generation time when @@allow("create", ...) is absent) — the only
  # way to catch the RBAC-deny was reading the schema's own doc comments, not the generated code

cd apps/self-service && npx tsc --noEmit -p tsconfig.json   # 0 errors, before AND after the fix
  # (i.e. this genuinely does NOT surface as a type error either way)
pnpm test                                                    # 23 suites, 94 tests passed
pnpm --filter @lightbridge/authz-rpc test                    # 3 test files, 11 tests passed
pnpm turbo run build:web                                     # succeeded
```

Results:

```text
cratestack diff reported: 8 breaking (all Cuid->String, confirmed no-op for this generator),
  2 additive (setAccountMemberRole, deleteAccountPermanently procedures), 1 internal-only (the
  Account @@allow change from "delete" to "update" -- this is the one that actually mattered and
  the tool's own documented scope explicitly does not classify it as breaking).
Full re-verification (tsc/tests/build) green both before locating the RBAC-deny issue and after
  fixing useDeleteAccount -- confirming tsc alone would never have caught this regression.
```

Not verified: this change (like the rest of the RPC migration) has not been exercised against a
live backend — no cratestack-pg instance was reachable in this environment. The RBAC-deny
behavior for `model.Account.delete` is read directly from the backend schema's own doc comments,
not observed by making a live 403 happen.

---

## 5. Screenshots / Evidence

- Not applicable — an internal call-site swap behind an unchanged hook signature and unchanged UI;
  the delete-account sheet/view render identically before and after.

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [x] Medium
* [ ] High

Potential risks:

* This has not been tested against a live backend implementing `deleteAccountPermanently` — the
  procedure's exact runtime behavior (does it hard-delete, soft-delete, cascade to
  projects/api-keys?) is read from the schema/comments, not observed.
* If the backend's owner-only role check has an edge case (e.g. an account with no `"owner"`-role
  member, only `"admin"`/`"member"`), `deleteAccountPermanently` may reject every caller — this
  client can't detect or work around that; it surfaces whatever error the procedure returns.
* `AccountMembership.role` being a new required field (per `cratestack diff`, "breaking") could
  affect callers that construct `AccountMembership` payloads directly — confirmed this client
  doesn't (no direct model access anywhere in hooks/screens, only via
  `addAccountMember`/`removeAccountMember` procedures, and `AddAccountMemberInput.role` is
  optional).

Mitigation:

* Full re-verification (tsc/tests/build) confirms nothing else in this client silently broke.
* Scoped to exactly the one hook that called the now-denied generic verb — no speculative changes
  to `setAccountMemberRole` or role-based UI without a product decision first.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [ ] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

_(Human-verification checkboxes intentionally left unchecked — this PR was authored end-to-end by Claude in an agentic session; @selast, please review before checking these off and merging.)_

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [x] Product intent
* [x] Edge cases

Specific things worth a close look on this update:
- Whether `deleteAccountPermanently`'s actual semantics (hard delete? cascade?) match what the
  `DeleteAccountView`/`DeleteAccountSheet` UI currently promises the user.
- Whether `setAccountMemberRole`/the new `role` field should get a follow-up ticket now, given the
  account-settings Members section still can't list members at all (pre-existing known gap,
  unrelated to this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
