### PR TITLE
fix(self-service): resolve generated .js ESM imports in Metro — unbreaks the web export

### DIFF
--- a/apps/self-service/metro.config.js
+++ b/apps/self-service/metro.config.js
@@ -1,5 +1,6 @@
 const { getDefaultConfig } = require('expo/metro-config');
 const { withNativeWind } = require('nativewind/metro');
+const fs = require('fs');
 const path = require('path');
 
 const config = getDefaultConfig(__dirname);
@@ -18,6 +19,30 @@ config.resolver.resolveRequest = (context, moduleName, platform) => {
       ),
       type: 'sourceFile',
     };
+  }
+  // cratestack-cli (packages/authz-rpc's codegen, see
+  // packages/authz-rpc/generated/) emits ESM-style relative imports with an
+  // explicit `.js` extension (e.g. `from "./runtime.js"`), following the
+  // TypeScript convention where a `.js` specifier resolves to the sibling
+  // `.ts` source. Metro doesn't apply that convention and looks for a
+  // literal `runtime.js` file, which doesn't exist, so resolution fails.
+  // Rewrite such an import to its `.ts`/`.tsx` sibling, but only when that
+  // sibling actually exists on disk and no real `.js` file sits at the
+  // literal path — so bare package specifiers and genuine `.js` files are
+  // left completely untouched.
+  if ((moduleName.startsWith('./') || moduleName.startsWith('../')) && moduleName.endsWith('.js')) {
+    const originDir = path.dirname(context.originModulePath);
+    const literalJsPath = path.resolve(originDir, moduleName);
+    if (!fs.existsSync(literalJsPath)) {
+      const specifierWithoutExt = moduleName.slice(0, -'.js'.length);
+      const sourceExt = ['.ts', '.tsx'].find((ext) =>
+        fs.existsSync(path.resolve(originDir, `${specifierWithoutExt}${ext}`))
+      );
+      if (sourceExt) {
+        const resolve = originalResolveRequest ?? context.resolveRequest;
+        return resolve(context, `${specifierWithoutExt}${sourceExt}`, platform);
+      }
+    }
   }
   if (originalResolveRequest) {
     return originalResolveRequest(context, moduleName, platform);


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Extends the existing `resolveRequest` override in `apps/self-service/metro.config.js` so Metro resolves relative `.js`-suffixed ESM specifiers onto their real `.ts`/`.tsx` sources.
- No other file changes. The generated client is left exactly as `cratestack-cli` emits it.

It solves:

- The web export (`turbo run build:web`) has been failing on `main` since https://github.com/ADORSYS-GIS/converse-frontends/pull/150 merged, which means **no deployable image has been produced since 2026-08-01**.
- Failing run: https://github.com/ADORSYS-GIS/converse-frontends/actions/runs/31871199429

---

## 2. Intent

The intent of this PR is:

> Restore the deploy pipeline. `cratestack-cli` 0.7.16 (pinned in #150) emits `.js`-suffixed relative ESM imports — `from "./runtime.js"` — where the previous generator emitted extensionless `./runtime`. Metro cannot resolve those onto the `.ts` sources, so the Expo web export dies with `Unable to resolve module ./runtime.js from packages/authz-rpc/generated/src/client.ts`.
>
> This was invisible locally because `packages/authz-rpc/generated/` is gitignored **and** the root `postinstall` never rebuilds it: `codegen:all` runs `pnpm -r --if-present run codegen`, which only matches scripts literally named `codegen`, while this package defines only `codegen:cratestack`. Anyone with an existing `generated/` directory kept building against a stale artifact from the previous generator and saw green. Only a clean regeneration hits the bug — and only CI does clean regenerations.

---

## 3. Scope

### In Scope

- The Metro resolver fix in `apps/self-service/metro.config.js`.

### Out of Scope

- Reverting the `cratestack-cli` 0.7.16 pin. That pin carries the `Value`-untagging wire-format fix production depends on (https://github.com/ADORSYS-GIS/lightbridge-authz/pull/283); reverting would reintroduce a correctness bug to work around a build-tooling one.
- Post-processing the generated output to strip extensions. More fragile — it fights the generator on every regeneration and needs a hook point that does not exist in the CI flow.
- Fixing the `codegen:all` / `codegen:cratestack` script-name mismatch, and adding PR-level coverage for the web export. Both are real and are called out under Reviewer Focus, but neither belongs in a hotfix.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
# Reproduce from a genuinely clean regeneration (the state CI is in)
rm -rf packages/authz-rpc/generated
pnpm --filter @lightbridge/authz-rpc run codegen:cratestack
grep -n 'from "\./runtime\.js"' packages/authz-rpc/generated/src/client.ts
pnpm build --force
pnpm -r --if-present run test
```

Results:

```text
# BEFORE the fix, clean regen:
Error: Unable to resolve module ./runtime.js from
  .../packages/authz-rpc/generated/src/client.ts
  > 5 | } from "./runtime.js";
Failed: self-service#build:web

# AFTER the fix, clean regen + forced (uncached) rebuild:
client.ts:5:} from "./runtime.js";      <- generator output unchanged, still .js
self-service:build:web: Web Bundled 3238ms expo-router/entry.js (1843 modules)
self-service:build:web: Exported: dist
 Tasks:    1 successful, 1 total
Cached:    0 cached, 1 total

# Test suite, no regressions:
packages/authz-rpc  14 tests passed
packages/hooks      10 tests passed
apps/self-service   23 suites, 101 tests passed
```

The fix was verified twice from a clean regeneration, and then reproduced independently in a second worktree (failure confirmed first, then success with the same generated input) to rule out a cached or stale-artifact result.

---

## 5. Screenshots / Evidence

* Failing CI run (the break this fixes): https://github.com/ADORSYS-GIS/converse-frontends/actions/runs/31871199429
* Commit that introduced the regression: https://github.com/ADORSYS-GIS/converse-frontends/pull/150
* Upstream cause — cratestack "serialize Value untagged on the wire": https://github.com/cratestack/cratestack/pull/506
* Build output before/after: pasted verbatim under Verification above.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* A module-resolution hook is global, so an over-broad rewrite could mis-resolve unrelated imports.
* Native (iOS/Android) resolution runs through the same `resolveRequest`, so a web-motivated fix could in principle affect native builds.

Mitigation:

* The branch is constrained three ways: it only fires on **relative** specifiers (`./`, `../`) — bare package specifiers never match; it checks `fs.existsSync` on the literal `.js` path first, so a real `.js` file on disk is left entirely alone; and it only rewrites when a sibling `.ts`/`.tsx` actually exists. No guessing, no blind extension-stripping.
* It delegates through the same `originalResolveRequest ?? context.resolveRequest` chain the existing `idb-keyval` branch uses, so every non-matching module resolves exactly as before.
* Because it only activates for a relative `.js` specifier with no real `.js` file but a real `.ts` sibling, it is inert on native resolution paths, which do not produce that shape.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Diagnosis, fix and this description were produced by Claude Code (Opus 5 orchestrating a Sonnet subagent) on behalf of @stephane-segning. The diagnosis was reproduced independently three times — twice by the implementing agent and once in a separate worktree by the orchestrator — before the fix was written, and the post-fix build was re-verified independently against the same generated input.

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

**Human attestation pending @stephane-segning's review.** Per the governance doctrine, these boxes are the accountable human's to tick — this PR was opened by an agent on their instruction, and an agent must not sign them on their behalf.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [ ] Product intent
* [x] Edge cases

Two follow-ups this hotfix deliberately does not do, both of which are the actual reason this reached `main`:

1. **`docker-image.yml` only triggers on push to `main` and tags — never on `pull_request`.** The PR-level workflows (`test`, `quality`, `security`) never run `build:web`. So this PR, and the six that preceded it, are green here and only break on landing. Worth a PR-triggered clean-tree `pnpm build` job scoped to changes under `packages/authz-rpc/**` or the cratestack pin.
2. **`codegen:all` does not rebuild this package.** Renaming `codegen:cratestack` to `codegen` (updating the CI steps that call it) would make a fresh `pnpm install` reproduce CI's state instead of silently leaving a stale artifact in place.
