### PR TITLE
chore: set native issue types in the issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/dev-ticket.yml
+++ b/.github/ISSUE_TEMPLATE/dev-ticket.yml
@@ -2,6 +2,7 @@ name: Development Ticket
 description: Implementation work, bugs, refactors, technical tasks, spikes, or operational work.
 title: "[Ticket]: "
 labels: ["ticket"]
+type: Task
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -2,6 +2,7 @@ name: Epic
 description: A large initiative spanning multiple stories with a meaningful business or technical objective.
 title: "[Epic]: "
 labels: ["epic"]
+type: Epic
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/user-story.yml
+++ b/.github/ISSUE_TEMPLATE/user-story.yml
@@ -2,6 +2,7 @@ name: User Story
 description: A user need or a valuable capability, with testable acceptance criteria.
 title: "[Story]: "
 labels: ["user-story"]
+type: Story
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary

Adds the native GitHub issue `type:` field (`Epic` / `Story` / `Task`) to
this repo's three issue forms (`epic.yml`, `user-story.yml`,
`dev-ticket.yml`), placed immediately after the existing `labels:` line.
No `body:` block, question, or validation was touched.

## Intent

**Source of truth:** [`ADORSYS-GIS/ai-helm#1002`](https://github.com/ADORSYS-GIS/ai-helm/issues/1002) — the tracking epic for the 2026-08-13 cross-repo backlog consolidation,
which had to hand-type the native issue type on every open issue across
the ADORSYS-GIS/vymalo estate precisely because the issue forms never
set one — they only stamped a title prefix (`[Epic]:`/`[Story]:`/
`[Ticket]:`) and a label (`epic`/`user-story`/`ticket`), leaving the
native `type` field (and therefore the Epic → Story → Task hierarchy
view) empty on every newly-filed ticket. This is part 2 of a 3-part
effort to make that taxonomy self-enforcing at creation time instead of
reapplied by hand after the fact. No standalone tracking issue exists
for the consolidation itself; the related, narrower issue
[`ai-governance#15`](https://github.com/ADORSYS-GIS/ai-governance/issues/15)
(a `verification-evidence` Done-gate-at-creation bug in the same forms)
is tracked separately and is **not** touched by this PR.

## Scope

- `.github/ISSUE_TEMPLATE/epic.yml` — add `type: Epic`
- `.github/ISSUE_TEMPLATE/user-story.yml` — add `type: Story`
- `.github/ISSUE_TEMPLATE/dev-ticket.yml` — add `type: Task`
- Confirmed (unchanged) `title:`/`labels:` already match the intended
  convention (`[Epic]:`/`epic`, `[Story]:`/`user-story`,
  `[Ticket]:`/`ticket`) — no edit needed there.
- Out of scope: any `body:` field, question wording, or validation rule.

## Verification

- [x] `git diff` reviewed by hand — each file gets exactly one added
      line (`type: <Name>`), nothing else changed
- [x] Confirmed via `gh api graphql` that the organization that owns
      this repo's issue-type registry already defines `Epic`, `Story`,
      and `Task` as native issue types, so the values referenced here
      resolve
- [ ] Not yet verified live: actually filing a test issue from each
      form post-merge to confirm GitHub renders/assigns the native
      type — left to the reviewer/maintainer, since this PR must not
      be merged by AI

## Risk Assessment

Low. Purely additive metadata on issue forms; does not change any
existing issue, does not touch CI, does not touch `body:` validation.
Worst case if a `type:` value were ever misspelled: GitHub ignores an
unrecognized type value and the form still renders as before (fails
open, not closed).

## AI Usage Declaration

- [x] AI (Claude, Anthropic) proposed and made this change under
      direct maintainer instruction, as part of a scripted multi-repo
      rollout.
- [x] A human (the repo maintainer, @stephane-segning) reviews this PR
      before merge; it is intentionally left unmerged by the AI.
- [x] Verification performed: diff reviewed line-by-line before commit;
      target org's issue-type registry queried and confirmed to contain
      the three referenced type names.
- [ ] Live GitHub issue-form render was not exercised in this PR (would
      require filing a real issue) — left for reviewer verification.

## Reviewer Focus

- Confirm the three `type:` values actually take effect when filing a
  new issue from each form (Epic/Story/Task selectable/assigned
  correctly).
- Confirm no other repo automation (e.g. project-board workflows) keys
  off the *absence* of a native type in a way this change could disrupt.



