### PR TITLE
feat(authz-rpc): adopt cratestack 0.4.16 RPC batching (plumbing + activation)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -43,13 +43,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.local/bin/cratestack
-          key: cratestack-cli-0.4.13-${{ runner.os }}-${{ runner.arch }}
+          key: cratestack-cli-0.4.16-${{ runner.os }}-${{ runner.arch }}
 
-      # 0.4.13 ships prebuilt binaries on GH Releases — no Rust toolchain needed.
+      # 0.4.16 ships prebuilt binaries on GH Releases — no Rust toolchain needed.
       - name: Install cratestack-cli
         if: steps.cratestack-cache.outputs.cache-hit != 'true'
         env:
-          CRATESTACK_VERSION: '0.4.13'
+          CRATESTACK_VERSION: '0.4.16'
         run: |
           set -euo pipefail
           case "$(uname -m)" in

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,13 +34,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.local/bin/cratestack
-          key: cratestack-cli-0.4.13-${{ runner.os }}-${{ runner.arch }}
+          key: cratestack-cli-0.4.16-${{ runner.os }}-${{ runner.arch }}
 
-      # 0.4.13 ships prebuilt binaries on GH Releases — no Rust toolchain needed.
+      # 0.4.16 ships prebuilt binaries on GH Releases — no Rust toolchain needed.
       - name: Install cratestack-cli
         if: steps.cratestack-cache.outputs.cache-hit != 'true'
         env:
-          CRATESTACK_VERSION: '0.4.13'
+          CRATESTACK_VERSION: '0.4.16'
         run: |
           set -euo pipefail
           case "$(uname -m)" in

--- a/apps/self-service/package.json
+++ b/apps/self-service/package.json
@@ -17,6 +17,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@cratestack/api": "^0.4.16",
     "@expo/vector-icons": "15.1.1",
     "@gorhom/bottom-sheet": "^5.2.14",
     "@lightbridge/api-native": "workspace:*",

--- a/apps/self-service/src/app/_layout.tsx
+++ b/apps/self-service/src/app/_layout.tsx
@@ -21,6 +21,7 @@ import {
   getLatestAuthSession,
 } from '@lightbridge/hooks';
 import { APP_FONT_SOURCES, useAppFonts } from '@lightbridge/ui';
+import { createBatchLink } from '@cratestack/api';
 import { queryClient } from '../queries';
 import { useAuthzRpcClient } from '@lightbridge/authz-rpc';
 import { isWebPlatform } from '@lightbridge/api-native';
@@ -32,6 +33,12 @@ import { AppSheetProvider } from '../navigation/app-sheet-provider';
 WebBrowser.maybeCompleteAuthSession();
 enableScreens();
 void SplashScreen.preventAutoHideAsync();
