### PR TITLE
ci: update GitHub Actions runners to ubuntu-latest

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,7 +18,7 @@ jobs:
     # Rootless Buildah on the self-hosted runner (daemonless — no Docker/dind).
     # The web bundle is built here via Turbo (hitting the runner's Turbo cache),
     # then baked into a thin nginx image. Single-arch: every cluster node is amd64.
-    runs-on: adorsys-gis-runner
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -24,7 +24,7 @@ jobs:
     # commit that added the `runs-on` input (PR #17, 2026-07-06).
     uses: ADORSYS-GIS/ai-governance/.github/workflows/governance-check.yml@9a08ab57e0f651c7f7fbd42fe2768d1e113c55e5
     with:
-      runs-on: adorsys-gis-runner
+      runs-on: ubuntu-latest
     permissions:
       pull-requests: write
       contents: read

--- a/.github/workflows/publish-charts-oci.yml
+++ b/.github/workflows/publish-charts-oci.yml
@@ -44,7 +44,7 @@ env:
 
 jobs:
   publish:
-    runs-on: adorsys-gis-runner
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   quality:
     name: Code Quality Scan
-    runs-on: adorsys-gis-runner
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,4 +18,4 @@ jobs:
     with:
       trivy-scan-type: 'fs'
       trivy-target: '.'
-      runs-on: adorsys-gis-runner
+      runs-on: ubuntu-latest

--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   build:
     name: Build Storybook
-    runs-on: adorsys-gis-runner
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
@@ -51,7 +51,7 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     needs: build
-    runs-on: adorsys-gis-runner
+    runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   test:
     name: Unit tests
-    runs-on: adorsys-gis-runner
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Updates GitHub Actions runner labels to `ubuntu-latest` in workflows.

It solves:

- Sunsets the use of old private runners and standardizes on `ubuntu-latest`.

---

## 2. Intent

The intent of this PR is:

> To align with current infrastructure standards by using standard runners (`ubuntu-latest`), avoiding failures related to missing or deprecated self-hosted runners.

---

## 3. Scope

### In Scope

- Workflow files in `.github/workflows/`

### Out of Scope

- Changes to actual pipeline steps or commands.

---

## 4. Verification

I verified this change by:

- [x] Checking logs (by verifying workflow triggers on PR creation)

---

## 5. Screenshots / Evidence

Add evidence here:

* N/A

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

---

## 7. AI Usage Declaration

AI was used for:

* [x] Refactoring

Human verification:

* [x] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness