### PR TITLE
fix(security): raise js-yaml and nanoid override floors for 5 HIGH CVEs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,9 @@ overrides:
   ws@8: ^8.21.0
   postcss: ^8.5.18
   brace-expansion: ^5.0.8
-  js-yaml@3: ^3.15.0
-  js-yaml@4: ^4.3.0
+  js-yaml@3: ^3.15.1
+  js-yaml@4: ^4.3.1
+  nanoid@3: ^3.3.18
 
 importers:
 
@@ -5029,12 +5030,12 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsc-safe-url@0.2.4:
@@ -5461,13 +5462,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -8086,7 +8082,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 10.2.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -8446,7 +8442,7 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.29.0
       chalk: 4.1.2
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
 
   '@gorhom/bottom-sheet@5.2.14(@types/react@19.2.14)(react-native-gesture-handler@2.30.1(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native-reanimated@4.2.1(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -8461,7 +8457,7 @@ snapshots:
 
   '@gorhom/portal@1.0.14(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)':
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.18
       react: 19.2.0
       react-native: 0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
 
@@ -8479,7 +8475,7 @@ snapshots:
     dependencies:
       '@jsdevtools/ono': 7.1.3
       '@types/json-schema': 7.0.15
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
 
   '@hey-api/openapi-ts@0.91.1(typescript@5.9.3)':
@@ -8535,7 +8531,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -9300,7 +9296,7 @@ snapshots:
       '@react-navigation/routers': 7.5.5
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
-      nanoid: 3.3.12
+      nanoid: 3.3.18
       query-string: 7.1.3
       react: 19.2.0
       react-is: 19.2.6
@@ -9336,14 +9332,14 @@ snapshots:
       '@react-navigation/core': 7.17.4(react@19.2.0)
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
-      nanoid: 3.3.12
+      nanoid: 3.3.18
       react: 19.2.0
       react-native: 0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
       use-latest-callback: 0.2.6(react@19.2.0)
 
   '@react-navigation/routers@7.5.5':
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.18
 
   '@rolldown/binding-android-arm64@1.1.4':
     optional: true
@@ -11385,7 +11381,7 @@ snapshots:
       expo-symbols: 55.0.8(expo-font@55.0.7)(expo@55.0.23)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       fast-deep-equal: 3.1.3
       invariant: 2.2.4
-      nanoid: 3.3.12
+      nanoid: 3.3.18
       query-string: 7.1.3
       react: 19.2.0
       react-fast-compare: 3.2.2
@@ -12494,12 +12490,12 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -12969,9 +12965,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.12: {}
-
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -13351,7 +13345,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,5 +23,6 @@ overrides:
   "ws@8": "^8.21.0" # CVE-2026-48779 (HIGH): DoS via memory exhaustion
   postcss: "^8.5.18" # CVE-2026-45623 / GHSA-r28c-9q8g-f849 (HIGH): path traversal via sourceMappingURL auto-loading
   brace-expansion: "^5.0.8" # CVE-2026-13149 / CVE-2026-14257 (HIGH): DoS via crafted brace patterns
-  "js-yaml@3": "^3.15.0" # CVE-2026-59869 (HIGH): DoS via crafted YAML
-  "js-yaml@4": "^4.3.0" # CVE-2026-59869 (HIGH): same CVE also affects the 4.x line below 4.3.0
+  "js-yaml@3": "^3.15.1" # CVE-2026-59869 (HIGH): DoS via crafted YAML; floor raised again for CVE-2026-59870 (HIGH): quadratic CPU consumption in !!omap resolution, fixed 3.15.1
+  "js-yaml@4": "^4.3.1" # CVE-2026-59869 (HIGH): same CVE also affects the 4.x line below 4.3.0; floor raised again for CVE-2026-59870 (HIGH): quadratic CPU consumption in !!omap resolution, fixed 4.3.1
+  "nanoid@3": "^3.3.18" # CVE-2026-67213 (HIGH): DoS via infinite loop in random ID generation, fixed 3.3.18; also covers CVE-2026-67214 (HIGH): infinite loop in custom alphabet handling, fixed 3.3.16


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Raises the `js-yaml@3` / `js-yaml@4` override floors (3.15.0 → 3.15.1, 4.3.0 → 4.3.1) in `pnpm-workspace.yaml`.
- Adds a `nanoid@3` override at `^3.3.18`.
- Regenerates `pnpm-lock.yaml` accordingly. No application code touched.