+
+// Module-scope, not per-render: `links` is a construction-only option on `AuthzRpcRuntime` (see
+// its doc comment) — `useAuthzRpcClient` only re-applies it on the very first call anyway, but a
+// single shared scheduler instance also avoids ever having two independent batch queues alive at
+// once, which a fresh `createBatchLink()` per render would risk.
+const authzBatchLink = createBatchLink();
 
 function AppBootstrap() {
   const runtimeConfig = useRuntimeConfig();
@@ -67,6 +74,7 @@ function AppBootstrap() {
   useAuthzRpcClient({
     baseURL: runtimeConfig.backendUrl,
     basePath: runtimeConfig.apiBasePath,
+    links: [authzBatchLink],
     auth: async () => {
       if (!isHydrated) {
         return '';

--- a/docs/knowledge/architecture-conventions.md
+++ b/docs/knowledge/architecture-conventions.md
@@ -36,7 +36,19 @@ turned into the generated client under `packages/authz-rpc/generated/` by the of
 `generated/` is gitignored, same as every other package's codegen output (e.g. `api-rest`'s
 `src/client/`) — it's a build artifact, not source. Regenerate it locally with
 `pnpm --filter @lightbridge/authz-rpc codegen:cratestack`; CI (`test.yml`, `docker-image.yml`)
-installs a cached `cratestack-cli` and runs the same command before tests/build.
+installs a cached `cratestack-cli` (pinned to `0.4.16`) and runs the same command before
+tests/build.
+
+Since `cratestack-cli` 0.4.14 (issue #182), the generated runtime accepts a composable
+`links?: RpcLink[]` interceptor chain, threaded through as `AuthzRpcRuntimeOptions.links`
+(`packages/authz-rpc/src/runtime.ts`). `@cratestack/api`'s `createBatchLink()` plugs into it —
+an automatic scheduler that collapses concurrent unary calls into one `POST /rpc/batch` request —
+and is exercised in `packages/authz-rpc/src/runtime.test.ts`, but **is not wired into the app
+root** (`apps/self-service/src/app/_layout.tsx`'s `useAuthzRpcClient(config)` call omits `links`).
+Activating it end-to-end is tracked separately
+([converse-frontends#120](https://github.com/ADORSYS-GIS/converse-frontends/issues/120)); the
+backend RBAC gate for `POST /rpc/batch` was fixed to authorize per-frame in
+[lightbridge-authz#157](https://github.com/ADORSYS-GIS/lightbridge-authz/issues/157).
 
 **Rule:** Never place application-specific business logic in `packages/`. Packages export reusable, app-agnostic code only.
 

--- a/packages/authz-rpc/package.json
+++ b/packages/authz-rpc/package.json
@@ -12,6 +12,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@cratestack/api": "^0.4.16",
     "@paralleldrive/cuid2": "^2.2.2",
     "cborg": "^4.2.9"
   },

--- a/packages/authz-rpc/src/runtime.test.ts
+++ b/packages/authz-rpc/src/runtime.test.ts
@@ -1,6 +1,8 @@
+import { createBatchLink } from '@cratestack/api';
 import { describe, expect, it, vi } from 'vitest';
 
 import { LightbridgeAuthzRpcClient } from '../generated/src/client';
+import { CratestackRpcError } from '../generated/src/runtime';
 import { CborCodec, JsonCodec } from './codec';
 import { AuthzRpcRuntime } from './runtime';
 
@@ -12,6 +14,26 @@ const accountPage = {
       id: 'acc_01',
       billingIdentity: 'corp-identity-001',
       status: 'active',
+      createdAt: '2024-01-01T12:00:00Z',
+      updatedAt: '2024-01-01T12:00:00Z',
+    },
+  ],
+  totalCount: 1,
+  pageInfo: { limit: 10, offset: 0, hasNextPage: false, hasPreviousPage: false },
+};
+
+const projectPage = {
+  items: [
+    {
+      id: 'proj_01',
+      accountId: 'acc_01',
+      name: 'Test Project',
+      billingPlan: 'free',
+      status: 'active',
+      isDefault: true,
+      defaultLimits: {},
+      account: { id: 'acc_01' },
+      apiKeys: [],
       createdAt: '2024-01-01T12:00:00Z',
       updatedAt: '2024-01-01T12:00:00Z',
     },
@@ -112,5 +134,115 @@ describe('AuthzRpcRuntime + generated client', () => {
     expect(refreshAuth).toHaveBeenCalledTimes(1);
     expect(fetchFn).toHaveBeenCalledTimes(2);
     expect(page.items).toHaveLength(1);
+  });
+});
+
+// `AuthzRpcRuntime` always encodes request bodies through our `Codec` (JSON here), which returns
+// a `Uint8Array`, not a string — decode it the same way the runtime's own `readErrorBody`/
+// `readUnaryResponse` do before parsing as JSON.
+function decodeBatchRequestBody(body: BodyInit | null | undefined): { id: number; op: string }[] {
+  return JSON.parse(new TextDecoder().decode(body as Uint8Array)) as { id: number; op: string }[];
+}
+
+// Proves `AuthzRpcRuntime`'s `links` passthrough (ticket #119) actually activates
+// `@cratestack/api`'s `createBatchLink()` correctly end to end — this link is not yet wired into
+// the app root (see ticket #120), so this is the only place it's exercised today.
+describe('AuthzRpcRuntime with createBatchLink()', () => {
+  it('collapses two concurrent calls issued in the same tick into one POST /rpc/batch request', async () => {
+    const fetchFn = vi.fn(async (url: string, init: RequestInit) => {
+      expect(url).toBe('https://api.example.com/api/rpc/batch');
+      const requests = decodeBatchRequestBody(init.body);
+      const frames = requests.map((request) => ({
+        id: request.id,
+        output: request.op === 'model.Account.list' ? accountPage : projectPage,
+      }));
+      return new Response(JSON.stringify(frames), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+
+    const authz = new AuthzRpcRuntime('https://api.example.com', {
+      auth: async () => 'test-token',
+      codec: JsonCodec,
+      fetch: fetchFn as unknown as typeof fetch,
+      links: [createBatchLink()],
+    });
+    const client = new LightbridgeAuthzRpcClient(authz.runtime);
+
+    const [accounts, projects] = await Promise.all([
+      client.accounts.list({ limit: 10, offset: 0 }),
+      client.projects.list({ limit: 10, offset: 0 }),
+    ]);
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(accounts.items[0].billingIdentity).toBe('corp-identity-001');
+    expect(projects.items[0].name).toBe('Test Project');
+  });
+
+  it('fails only the errored frame, leaving the rest of the same batch unaffected', async () => {
+    const fetchFn = vi.fn(async (_url: string, init: RequestInit) => {
+      const requests = decodeBatchRequestBody(init.body);
+      const frames = requests.map((request) =>
+        request.op === 'model.Project.list'
+          ? { id: request.id, error: { code: 'not_found', message: 'no such project' } }
+          : { id: request.id, output: accountPage }
+      );
+      return new Response(JSON.stringify(frames), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+
+    const authz = new AuthzRpcRuntime('https://api.example.com', {
+      auth: async () => 'test-token',
+      codec: JsonCodec,
+      fetch: fetchFn as unknown as typeof fetch,
+      links: [createBatchLink()],
+    });
+    const client = new LightbridgeAuthzRpcClient(authz.runtime);
+
+    const [accountsResult, projectsResult] = await Promise.allSettled([
+      client.accounts.list({ limit: 10, offset: 0 }),
+      client.projects.list({ limit: 10, offset: 0 }),
+    ]);
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(accountsResult.status).toBe('fulfilled');
+    expect(projectsResult.status).toBe('rejected');
+    if (projectsResult.status === 'rejected') {
+      expect(projectsResult.reason).toBeInstanceOf(CratestackRpcError);
+      expect((projectsResult.reason as CratestackRpcError).code).toBe('not_found');
+    }
+  });
+
+  it('still wraps a call issued in isolation as a one-frame /rpc/batch request', async () => {
+    const fetchFn = vi.fn(async (url: string, init: RequestInit) => {
+      // `createBatchLink()` unconditionally routes every unary call through `/rpc/batch` once
+      // its scheduling window flushes — there is no size-1 special case that falls back to a
+      // plain `/rpc/{op_id}` request. Collapsing only happens incidentally, when 2+ calls share
+      // a window; a lone call still pays the one-frame batch envelope.
+      expect(url).toBe('https://api.example.com/api/rpc/batch');
+      const requests = decodeBatchRequestBody(init.body);
+      expect(requests).toHaveLength(1);
+      expect(requests[0].op).toBe('model.Account.list');
+      return new Response(JSON.stringify([{ id: requests[0].id, output: accountPage }]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+
+    const authz = new AuthzRpcRuntime('https://api.example.com', {
+      auth: async () => 'test-token',
+      codec: JsonCodec,
+      fetch: fetchFn as unknown as typeof fetch,
+      links: [createBatchLink()],
+    });
+    const client = new LightbridgeAuthzRpcClient(authz.runtime);
+
+    const page = await client.accounts.list({ limit: 10, offset: 0 });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(page.items[0].billingIdentity).toBe('corp-identity-001');
   });
 });

--- a/packages/authz-rpc/src/runtime.ts
+++ b/packages/authz-rpc/src/runtime.ts
@@ -13,7 +13,10 @@ import {
   type CratestackRpcClientOptions,
   type CratestackRpcCodec,
 } from '../generated/src/runtime';
+import type { RpcLink } from '../generated/src/links';
 import { type Codec, defaultCodec } from './codec';
+
+export type { RpcLink } from '../generated/src/links';
 
 /**
  * Adapts our `Codec` (`encode(): Uint8Array`) to the generated `CratestackRpcCodec`
@@ -41,6 +44,13 @@ export type AuthzRpcRuntimeOptions = {
    *  `fetch`. Mainly for tests — the generated runtime's own `fetch` option is always set to
    *  `authenticatedFetch` by this class, so this is the real injection point instead. */
   fetch?: typeof fetch;
+  /** Passed straight through to the generated `CratestackRpcRuntime`'s composable interceptor
+   *  chain (cratestack issue #182). Construction-only, like `basePath`/`codec` above — changing
+   *  it on a later `configure()` call has no effect, since `configure()` only swaps the mutable
+   *  auth closures, not the underlying runtime. Omitted by default everywhere in this app today;
+   *  see `@cratestack/api`'s `createBatchLink()` for the automatic-batching link this exists to
+   *  support. */
+  links?: RpcLink[];
 };
 
 const REFRESH_COOLDOWN_MS = 60 * 1000;
@@ -64,6 +74,7 @@ export class AuthzRpcRuntime {
     this.runtime = new CratestackRpcRuntime(origin, {
       basePath: options.basePath,
       codec: toCratestackCodec(options.codec ?? defaultCodec()),
+      links: options.links,
       headers: async () => {
         const token = await this.authOptions.auth();
         const headers: Record<string, string> = {};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
 
   apps/self-service:
     dependencies:
+      '@cratestack/api':
+        specifier: ^0.4.16
+        version: 0.4.16
       '@expo/vector-icons':
         specifier: 15.1.1
         version: 15.1.1(expo-font@55.0.7)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -239,6 +242,9 @@ importers:
 
   packages/authz-rpc:
     dependencies:
+      '@cratestack/api':
+        specifier: ^0.4.16
+        version: 0.4.16
       '@paralleldrive/cuid2':
         specifier: ^2.2.2
         version: 2.3.1
@@ -969,6 +975,10 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@cratestack/api@0.4.16':
+    resolution: {integrity: sha512-ujFVaqTPFh02M5lqxfX5xHBMoS/lFyJpIfsJlBu2p/+P8PnFDROFHIn4sL7F0E8e1A8xROTLJzfognekW6j/OQ==}
+    engines: {node: '>=18'}
 
   '@egjs/hammerjs@2.0.17':
     resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
@@ -7799,6 +7809,8 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@cratestack/api@0.4.16': {}
 
   '@egjs/hammerjs@2.0.17':
     dependencies:


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Bumps the pinned `cratestack-cli` from 0.4.13 to 0.4.16 in `.github/workflows/test.yml` and `.github/workflows/docker-image.yml`, and regenerates `packages/authz-rpc/generated/`.
- Adds `@cratestack/api` as a dependency of `packages/authz-rpc` and `apps/self-service`.
- Threads a `links?: RpcLink[]` passthrough option through `AuthzRpcRuntime` (`packages/authz-rpc/src/runtime.ts`), with a new unit test proving `@cratestack/api`'s `createBatchLink()` correctly collapses concurrent calls into one `POST /rpc/batch` request (and leaves an isolated call, or a partially-failing batch, behaving correctly).
- Documents the new capability in `docs/knowledge/architecture-conventions.md`.
- Activates `createBatchLink()` for real: `apps/self-service/src/app/_layout.tsx`'s `useAuthzRpcClient(config)` call now passes `links: [authzBatchLink]`.

It solves:

- #117 (epic), #118 (story) — converse-frontends had no way to use cratestack's new batching capability at all (client predated it). This PR closes the two dev tickets scoped for this repo: #119 (plumbing) and #120 (activation). The backend half, lightbridge-authz#157, already merged as [lightbridge-authz#165](https://github.com/ADORSYS-GIS/lightbridge-authz/pull/165) — this PR is safe to activate against because that PR ships per-frame RBAC enforcement for `POST /rpc/batch`, replacing the previous unconditional 403.

Closes #117, #118, #119, #120.

---

## 2. Intent

The intent of this PR is:

> Bring converse-frontends' generated authz-rpc client up to date with a capability cratestack shipped upstream (composable `links` interceptor chain, `@cratestack/api`'s `createBatchLink()`), and fully close the loop now that the backend blocker is resolved — so concurrent authz RPC calls in the self-service app collapse into one network round trip instead of one each.

---

## 3. Scope

### In Scope

- cratestack-cli version bump (CI + regenerated client).
- `AuthzRpcRuntime`'s `links` plumbing and its unit test.
- Activating the batch link in the app root.
- A short doc update noting the capability and linking the relevant issues.

### Out of Scope

- Any semantic bulk endpoints (`batchGetAccounts`, etc.) — cratestack's RPC-transport codegen doesn't generate these; only the generic transport-level batch multiplexer exists.
- `idempotencyKey` generation on mutation call sites — `createBatchLink()`'s default dedup only collapses calls sharing an explicit idempotency key, and no such convention exists in this codebase yet. Worth a future story once batching is live and dedup benefits are measurable, not bundled here.
- Widening the batching window via `windowMs` — left at the library default (`queueMicrotask`-only, same-tick collapsing).

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [ ] Testing permissions/security behavior (backend-side; covered by lightbridge-authz#165, not this PR)
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
pnpm --filter @lightbridge/authz-rpc run codegen:cratestack   # against a locally rebuilt cratestack-cli 0.4.16
pnpm --filter @lightbridge/authz-rpc test
pnpm --filter self-service test
cd apps/self-service && pnpm exec tsc --noEmit
pnpm --filter self-service run build:web
pnpm exec prettier -c <all changed files>
pnpm exec eslint <all changed files>
```

Results:

```text
packages/authz-rpc: Test Files 3 passed (3), Tests 18 passed (18)
  — includes 3 new tests: concurrent calls collapse to one /rpc/batch request,
    a per-frame error only fails that caller, and an isolated call still works
    (wrapped as a one-frame batch, per createBatchLink()'s actual behavior —
    it has no size-1 bypass to a plain unary request).
self-service: Test Suites 23 passed (23), Tests 98 passed (98)
tsc --noEmit: clean
expo export --platform web: succeeded, no new warnings
prettier / eslint: clean on all changed files
```

Manual verification: started the self-service web dev server in this session's browser preview and loaded it. No module-resolution or runtime error from the new `@cratestack/api` import; app reached its normal pre-auth Keycloak-discovery step. The only network failure observed (`GET http://localhost:9100/realms/dev/.well-known/openid-configuration` → `ERR_CONNECTION_REFUSED`) is this sandbox having no local Keycloak/backend reachable — a pre-existing environment limitation, not caused by this change.

**Known verification gap, stated plainly:** I could not confirm actual request-collapsing (or the backend's per-frame authorization) against a real, deployed lightbridge-authz backend — no such environment was reachable from this session. Ticket #120's acceptance criteria call for a network-panel check against a real/staging backend post-deploy; that step is still outstanding and should happen before/shortly after merge, ideally by whoever has access to a staging environment with lightbridge-authz#165 deployed.

---

## 5. Screenshots / Evidence

* No visual change — this is network-transport plumbing, not a UI change.
* Test output: see Verification section above (full output available in CI on this PR).

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* `createBatchLink()` routes every unary call through `/rpc/batch`, even isolated ones (there's no size-1 fallback to a plain `/rpc/{op_id}` request) — confirmed and covered by a dedicated test. This means every authz call now depends on the backend's batch endpoint being healthy and correctly authorized, not just the unary endpoints.
* The link's documented limitation: a synthesized batch request reuses the *first* queued call's headers for the whole flush. This app builds headers from a shared `auth()` callback rather than per-call overrides, so it should be unaffected, but this wasn't verified against a live token-refresh race under real network conditions.
* No live-backend verification was performed (see Verification gap above) — if lightbridge-authz#165 isn't actually deployed to the environment this app points at, every authz call would start failing on merge, not just batched ones.

Mitigation:

* Recommend a canary/staging check (network panel showing a real `/rpc/batch` round trip succeed) before/soon after this merges, given the live-backend gap above.
* The change is trivially revertible: removing `links: [authzBatchLink]` from `_layout.tsx` reverts to the exact prior per-call request behavior, with zero other code changes needed.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Refactoring
* [x] Generating tests
* [x] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [x] Security
* [ ] Performance
* [x] Tests
* [ ] Maintainability
* [ ] Product intent
* [x] Edge cases

Specifically: whether it's safe to merge and activate given lightbridge-authz#165 is merged but this PR's author could not confirm it's deployed to a reachable environment.
