### PR TITLE
docs(auth): record that self-service has no lightbridge-authz token-exchange exposure (ADR-0011)

### DIFF
--- a/docs/knowledge/auth-and-identity.md
+++ b/docs/knowledge/auth-and-identity.md
@@ -75,6 +75,20 @@ AuthSession stored (see Token Storage below)
 - Persists the refreshed session to storage.
 - Returns `null` on any failure (caller is responsible for handling expired sessions).
 
+### Non-Dependency: `lightbridge-authz` Token-Exchange (ADR-0011)
+
+> **This app never calls `lightbridge-authz`'s `/oauth2/token` endpoint** — it authenticates
+> directly against Keycloak (flow above). It therefore has **zero exposure** to the v3.0.0
+> token-exchange work: client registry requirements, per-client `aud`, the derived `id_token`,
+> `issued_token_type`, and `jti` format are all out of this app's dependency surface.
+>
+> `packages/hooks/src/auth/jwt-utils.ts` declares `jti?: string` on `JwtPayload`, but nothing in
+> this repo reads it, so a `jti`-format change on the issuing side is a non-event here.
+>
+> Source of truth: [lightbridge-authz ADR-0011](https://github.com/ADORSYS-GIS/lightbridge-authz/blob/main/docs/adr/0011-authz-issues-a-full-oidc-token-object.md),
+> [lightbridge-authz#286](https://github.com/ADORSYS-GIS/lightbridge-authz/pull/286),
+> [lightbridge-authz#288](https://github.com/ADORSYS-GIS/lightbridge-authz/pull/288).
+
 ---
 
 ## Token Types: `AuthTokens`


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds a "Non-Dependency: `lightbridge-authz` Token-Exchange (ADR-0011)" subsection to `docs/knowledge/auth-and-identity.md`.
- Documentation only. No code, no tests, no config.

It solves:

- https://github.com/ADORSYS-GIS/converse-frontends/issues/144

---

## 2. Intent

The intent of this PR is:

> Write down, once, an answer that is currently re-derived across two repos on every `lightbridge-authz` release that touches `/oauth2/token`. This app authenticates directly against Keycloak and never calls that endpoint, so the ADR-0011 token-exchange surface — client registry, per-client `aud`, `id_token`, `issued_token_type`, `jti` format — is outside its dependency surface. The doc already covers the Keycloak PKCE flow in detail; it just never said "and therefore this doesn't apply to us."

---

## 3. Scope

### In Scope

- One subsection in `docs/knowledge/auth-and-identity.md`, placed under the Keycloak flow it disclaims a dependency on, with links to ADR-0011 and PRs #286/#288.

### Out of Scope

- Any code change.
- Re-auditing this on every future `lightbridge-authz` release. This records the currently verified state; if the auth model changes, that is a separate ticket updating this same section.

---

## 4. Verification

I verified this change by:

- [ ] Running automated tests
- [x] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
grep -rn "oauth2/token\|token-exchange\|tokenExchange" --include="*.ts" --include="*.tsx" . | grep -v node_modules
grep -rn "\.jti\b" --include="*.ts" --include="*.tsx" . | grep -v node_modules
grep -n "jti" packages/hooks/src/auth/jwt-utils.ts
```

Results:

```text
# /oauth2/token, token-exchange, tokenExchange -> zero matches (exit 1)
# .jti                                          -> zero matches (exit 1)
# jwt-utils.ts:23:  jti?: string;               -> declared, never read
```

Re-run against the post-edit tree. The note describes the state these greps confirm; no drift from the ticket's claims was found.

---

## 5. Screenshots / Evidence

* Source of truth: https://github.com/ADORSYS-GIS/converse-frontends/issues/144
* ADR-0011: https://github.com/ADORSYS-GIS/lightbridge-authz/blob/main/docs/adr/0011-authz-issues-a-full-oidc-token-object.md
* https://github.com/ADORSYS-GIS/lightbridge-authz/pull/286 and https://github.com/ADORSYS-GIS/lightbridge-authz/pull/288
* Verification output pasted above.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* The note goes stale if this app's auth model changes without updating it.

Mitigation:

* Placed directly under the Keycloak flow section it depends on, so a change to that flow puts an editor in front of this note.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [ ] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Written by Claude Code (Sonnet subagent under an Opus 5 orchestrator) on behalf of @stephane-segning. The claims in the note were re-verified by executing the greps above rather than by trusting the ticket text.

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

**Human attestation pending @stephane-segning's review** — an agent must not tick the accountable human's boxes on their behalf.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [ ] Product intent
* [ ] Edge cases

Specifically: is the claim accurate and stated strongly enough to stop the next release from triggering another two-repo investigation?