It solves:

- The Trivy security gate has been failing on `main` on every run — 5 HIGH transitive CVEs. Failing run: https://github.com/ADORSYS-GIS/converse-frontends/actions/runs/31873194179

---

## 2. Intent

The intent of this PR is:

> Clear the pre-existing HIGH findings blocking the `scan / Vulnerability Scan (Trivy)` gate, so PRs can be merged on genuinely green CI rather than past a known-red security check.
>
> | Library | Advisory | Installed | Fixed in |
> |---|---|---|---|
> | `js-yaml` | GHSA-5p4m-2wfm-xmqj (CVE-2026-59870) — quadratic CPU consumption in `!!omap` resolution | 3.15.0, 4.3.0 | 3.15.1, 4.3.1 |
> | `nanoid` | CVE-2026-67213 — DoS via infinite loop in random ID generation | 3.3.12, 3.3.16 | 3.3.18 |
> | `nanoid` | CVE-2026-67214 — infinite loop in custom alphabet handling | 3.3.12 | 3.3.16 |
>
> All transitive, all with published fixes, so `ignore-unfixed: true` does not suppress them. This repo's established remedy for exactly this is a floor in the `overrides:` block, which already carried `js-yaml@3`/`js-yaml@4` pins for an earlier advisory (CVE-2026-59869) — those are patch-bumped here rather than replaced.

---

## 3. Scope

### In Scope

- Three override lines and the regenerated lockfile.

### Out of Scope

- Any application code change.
- A `nanoid@5` override — the resolved tree contains no 5.x line (verified against the lockfile, not assumed).
- The broader dependency-freshness work in https://github.com/ADORSYS-GIS/converse-frontends/issues/142.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [x] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
pnpm install --no-frozen-lockfile
grep -oE "(js-yaml|nanoid)@[0-9.]+" pnpm-lock.yaml | sort -u
trivy fs --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 .
pnpm -r --if-present run test
pnpm build
```

Results:

```text
# Resolved versions — no vulnerable version remains in the tree:
js-yaml@3.15.1
js-yaml@4.3.1
nanoid@3.3.18        (no 5.x line present anywhere)

# Trivy (v0.72.0), the actual gate command, run locally:
pnpm-lock.yaml │ pnpm │ 0 vulnerabilities
exit code 0

# Tests:
authz-rpc 14 passed | hooks 10 passed | self-service 23 suites / 101 passed

# Build:
turbo run build:web -> Exported: dist   (1/1 tasks successful)
```

Trivy was executed, not inferred. A raised floor can break a transitive consumer, so the full test suite and a real web export were run rather than relying on a clean scan alone.

---

## 5. Screenshots / Evidence

* Failing gate this fixes: https://github.com/ADORSYS-GIS/converse-frontends/actions/runs/31873194179
* https://github.com/advisories/GHSA-5p4m-2wfm-xmqj
* https://avd.aquasec.com/nvd/cve-2026-67213 and https://avd.aquasec.com/nvd/cve-2026-67214
* Scan, test and build output pasted above.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* Raising a transitive floor can pull in a version some consumer is not compatible with.

Mitigation:

* All three are patch/minor bumps within the same major, on packages with no direct import in this codebase.
* Verified beyond the scan: full test suite green and a real `build:web` export succeeds on the updated lockfile.
* The `nanoid` floor is the higher of the two fix versions, so one override closes both advisories.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Produced by Claude Code (Sonnet subagent under an Opus 5 orchestrator) on behalf of @stephane-segning. The remaining-version claims come from the resolved lockfile and a real local Trivy run, not from assuming the overrides took effect.

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

**Human attestation pending @stephane-segning's review** — an agent must not tick the accountable human's boxes on their behalf.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [x] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [ ] Edge cases
* [ ] Product intent

Specifically: whether pinning floors in `overrides:` remains the right long-term answer here, or whether the growing list argues for taking https://github.com/ADORSYS-GIS/converse-frontends/issues/142's dependency refresh sooner.
