### PR TITLE
feat(self-service): add Set as default action for accounts/projects

### DIFF
--- a/apps/self-service/src/screens/account-settings-screen.tsx
+++ b/apps/self-service/src/screens/account-settings-screen.tsx
@@ -11,6 +11,7 @@ import {
   usePermissions,
   useQueryState,
   useRemoveAccountMember,
+  useSetDefaultAccount,
   useUpdateAccount,
 } from '@lightbridge/hooks';
 import type { Account } from '@lightbridge/hooks';
@@ -41,6 +42,7 @@ export function AccountSettingsScreen({ embedded = false }: Readonly<{ embedded?
   const enableAccount = useEnableAccount();
   const addMember = useAddAccountMember();
   const removeMember = useRemoveAccountMember();
+  const setDefaultAccount = useSetDefaultAccount();
 
   // The Account model no longer carries a member/owners list on the wire —
   // membership is managed purely through add/removeAccountMember mutations,
@@ -90,11 +92,20 @@ export function AccountSettingsScreen({ embedded = false }: Readonly<{ embedded?
     void enableAccount.mutateAsync({ id: selectedAccount.id });
   };
 
+  const handleSetDefaultAccount = () => {
+    if (!selectedAccount?.id) return;
+    void setDefaultAccount.mutateAsync({ id: selectedAccount.id });
+  };
+
   const statusError = disableAccount.error
     ? getApiErrorMessage(disableAccount.error)
     : enableAccount.error
       ? getApiErrorMessage(enableAccount.error)
       : null;
+
+  const setDefaultError = setDefaultAccount.error
+    ? getApiErrorMessage(setDefaultAccount.error)
+    : null;
 
   const memberError = addMember.error
     ? getApiErrorMessage(addMember.error)
@@ -134,6 +145,10 @@ export function AccountSettingsScreen({ embedded = false }: Readonly<{ embedded?
       isChangingStatus={disableAccount.isPending || enableAccount.isPending}
       statusError={statusError}
       memberError={memberError}
+      isDefault={selectedAccount?.isDefault ?? false}
+      onSetDefaultAccount={handleSetDefaultAccount}
+      isSettingDefault={setDefaultAccount.isPending}
+      setDefaultError={setDefaultError}
     />
   );
 }

--- a/apps/self-service/src/screens/project-settings-screen.tsx
+++ b/apps/self-service/src/screens/project-settings-screen.tsx
@@ -8,6 +8,7 @@ import {
   usePermissions,
   useProjects,
   useQueryState,
+  useSetDefaultProject,
   useUpdateProject,
 } from '@lightbridge/hooks';
 import type { Account, Project } from '@lightbridge/hooks';
@@ -43,6 +44,7 @@ export function ProjectSettingsScreen({ embedded = false }: Readonly<{ embedded?
   const updateProject = useUpdateProject();
   const disableProject = useDisableProject();
   const enableProject = useEnableProject();
+  const setDefaultProject = useSetDefaultProject();
 
   const handleSelectAccount = (id: string) => {
     setAccountParam(id);
@@ -137,11 +139,20 @@ export function ProjectSettingsScreen({ embedded = false }: Readonly<{ embedded?
     void enableProject.mutateAsync({ id: project.id, accountId });
   };
 
+  const handleSetDefaultProject = () => {
+    if (!project || !accountId) return;
+    void setDefaultProject.mutateAsync({ id: project.id, accountId });
+  };
+
   const statusError = disableProject.error
     ? getApiErrorMessage(disableProject.error)
     : enableProject.error
       ? getApiErrorMessage(enableProject.error)
       : null;
+
+  const setDefaultError = setDefaultProject.error
+    ? getApiErrorMessage(setDefaultProject.error)
+    : null;
 
   return (
     <ProjectSettingsView
@@ -172,6 +183,9 @@ export function ProjectSettingsScreen({ embedded = false }: Readonly<{ embedded?
       onEnableProject={handleEnableProject}
       isChangingStatus={disableProject.isPending || enableProject.isPending}
       statusError={statusError}
+      onSetDefaultProject={handleSetDefaultProject}
+      isSettingDefault={setDefaultProject.isPending}
+      setDefaultError={setDefaultError}
     />
   );
 }

--- a/apps/self-service/src/views/settings/__tests__/account-settings-view.test.tsx
+++ b/apps/self-service/src/views/settings/__tests__/account-settings-view.test.tsx
@@ -26,6 +26,7 @@ function renderView(overrides: Partial<React.ComponentProps<typeof AccountSettin
       onDeleteAccount={noop}
       onSuspendAccount={noop}
       onEnableAccount={noop}
+      onSetDefaultAccount={noop}
       {...overrides}
     />
   );
@@ -100,10 +101,18 @@ describe('AccountSettingsView', () => {
           id: 'acc-1',
           billingIdentity: 'acme-inc',
           status: 'active',
+          isDefault: true,
           createdAt: '',
           updatedAt: '',
         },
-        { id: 'acc-2', billingIdentity: 'globex', status: 'active', createdAt: '', updatedAt: '' },
+        {
+          id: 'acc-2',
+          billingIdentity: 'globex',
+          status: 'active',
+          isDefault: false,
+          createdAt: '',
+          updatedAt: '',
+        },
       ],
       selectedAccountId: 'acc-1',
       onSelectAccount,
@@ -136,5 +145,27 @@ describe('AccountSettingsView', () => {
     await fireEvent.press(screen.getByText('Delete account'));
 
     expect(onDeleteAccount).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a Set as default action and an enabled Delete button for a non-default account', async () => {
+    const onSetDefaultAccount = jest.fn();
+    await renderView({ isDefault: false, onSetDefaultAccount });
+
+    await fireEvent.press(screen.getByText('Set as default'));
+    expect(onSetDefaultAccount).toHaveBeenCalledTimes(1);
+
+    expect(
+      screen.getByRole('button', { name: 'Delete account' }).props.accessibilityState.disabled
+    ).toBe(false);
+  });
+
+  it('replaces the Set as default action with a badge and disables Delete for the default account', async () => {
+    await renderView({ isDefault: true });
+
+    expect(screen.getByText('Default')).toBeTruthy();
+    expect(screen.queryByText('Set as default')).toBeNull();
+    expect(
+      screen.getByRole('button', { name: 'Delete account' }).props.accessibilityState.disabled
+    ).toBe(true);
   });
 });

--- a/apps/self-service/src/views/settings/__tests__/project-settings-view.test.tsx
+++ b/apps/self-service/src/views/settings/__tests__/project-settings-view.test.tsx
@@ -15,6 +15,7 @@ const account: Account = {
   id: 'acc-1',
   billingIdentity: 'acme-inc',
   status: 'active',
+  isDefault: true,
   createdAt: '2026-01-01T00:00:00Z',
   updatedAt: '2026-01-01T00:00:00Z',
 };
@@ -27,6 +28,7 @@ const project: Project = {
   allowedModels: ['gpt-4o'],
   defaultLimits: { requests_per_second: 5, requests_per_day: null, concurrent_requests: null },
   status: 'active',
+  isDefault: false,
   createdAt: '2026-01-01T00:00:00Z',
   updatedAt: '2026-01-02T00:00:00Z',
 };
@@ -50,6 +52,7 @@ function renderView(overrides: Partial<React.ComponentProps<typeof ProjectSettin
       onDeleteProject={noop}
       onSuspendProject={noop}
       onEnableProject={noop}
+      onSetDefaultProject={noop}
       {...overrides}
     />
   );
@@ -166,6 +169,28 @@ describe('ProjectSettingsView', () => {
     await fireEvent.press(screen.getByText('Delete project'));
 
     expect(onDeleteProject).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a Set as default action and an enabled Delete button for a non-default project', async () => {
+    const onSetDefaultProject = jest.fn();
+    await renderView({ onSetDefaultProject });
+
+    await fireEvent.press(screen.getByText('Set as default'));
+    expect(onSetDefaultProject).toHaveBeenCalledTimes(1);
+
+    expect(
+      screen.getByRole('button', { name: 'Delete project' }).props.accessibilityState.disabled
+    ).toBe(false);
+  });
+
+  it('replaces the Set as default action with a badge and disables Delete for the default project', async () => {
+    await renderView({ project: { ...project, isDefault: true } });
+
+    expect(screen.getByText('Default')).toBeTruthy();
+    expect(screen.queryByText('Set as default')).toBeNull();
+    expect(
+      screen.getByRole('button', { name: 'Delete project' }).props.accessibilityState.disabled
+    ).toBe(true);
   });
 
   it('renders the empty state with a create action when there is no project', async () => {

--- a/apps/self-service/src/views/settings/account-settings-view.tsx
+++ b/apps/self-service/src/views/settings/account-settings-view.tsx
@@ -51,6 +51,10 @@ type AccountSettingsViewProps = {
   isChangingStatus?: boolean;
   statusError?: string | null;
   memberError?: string | null;
+  isDefault?: boolean;
+  onSetDefaultAccount: () => void;
+  isSettingDefault?: boolean;
+  setDefaultError?: string | null;
 };
 
 export function AccountSettingsView({
@@ -82,6 +86,10 @@ export function AccountSettingsView({
   isChangingStatus = false,
   statusError = null,
   memberError = null,
+  isDefault = false,
+  onSetDefaultAccount,
+  isSettingDefault = false,
+  setDefaultError = null,
 }: Readonly<AccountSettingsViewProps>) {
   const { t } = useTranslation();
   const colors = useThemeColors();
@@ -188,6 +196,17 @@ export function AccountSettingsView({
                       key={account.id}
                       variant={account.id === selectedAccountId ? 'primary' : 'neutral'}
                       size="sm"
+                      leadingIcon={
+                        account.isDefault ? (
+                          <Feather
+                            name="star"
+                            size={12}
+                            color={
+                              account.id === selectedAccountId ? colors.surface : colors.subtle
+                            }
+                          />
+                        ) : undefined
+                      }
                       onPress={() => onSelectAccount(account.id)}
                       accessibilityLabel={t('settings.account.selectAccount', {
                         account: account.billingIdentity,
@@ -324,15 +343,55 @@ export function AccountSettingsView({
             </SectionCard>
           ) : null}
 
+          {canUpdate ? (
+            <SectionCard
+              tone="muted"
+              title={t('settings.account.defaultSection')}
+              description={
+                isDefault
+                  ? t('settings.account.defaultDescriptionCurrent')
+                  : t('settings.account.defaultDescription')
+              }>
+              <Stack gap="sm" align="start">
+                {isDefault ? (
+                  <Badge tone="info" icon={<Feather name="star" size={12} color={colors.accent} />}>
+                    {t('settings.account.defaultBadge')}
+                  </Badge>
+                ) : (
+                  <Button
+                    variant="neutral"
+                    size="sm"
+                    disabled={isSettingDefault}
+                    onPress={onSetDefaultAccount}
+                    style={{ alignSelf: 'flex-start' }}>
+                    {isSettingDefault
+                      ? t('settings.account.settingDefault')
+                      : t('settings.account.setDefault')}
+                  </Button>
+                )}
+                {setDefaultError ? (
+                  <Text intent="caption" style={{ color: colors.error }}>
+                    {setDefaultError}
+                  </Text>
+                ) : null}
+              </Stack>
+            </SectionCard>
+          ) : null}
+
           {canDelete ? (
             <SectionCard
               tone="danger"
               title={t('settings.account.dangerSection')}
-              description={t('settings.account.dangerDescription')}>
+              description={
+                isDefault
+                  ? t('settings.account.dangerDescriptionDefault')
+                  : t('settings.account.dangerDescription')
+              }>
               <Stack align="start">
                 <Button
                   variant="danger"
                   size="sm"
+                  disabled={isDefault}
                   onPress={onDeleteAccount}
                   style={{ alignSelf: 'flex-start' }}>
                   {t('settings.account.deleteAccount')}

--- a/apps/self-service/src/views/settings/project-settings-view.tsx
+++ b/apps/self-service/src/views/settings/project-settings-view.tsx
@@ -77,6 +77,9 @@ type ProjectSettingsViewProps = {
   onEnableProject: () => void;
   isChangingStatus?: boolean;
   statusError?: string | null;
+  onSetDefaultProject: () => void;
+  isSettingDefault?: boolean;
+  setDefaultError?: string | null;
 };
 
 /** Renders a nullable numeric limit as a text-field draft ('' = no limit). */
@@ -121,6 +124,9 @@ export function ProjectSettingsView({
   onEnableProject,
   isChangingStatus = false,
   statusError = null,
+  onSetDefaultProject,
+  isSettingDefault = false,
+  setDefaultError = null,
 }: Readonly<ProjectSettingsViewProps>) {
   const { t, i18n } = useTranslation();
   const colors = useThemeColors();
@@ -289,6 +295,15 @@ export function ProjectSettingsView({
                         key={item.id}
                         variant={item.id === selectedProjectId ? 'primary' : 'neutral'}
                         size="sm"
+                        leadingIcon={
+                          item.isDefault ? (
+                            <Feather
+                              name="star"
+                              size={12}
+                              color={item.id === selectedProjectId ? colors.surface : colors.subtle}
+                            />
+                          ) : undefined
+                        }
                         onPress={() => onSelectProject(item.id)}
                         accessibilityLabel={t('settings.project.selectProject', {
                           project: item.name,
@@ -498,15 +513,57 @@ export function ProjectSettingsView({
                 </SectionCard>
               ) : null}
 
+              {canUpdate ? (
+                <SectionCard
+                  tone="muted"
+                  title={t('settings.project.defaultSection')}
+                  description={
+                    project.isDefault
+                      ? t('settings.project.defaultDescriptionCurrent')
+                      : t('settings.project.defaultDescription')
+                  }>
+                  <Stack gap="sm" align="start">
+                    {project.isDefault ? (
+                      <Badge
+                        tone="info"
+                        icon={<Feather name="star" size={12} color={colors.accent} />}>
+                        {t('settings.project.defaultBadge')}
+                      </Badge>
+                    ) : (
+                      <Button
+                        variant="neutral"
+                        size="sm"
+                        disabled={isSettingDefault}
+                        onPress={onSetDefaultProject}
+                        style={{ alignSelf: 'flex-start' }}>
+                        {isSettingDefault
+                          ? t('settings.project.settingDefault')
+                          : t('settings.project.setDefault')}
+                      </Button>
+                    )}
+                    {setDefaultError ? (
+                      <Text intent="caption" style={{ color: colors.error }}>
+                        {setDefaultError}
+                      </Text>
+                    ) : null}
+                  </Stack>
+                </SectionCard>
+              ) : null}
+
               {canDelete ? (
                 <SectionCard
                   tone="danger"
                   title={t('settings.project.dangerSection')}
-                  description={t('settings.project.dangerDescription')}>
+                  description={
+                    project.isDefault
+                      ? t('settings.project.dangerDescriptionDefault')
+                      : t('settings.project.dangerDescription')
+                  }>
                   <Stack align="start">
                     <Button
                       variant="danger"
                       size="sm"
+                      disabled={project.isDefault}
                       onPress={onDeleteProject}
                       style={{ alignSelf: 'flex-start' }}>
                       {t('settings.project.deleteProject')}

--- a/packages/authz-rpc/schema/authz.cstack
+++ b/packages/authz-rpc/schema/authz.cstack
@@ -44,6 +44,7 @@ model Account {
   // generated create/update inputs so a raw RPC caller cannot supply a born-suspended
   // status, matching `ApiKey.status` below.
   status String @readonly
+  isDefault Boolean @readonly
   projects Project[] @relation(fields:[id],references:[accountId])
   memberships AccountMembership[] @relation(fields:[id],references:[accountId])
 
@@ -57,6 +58,16 @@ model Account {
   // `createAccount` procedure, which inserts the account and the creator's membership in
   // one transaction, and `model.Account.create` is also denied unconditionally at the
   // RBAC layer (crates/lightbridge-authz-rest/src/rpc_authorize.rs).
+  //
+  // isDefault is set once, server-side, inside `createAccount` -- true only if the creating
+  // subject had zero prior account memberships at that moment (their genuine first/bootstrap
+  // account). `deleteAccountPermanently` (hand-written SQL) refuses to delete a default
+  // account -- disableAccount (suspend) still works on it. `@readonly` keeps it out of the
+  // generated create/update inputs, same as `status` above; it is reassignable, but only through
+  // the dedicated `setDefaultAccount` procedure below (hand-written SQL, same pattern as
+  // disableAccount/enableAccount), which atomically unsets the subject's current default account
+  // before setting the new one -- a raw `model.Account.update` caller can never flip it directly,
+  // and can't race the unset/set pair against itself the way a generic field update would allow.
   //
   // NOTE: no `@@allow("delete", ...)` either, as of the membership-roles change. Account
   // deletion is now owner-only, and cratestack's relation-quantifier policy predicates can't
@@ -87,6 +98,20 @@ model Project {
   // by disable/enable procedures + DB `DEFAULT 'active'`, `@readonly` so it is absent from
   // the generic `model.Project.create`/`update` inputs.
   status String @readonly
+  // Set once, server-side, by a `BEFORE INSERT` trigger (`migrations/20260725000001_default_
+  // account_project.sql`) -- true only for an account's first-ever project. `@readonly` keeps it
+  // out of the generic create/update inputs; unlike Account/ApiKey, Project creation was never
+  // moved to a hand-written procedure (see `@@allow("create", ...)` below), so cratestack's
+  // generic `model.Project.create` verb has no hook for this per-request "is this the account's
+  // first project" computation -- the DB trigger is the only mechanism available. A partial
+  // unique index backstops the race where two concurrent first-project creates for the same
+  // brand-new account would otherwise both see zero existing rows. Gates `@@allow("delete", ...)`
+  // below -- a default project can still be suspended (disableProject) but never hard-deleted.
+  // Reassignable within the account via the dedicated `setDefaultProject` procedure below
+  // (hand-written SQL, same shape as `setDefaultAccount`), which atomically unsets the account's
+  // current default project before setting the new one -- the partial unique index above still
+  // backstops the invariant even if two reassignments race.
+  isDefault Boolean @readonly
   account Account @relation(fields:[accountId],references:[id])
   apiKeys ApiKey[] @relation(fields:[id],references:[projectId])
 
@@ -95,7 +120,7 @@ model Project {
   @@allow("create", account.memberships.some.subject == auth().id)
   @@allow("read", account.memberships.some.subject == auth().id)
   @@allow("update", account.memberships.some.subject == auth().id)
-  @@allow("delete", account.memberships.some.subject == auth().id)
+  @@allow("delete", isDefault != true && account.memberships.some.subject == auth().id)
 }
 
 // Field-level immutability closes the gap the coarse RBAC gate cannot express on
@@ -336,4 +361,30 @@ mutation procedure disableProject(args: ProjectStatusInput): Project
   @allow(auth() != null)
 
 mutation procedure enableProject(args: ProjectStatusInput): Project
+  @allow(auth() != null)
+
+// Reassign the default account/project (escape hatch for the "default can never be hard-deleted"
+// policy above -- without this, the first account/project a subject ever creates is permanently
+// undeletable). Any member of the account may promote a different row to default -- same coarse
+// membership check as everywhere else on this surface, no extra owner/admin gate (deletion itself
+// carries none either, for Project; Account deletion is owner-only but reassigning default status
+// is a strictly less destructive operation than that). Hand-written sqlx in `StoreRepo::
+// set_default_account` / `set_default_project`: each atomically unsets the current default before
+// setting the new one inside a single transaction, so the "at most one default" invariant never
+// observes two rows true (or zero) at once, and rejects (NotFound) a target that doesn't belong to
+// the caller's account. The `@allow(auth() != null)` gate only asserts an authenticated caller; the
+// coarse `account:update` / `project:update` capability is enforced by the RBAC layer, and the real
+// membership check lives in the hand-written SQL, same pattern as disableAccount/disableProject.
+type SetDefaultAccountInput {
+  accountId String
+}
+
+mutation procedure setDefaultAccount(args: SetDefaultAccountInput): Account
+  @allow(auth() != null)
+
+type SetDefaultProjectInput {
+  projectId String
+}
+
+mutation procedure setDefaultProject(args: SetDefaultProjectInput): Project
   @allow(auth() != null)

--- a/packages/hooks/src/accounts.ts
+++ b/packages/hooks/src/accounts.ts
@@ -94,6 +94,24 @@ export function useEnableAccount() {
   };
 }
 
+export function useSetDefaultAccount() {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async ({ id }: { id: string }): Promise<Account> =>
+      getAuthzRpcClient().procedures.setDefaultAccount({ args: { accountId: id } }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: accountsQueryKey });
+    },
+  });
+
+  return {
+    isPending: mutation.isPending,
+    error: mutation.error,
+    mutateAsync: mutation.mutateAsync,
+  };
+}
+
 export function useAddAccountMember() {
   const queryClient = useQueryClient();
 

--- a/packages/hooks/src/projects.ts
+++ b/packages/hooks/src/projects.ts
@@ -31,6 +31,11 @@ function buildCreateProjectInput(accountId: string, fields: CreateProjectFields)
     defaultLimits: {},
     billingPlan: fields.billingPlan,
     status: 'active',
+    // `isDefault` is `@readonly` server-side (set by the `projects_set_is_default` trigger — true
+    // only for an account's first-ever project) but, unlike the Rust codegen, the TS generator
+    // doesn't drop `@readonly` fields from `CreateProjectInput`, so it must still be supplied here.
+    // Any caller-supplied value is ignored server-side, same as `status` above.
+    isDefault: false,
   };
 }
 
@@ -182,6 +187,26 @@ export function useEnableProject() {
   const mutation = useMutation({
     mutationFn: async ({ id }: { id: string; accountId: string }) =>
       untagProject(await getAuthzRpcClient().procedures.enableProject({ args: { projectId: id } })),
+    onSuccess: (_, { accountId }) => {
+      queryClient.invalidateQueries({ queryKey: projectsQueryKey(accountId) });
+    },
+  });
+
+  return {
+    isPending: mutation.isPending,
+    error: mutation.error,
+    mutateAsync: mutation.mutateAsync,
+  };
+}
+
+export function useSetDefaultProject() {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async ({ id }: { id: string; accountId: string }) =>
+      untagProject(
+        await getAuthzRpcClient().procedures.setDefaultProject({ args: { projectId: id } })
+      ),
     onSuccess: (_, { accountId }) => {
       queryClient.invalidateQueries({ queryKey: projectsQueryKey(accountId) });
     },

--- a/packages/i18n/src/i18n-config.ts
+++ b/packages/i18n/src/i18n-config.ts
@@ -181,9 +181,19 @@ const resources = {
           suspending: 'Suspending...',
           enableAccount: 'Reactivate account',
           enabling: 'Reactivating...',
+          defaultSection: 'Default account',
+          defaultDescription:
+            'Your default account cannot be permanently deleted. Promote this account to free up your current default for deletion.',
+          defaultDescriptionCurrent:
+            'This is your default account. It cannot be permanently deleted until another account is promoted.',
+          defaultBadge: 'Default',
+          setDefault: 'Set as default',
+          settingDefault: 'Setting as default...',
           dangerSection: 'Danger zone',
           dangerDescription:
             'Deleting this account removes it and everything under it. This cannot be undone.',
+          dangerDescriptionDefault:
+            'This is your default account and cannot be permanently deleted. Set another account as default first.',
           deleteAccount: 'Delete account',
         },
         project: {
@@ -235,9 +245,19 @@ const resources = {
           suspending: 'Suspending...',
           enableProject: 'Reactivate project',
           enabling: 'Reactivating...',
+          defaultSection: 'Default project',
+          defaultDescription:
+            'Your account’s default project cannot be permanently deleted. Promote this project to free up the current default for deletion.',
+          defaultDescriptionCurrent:
+            'This is your account’s default project. It cannot be permanently deleted until another project is promoted.',
+          defaultBadge: 'Default',
+          setDefault: 'Set as default',
+          settingDefault: 'Setting as default...',
           dangerSection: 'Danger zone',
           dangerDescription:
             'Deleting this project removes its API keys and usage history. This cannot be undone.',
+          dangerDescriptionDefault:
+            'This is your account’s default project and cannot be permanently deleted. Set another project as default first.',
           deleteProject: 'Delete project',
         },
       },


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Syncs `packages/authz-rpc/schema/authz.cstack` with the backend's new `setDefaultAccount`/`setDefaultProject` procedures and regenerates the TypeScript RPC client (`cratestack generate-typescript`).
- Adds `useSetDefaultAccount` / `useSetDefaultProject` hooks (`packages/hooks/src/accounts.ts`, `projects.ts`).
- Adds a "Set as default" action to the account and project settings screens, replaced by a "Default" badge on the row that's already default; also disables that row's "Delete" button (with an explanatory description) until another row is promoted.
- Fixes a latent gap in `buildCreateProjectInput`: the TS codegen (unlike the Rust side) doesn't drop `@readonly` fields from `CreateProjectInput`, so `isDefault` needed an explicit `false` there (mirroring the existing `status: 'active'` workaround).

It solves:

- Without this, the account/project a subject's `createAccount` call (or an account's first project) auto-provisions can never be permanently deleted — there was no way to free it up. Source of truth: https://github.com/ADORSYS-GIS/lightbridge-authz/issues/151 (tracking ticket); backend implementation: https://github.com/ADORSYS-GIS/lightbridge-authz/pull/152

---

## 2. Intent

Give an owner/member a way to promote a different account/project to default so the old default becomes freely deletable, without weakening the "default can't be hard-deleted" safety rail itself.

---

## 3. Scope

### In Scope

- Frontend schema copy + codegen sync for the two new procedures.
- Hooks + UI wiring for "Set as default" on both settings screens.
- Disabling (not hiding) the Delete action on the current default row, with a hint pointing at "Set as default".

### Out of Scope

- Backend implementation (schema, repo transaction logic, RBAC, MCP tools) — that's https://github.com/ADORSYS-GIS/lightbridge-authz/pull/152, still open. **This PR depends on that one merging and deploying before `setDefaultAccount`/`setDefaultProject` actually resolve on a live backend** — the UI action will otherwise 404/fail until then.
- Any new role gate (owner/admin-only) for this action — matches the backend's decision to allow any account member.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
pnpm --filter self-service test
pnpm --filter @lightbridge/hooks test
pnpm --filter @lightbridge/authz-rpc test
pnpm --filter self-service exec tsc --noEmit -p tsconfig.json
pnpm build
pnpm lint
```

Results:

```text
self-service: 98/98 tests passed (includes new "Set as default"/badge/disabled-delete coverage)
@lightbridge/hooks: 9/9 passed
@lightbridge/authz-rpc: 15/15 passed
tsc --noEmit: clean
pnpm build (expo export --platform web): succeeded
pnpm lint: pre-existing failures only (verified identical error/warning count with and without this diff — unrelated generated-file/story-file issues, not introduced here)
```

Manually verified in the browser preview (temporary ungated `/preview` route rendering `AccountSettingsView`/`ProjectSettingsView` with mock props, reverted before commit): the star indicator on the default chip, the "Set as default" button on a non-default row, the "Default" badge replacing it on the current default, and the disabled "Delete" button with its explanatory copy — for both accounts and projects.

---

## 5. Screenshots / Evidence

See the manual browser-preview verification described above (not persisted as files; reproducible via the same temporary `/preview` route pattern documented in this repo's own screen-testing convention).

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* The RPC calls (`setDefaultAccount`/`setDefaultProject`) will fail against a backend that hasn't yet merged/deployed https://github.com/ADORSYS-GIS/lightbridge-authz/pull/152.

Mitigation:

* Land and deploy the backend PR first (or alongside); the UI action surfaces the resulting error via the existing `getApiErrorMessage` path (same pattern as suspend/enable) rather than failing silently.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Generating tests
* [x] Reviewing the diff
* [ ] Refactoring
* [ ] Drafting documentation
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [x] Tests
* [ ] Performance
* [ ] Maintainability
* [x] Product intent
* [x] Edge cases

