### PR TITLE
fix(quality): correct fabricated action SHAs in quality.yml

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -24,15 +24,15 @@ jobs:
     runs-on: adorsys-gis-runner
     steps:
       - name: Checkout
-        uses: actions/checkout@3a9b7a1ccad09a3a8e33c0d1a059f9510a9a5f59  # v4.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0  # Required for reviewdog diffs on PRs
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Code Scanning
         if: always() && github.event_name != 'pull_request' && vars.ENABLE_CODE_SCANNING == 'true'
-        uses: github/codeql-action/upload-sarif@461ef6c76dbb2f00f3024de635e4ee55e083440ba  # v3.24.0
+        uses: github/codeql-action/upload-sarif@4187e74d05793876e9989daffde9c3e66b4acd07  # v3.37.3
         with:
           sarif_file: .ci/quality/reports/quality.sarif
           category: quality-pipeline
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload reports as artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: quality-reports
           path: .ci/quality/reports/


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Corrects `actions/checkout` and `github/codeql-action/upload-sarif` pins in `.github/workflows/quality.yml`, which were fabricated SHAs that do not resolve to any real commit
- Pins the three remaining floating-tag actions (`pnpm/action-setup@v6`, `actions/setup-node@v7`, `actions/upload-artifact@v4`) to full commit SHAs, per the original task requirement

It solves:

- The `Quality` workflow failing at the very first step ("Set up job") on every run since #126 merged, discovered via the verification PR #127

---

## 2. Intent

> #126 required every external action to be pinned to a full commit SHA with the human-readable version documented in a comment. Two of the five actions were pinned to SHAs that do not exist in their respective repos (invalid/fabricated), and three more were left on floating major-version tags (`@v6`, `@v7`, `@v4`) instead of being pinned at all. This broke the workflow outright: "Unable to resolve action `actions/checkout@3a9b7a1c...`" — confirmed by running PR #127 against the merged workflow.

---

## 3. Scope

### In Scope

- `.github/workflows/quality.yml` action pin corrections only

### Out of Scope

- Any other workflow file (pre-existing use of floating tags elsewhere, e.g. `test.yml`, is out of scope for this fix)
- Any change to scanner logic, scripts, or documentation

---

## 4. Verification

I verified this change by:

- [x] Checking logs (the actual failed run: https://github.com/ADORSYS-GIS/converse-frontends/actions/runs/30332955654)
- [x] Running manual tests (resolved every SHA against the live GitHub API, not guessed)
- [ ] Running automated tests
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
gh api repos/actions/checkout/git/refs/tags/v7.0.1 -q ".object.sha, .object.type"
gh api repos/pnpm/action-setup/git/refs/tags/v6.0.9 -q ".object.sha"
gh api repos/actions/setup-node/git/refs/tags/v7.0.0 -q ".object.sha"
gh api repos/github/codeql-action/git/refs/tags/v3.37.3 -q ".object.sha, .object.type"
gh api repos/github/codeql-action/git/tags/<tag-object-sha> -q ".object.sha"   # annotated tag -> commit
gh api repos/actions/upload-artifact/git/refs/tags/v4.6.2 -q ".object.sha"
gh api 'repos/github/codeql-action/contents/upload-sarif/action.yml?ref=<resolved-sha>' -q ".path"  # confirm monorepo subpath exists at that SHA
actionlint .github/workflows/quality.yml
python3 -c "import yaml; yaml.safe_load(open(\".github/workflows/quality.yml\"))"
```

Results:

```text
actions/checkout@v7.0.1        -> 3d3c42e5aac5ba805825da76410c181273ba90b1 (commit)
pnpm/action-setup@v6.0.9       -> 0ebf47130e4866e96fce0953f49152a61190b271
actions/setup-node@v7.0.0      -> 820762786026740c76f36085b0efc47a31fe5020
codeql-action/upload-sarif
  @v3.37.3                     -> 4187e74d05793876e9989daffde9c3e66b4acd07 (resolved through annotated tag)
actions/upload-artifact@v4.6.2 -> ea165f8d65b6e75b540449e92b4886f43607fa02

upload-sarif/action.yml exists at resolved SHA: confirmed via contents API
YAML syntax OK
actionlint: only the pre-existing repo-wide "adorsys-gis-runner label unknown"
  warning (same as test.yml, docker-image.yml, etc.) — no new findings
```

---

## 5. Screenshots / Evidence

* Logs: https://github.com/ADORSYS-GIS/converse-frontends/actions/runs/30332955654 (failed run showing "Unable to resolve action")
* This PR, once its own Quality check runs, is the evidence the fix works

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* A future action release could move a tag (extremely rare for these actions; SHAs are immutable regardless)

Mitigation:

* Every SHA was resolved live from the GitHub API at PR time, not carried over from the original (fabricated) values

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code (diagnosing the failed run)
* [x] Generating code (the fix itself)
* [x] Reviewing the diff

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [x] I accept responsibility for this PR
* [ ] I checked generated tests manually (n/a)
* [ ] I removed unsupported AI assumptions (n/a)

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness (do these SHAs actually correspond to the tags claimed?)
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [ ] Edge cases

Source of truth: #126, #127