### PR TITLE
fix(authz-rpc): strip undefined-valued properties before CBOR encode

### DIFF
--- a/packages/authz-rpc/src/codec.test.ts
+++ b/packages/authz-rpc/src/codec.test.ts
@@ -34,3 +34,37 @@ describe('CborCodec / JsonCodec', () => {
     expect(decoded.Map).toEqual({ a: { String: 'x' } });
   });
 });
+
+describe('CborCodec undefined-value handling', () => {
+  // Regression coverage for the prod-only project-creation bug: `cborEncode` (unlike
+  // `JSON.stringify`) does not drop `undefined`-valued object properties -- it encodes them as
+  // CBOR's `undefined` simple value, which the backend rejects as an invalid payload. See
+  // `stripUndefined` in `codec.ts`.
+
+  it('omits an undefined-valued top-level property, matching JSON.stringify', () => {
+    const payload = { name: 'demo', allowedModels: undefined, billingPlan: 'free' };
+    const decoded = CborCodec.decode(CborCodec.encode(payload)) as Record<string, unknown>;
+    expect('allowedModels' in decoded).toBe(false);
+    expect(decoded).toEqual(JSON.parse(JSON.stringify(payload)));
+  });
+
+  it('omits an undefined-valued nested property', () => {
+    const payload = { project: { name: 'demo', allowedModels: undefined } };
+    const decoded = CborCodec.decode(CborCodec.encode(payload)) as {
+      project: Record<string, unknown>;
+    };
+    expect('allowedModels' in decoded.project).toBe(false);
+  });
+
+  it('still round-trips a present value at the same key', () => {
+    const payload = { name: 'demo', allowedModels: tagValue(['gpt-4']) };
+    const decoded = CborCodec.decode(CborCodec.encode(payload)) as typeof payload;
+    expect(untagValue(decoded.allowedModels)).toEqual(['gpt-4']);
+  });
+
+  it('still round-trips null, distinct from undefined, at the same key', () => {
+    const payload = { name: 'demo', allowedModels: null };
+    const decoded = CborCodec.decode(CborCodec.encode(payload)) as Record<string, unknown>;
+    expect(decoded.allowedModels).toBeNull();
+  });
+});

--- a/packages/authz-rpc/src/codec.ts
+++ b/packages/authz-rpc/src/codec.ts
@@ -20,10 +20,36 @@ export const JsonCodec: Codec = {
   },
 };
 
+/**
+ * Drops `undefined`-valued object properties (recursively) so `cborEncode` sees exactly what
+ * `JSON.stringify` would have kept. `JSON.stringify` silently omits `undefined`-valued keys;
+ * `cborEncode` has no such behavior and instead encodes them as CBOR's `undefined` simple value
+ * (RFC 8949 -- distinct from `null`), which the backend's generated `Option<T>` fields cannot
+ * deserialize (`invalid_argument` / "invalid request payload"). This only ever reproduced on the
+ * CBOR path (`defaultCodec()`'s production default) -- JSON traffic in dev/CI never hit it.
+ * `undefined` array *elements* are left as-is (cborg encodes them the same way and there's no
+ * JSON.stringify precedent to match -- `JSON.stringify` turns those into `null`, not a hole).
+ */
+function stripUndefined(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stripUndefined);
+  }
+  if (value !== null && typeof value === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      if (entry !== undefined) {
+        result[key] = stripUndefined(entry);
+      }
+    }
+    return result;
+  }
+  return value;
+}
+
 export const CborCodec: Codec = {
   contentType: 'application/cbor',
   encode(value: unknown): Uint8Array {
-    return cborEncode(value);
+    return cborEncode(stripUndefined(value));
   },
   decode(bytes: Uint8Array): unknown {
     if (bytes.length === 0) {


### PR DESCRIPTION
Source of truth: reported directly by the maintainer in a live debugging session and root-caused
in the same session (no separate ticket — the fix landed immediately). Sibling backend ticket for
the second bug found in the same session:
https://github.com/ADORSYS-GIS/lightbridge-authz/issues/147

## 1. Summary

This PR changes:

- `packages/authz-rpc/src/codec.ts` — `CborCodec.encode` now strips `undefined`-valued object
  properties (recursively) before handing the value to `cborg`'s `encode`.
- `packages/authz-rpc/src/codec.test.ts` — 4 new tests covering top-level/nested `undefined`
  omission, a present value still round-tripping, and `null` staying distinct from `undefined`.

It solves:

- Project creation was 400ing in production with a generic `invalid_argument` / "invalid request
  payload" error. `cborg` (the CBOR encoder `defaultCodec()` selects in production) does not drop
  `undefined`-valued object properties the way `JSON.stringify` does — it encodes them as CBOR's
  `undefined` simple value instead of omitting the key. The create-project screen never collects
  `allowedModels`, so every `createProject` call sent `{ ..., allowedModels: undefined, ... }`,
  which the backend's generated `Option<Json>` field cannot deserialize (CBOR `undefined` is a
  distinct type from `null`). JSON dev/CI traffic never hit this since `JSON.stringify` drops the
  key entirely — that's why it only reproduced in prod.

---

## 2. Intent

Fix the root cause of the prod project-creation outage at the source: the client should encode a
JS `undefined` the same way regardless of wire format, matching what `JSON.stringify` already does.
A companion backend fix ([lightbridge-authz#144](https://github.com/ADORSYS-GIS/lightbridge-authz/pull/144))
adds server-side leniency (treats wire-level CBOR `undefined` as `null`) as defense-in-depth, but
that shouldn't be the only place this is corrected — a misbehaving CBOR encoder is a client bug,
not something every server endpoint should have to tolerate.

---

## 3. Scope

### In Scope

- `CborCodec.encode`'s handling of `undefined`-valued properties.

### Out of Scope

- `projects.ts`'s `buildCreateProjectInput`/`tagProjectJsonFields` ternary
  (`allowedModels: input.allowedModels === undefined ? undefined : tagValue(...)`) — looked safe to
  simplify at first glance, but `tagValue()` calls `Object.entries()` on its argument and throws on
  a literal `undefined`, so the ternary guard is load-bearing, not dead code. Left untouched.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
pnpm --filter @lightbridge/authz-rpc test    # 3 test files, 15 tests passed
cd apps/self-service && npx tsc --noEmit -p tsconfig.json   # 0 errors (after regenerating the
                                                             # cratestack client, since it's gitignored)
pnpm test                                     # full workspace: 23 suites, 94 tests passed
npx eslint packages/authz-rpc/src/codec.ts packages/authz-rpc/src/codec.test.ts   # clean
npx prettier --check packages/authz-rpc/src/codec.ts packages/authz-rpc/src/codec.test.ts   # clean
```

Results:

```text
Test Files  3 passed (3)
     Tests  15 passed (15)   (was 11 before this PR's 4 new tests)
Test Suites: 23 passed, 23 total
Tests:       94 passed, 94 total
tsc: 0 errors
```

---

## 5. Screenshots / Evidence

Not applicable — a codec-internals fix with no UI surface; regression coverage is the 4 new unit
tests in `codec.test.ts`.

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* `stripUndefined` is a new recursive object/array walk applied to every CBOR-encoded request body
  in production. It only removes `undefined`-valued keys/leaves everything else untouched, so any
  existing request that never carried an `undefined` value encodes byte-for-byte identically to
  before.
* Array *elements* that are `undefined` are deliberately left as-is (not stripped), since `cborg`
  already encodes those the same way regardless, and there's no `JSON.stringify` precedent to match
  (`JSON.stringify` turns an `undefined` array element into `null`, not a hole) — documented in the
  function's doc comment so this isn't mistaken for an oversight later.

Mitigation:

* Covered directly by the 4 new tests; full workspace test suite (94 tests) re-verified green.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Generating tests

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

_(Human-verification checkboxes intentionally left unchecked — this PR was authored end-to-end by
Claude in an agentic session; @selast, please review before checking these off and merging.)_

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [x] Edge cases

Specific things worth a close look:
- Whether `stripUndefined`'s array-element behavior (left as-is, not stripped/nulled) is the right
  call — it matches `cborg`'s own existing behavior for arrays, just not `JSON.stringify`'s, and no
  current call site in this codebase passes `undefined` array elements today.

<!-- ai-governance:stanza -->
<!-- BEGIN: AI Governance stanza (managed by ADORSYS-GIS/ai-governance) -->
## AI Governance

Source of truth: [lightbridge-authz#147](https://github.com/ADORSYS-GIS/lightbridge-authz/issues/147)
is the sibling backend ticket for the *second* bug (default account/project deletion) found in the
same debugging session; this PR's own root cause (project creation 400ing in prod) was reported
directly by the maintainer and root-caused live — no separate ticket was filed for it since the fix
landed in the same session it was reported.

Source of truth and full doctrine: https://adorsys-gis.github.io/ai-governance/
<!-- END: AI Governance stanza -->
