### PR TITLE
fix(hooks,self-service): real server-driven pagination on the API-keys list

### DIFF
--- a/apps/self-service/src/__tests__/api-keys-screen.test.tsx
+++ b/apps/self-service/src/__tests__/api-keys-screen.test.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
+
+// api-keys-screen.tsx pulls in `@lightbridge/hooks` (which drags in auth-session and the
+// generated authz-rpc client) — mock the barrel with just the hooks the screen actually calls
+// at render time, same spirit as the subpath-import workaround documented elsewhere in this
+// test suite (see use-pagination.test.tsx / use-query-state.test.tsx).
+const mockAccounts = [{ id: 'acc-1' }];
+const mockProjectsByAccount: Record<string, { id: string; name: string }[]> = {
+  'acc-1': [
+    { id: 'proj-1', name: 'Project One' },
+    { id: 'proj-2', name: 'Project Two' },
+  ],
+};
+// A full page (length === limit) so the "hasMore" heuristic reports true and the Next
+// control is enabled — matches a project with more than one page of API keys.
+const mockItems: { id: string }[] = Array.from({ length: 10 }, (_, i) => ({ id: `key-${i}` }));
+// Must be named with a `mock` prefix — babel-plugin-jest-hoist only allows referencing
+// out-of-scope variables from inside a jest.mock() factory when the name starts with "mock".
+const mockUseApiKeys = jest.fn(
+  (_projectId?: string, _options: { offset?: number; limit?: number } = {}) => ({
+    data: mockItems,
+    isLoading: false,
+  })
+);
+// Minimal real query-param state so selecting a different account/project actually re-renders
+// the screen with a new effective accountId/projectId, the way the real URL-backed hook does.
+// Defined as its own top-level `mock`-prefixed function (rather than inline in the jest.mock
+// factory below) because babel-plugin-jest-hoist's scope check trips even on identifiers that
+// only appear inside a TS type annotation of an inline arrow function.
+function mockUseQueryState(_key: string): [string | null, (value: string | null) => void] {
+  return require('react').useState(null);
+}
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ back: jest.fn(), navigate: jest.fn() }),
+}));
+
+jest.mock('@lightbridge/i18n', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('@lightbridge/ui/sheet', () => ({
+  useSheet: () => ({ present: jest.fn() }),
+}));
+
+jest.mock('@lightbridge/hooks', () => {
+  const actual = jest.requireActual('@lightbridge/hooks/pagination');
+  return {
+    __esModule: true,
+    usePagination: actual.usePagination,
+    useAccounts: () => ({ data: mockAccounts, isLoading: false }),
+    useProjects: (accountId?: string) => ({
+      data: accountId ? (mockProjectsByAccount[accountId] ?? []) : [],
+      isLoading: false,
+    }),
+    useApiKeys: (projectId?: string, options?: { offset?: number; limit?: number }) =>
+      mockUseApiKeys(projectId, options),
+    usePermissions: () => ({ has: () => true }),
+    useQueryState: mockUseQueryState,
+  };
+});
+
+// Stub out the view (owned by another area of the app) so this test stays focused on the
+// screen's own pagination wiring: it renders the props the screen passes down as simple,
+// queryable controls instead of the full list UI.
+jest.mock('../views/api-keys-list-view', () => {
+  const { Pressable, Text } = require('react-native');
+  return {
+    ApiKeysListView: (props: {
+      items: { id: string }[];
+      selectedProjectId?: string;
+      onSelectProject: (id: string) => void;
+    }) => (
+      <>
+        <Text testID="items-count">{props.items.length}</Text>
+        <Text testID="selected-project">{props.selectedProjectId ?? ''}</Text>
+        <Pressable testID="select-project-2" onPress={() => props.onSelectProject('proj-2')}>
+          <Text>select project 2</Text>
+        </Pressable>
+      </>
+    ),
+  };
+});
+
+import { ApiKeysScreen } from '../screens/api-keys-screen';
+
+describe('ApiKeysScreen pagination wiring', () => {
+  beforeEach(() => {
+    mockUseApiKeys.mockClear();
+  });
+
+  it('requests the first page (offset 0) on initial render', async () => {
+    await render(<ApiKeysScreen />);
+
+    expect(mockUseApiKeys).toHaveBeenCalledWith('proj-1', { offset: 0, limit: 10 });
+  });
+
+  it('advances the offset passed to useApiKeys when Next is pressed', async () => {
+    await render(<ApiKeysScreen />);
+    mockUseApiKeys.mockClear();
+
+    await act(async () => fireEvent.press(screen.getByLabelText('pagination.next')));
+
+    expect(mockUseApiKeys).toHaveBeenCalledWith('proj-1', { offset: 10, limit: 10 });
+  });
+
+  it('Previous is disabled on page 1', async () => {
+    await render(<ApiKeysScreen />);
+
+    const prev = screen.getByLabelText('pagination.previous');
+    expect(prev.props.accessibilityState.disabled).toBe(true);
+  });
+
+  it('resets back to offset 0 when the selected project changes', async () => {
+    await render(<ApiKeysScreen />);
+
+    // Page forward first, so there is something to reset from.
+    await act(async () => fireEvent.press(screen.getByLabelText('pagination.next')));
+    expect(mockUseApiKeys).toHaveBeenLastCalledWith('proj-1', { offset: 10, limit: 10 });
+
+    mockUseApiKeys.mockClear();
+    await act(async () => fireEvent.press(screen.getByTestId('select-project-2')));
+
+    expect(mockUseApiKeys).toHaveBeenLastCalledWith('proj-2', { offset: 0, limit: 10 });
+  });
+});

--- a/apps/self-service/src/screens/api-keys-screen.tsx
+++ b/apps/self-service/src/screens/api-keys-screen.tsx
@@ -1,14 +1,16 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useRouter } from 'expo-router';
 import { useTranslation } from '@lightbridge/i18n';
 import {
   useAccounts,
   useApiKeys,
+  usePagination,
   usePermissions,
   useProjects,
   useQueryState,
 } from '@lightbridge/hooks';
 import type { Account, Project } from '@lightbridge/hooks';
+import { Pagination } from '@lightbridge/ui';
 import { useSheet } from '@lightbridge/ui/sheet';
 import { ApiKeysListView } from '../views/api-keys-list-view';
 import { DeleteApiKeySheet } from './delete-api-key-sheet';
@@ -41,10 +43,25 @@ export function ApiKeysScreen() {
   const projectParamInList = projects.some((project) => project.id === projectParam);
   const projectId = (projectParamInList ? projectParam : undefined) ?? projects[0]?.id;
 
+  // Server-driven offset pagination — real Next/Prev over the backend list, not an
+  // in-memory re-slice of a fixed first page.
+  const pagination = usePagination({ pageSize: PAGE_SIZE });
+
+  // Land back on page 1 whenever the selected account or project changes, or the
+  // user could land on a stale page N of a different project's list.
+  useEffect(() => {
+    pagination.reset();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [accountId, projectId]);
+
   const { data: items = [], isLoading: isKeysLoading } = useApiKeys(projectId, {
-    offset: 0,
-    limit: PAGE_SIZE,
+    offset: pagination.offset,
+    limit: pagination.limit,
   });
+
+  // The backend returns a bare array with no total-count, so `hasMore` is the
+  // documented length-vs-limit heuristic from usePagination, not an exact count.
+  const hasMoreItems = pagination.hasMore(items.length);
 
   const handleSelectAccount = (id: string) => {
     setAccountParam(id);
@@ -92,24 +109,39 @@ export function ApiKeysScreen() {
   };
 
   return (
-    <ApiKeysListView
-      accounts={accounts}
-      projects={projects}
-      selectedAccountId={accountId}
-      selectedProjectId={projectId}
-      items={items}
-      isLoading={isAccountsLoading || isProjectsLoading || isKeysLoading}
-      onBack={() => router.back()}
-      onCreate={handleCreate}
-      onDelete={handleDelete}
-      onRevoke={handleRevoke}
-      onRotate={handleRotate}
-      onSelectAccount={handleSelectAccount}
-      onSelectProject={handleSelectProject}
-      canCreate={has('apikey:create')}
-      canDelete={has('apikey:delete')}
-      canRevoke={has('apikey:revoke')}
-      canRotate={has('apikey:rotate')}
-    />
+    <>
+      <ApiKeysListView
+        accounts={accounts}
+        projects={projects}
+        selectedAccountId={accountId}
+        selectedProjectId={projectId}
+        items={items}
+        isLoading={isAccountsLoading || isProjectsLoading || isKeysLoading}
+        onBack={() => router.back()}
+        onCreate={handleCreate}
+        onDelete={handleDelete}
+        onRevoke={handleRevoke}
+        onRotate={handleRotate}
+        onSelectAccount={handleSelectAccount}
+        onSelectProject={handleSelectProject}
+        canCreate={has('apikey:create')}
+        canDelete={has('apikey:delete')}
+        canRevoke={has('apikey:revoke')}
+        canRotate={has('apikey:rotate')}
+      />
+      {projectId ? (
+        <Pagination
+          border
+          page={pagination.page}
+          canPrev={pagination.canPrev}
+          hasMore={hasMoreItems}
+          onPrev={pagination.prev}
+          onNext={pagination.next}
+          pageLabel={t('pagination.page')}
+          previousLabel={t('pagination.previous')}
+          nextLabel={t('pagination.next')}
+        />
+      ) : null}
+    </>
   );
 }

--- a/packages/hooks/src/accounts.test.ts
+++ b/packages/hooks/src/accounts.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// accounts.ts pulls in `./auth-session` → `@tanstack/react-db`/native-storage modules and
+// `@lightbridge/authz-rpc` → the generated cratestack client — both drag in React Native's
+// entry point transitively, which Vitest's plain Rollup/esbuild pipeline can't parse (Flow
+// syntax). Mock both so this file only ever exercises the pure query-key/defaulting helpers
+// under test, same spirit as the "import from the dedicated subpath" workaround documented in
+// apps/self-service/src/__tests__/use-pagination.test.tsx for the Jest side.
+vi.mock('./auth-session', () => ({ useAuthSession: () => ({ isAuthenticated: true }) }));
+vi.mock('@lightbridge/authz-rpc', () => ({ getAuthzRpcClient: () => ({}) }));
+
+import { accountsListQueryKey, accountsQueryKey, resolveAccountsOptions } from './accounts';
+
+describe('resolveAccountsOptions', () => {
+  it('defaults to offset 0, limit 10 when nothing is passed (unchanged existing behavior)', () => {
+    expect(resolveAccountsOptions()).toEqual({ offset: 0, limit: 10 });
+    expect(resolveAccountsOptions({})).toEqual({ offset: 0, limit: 10 });
+  });
+
+  it('carries through a caller-supplied offset/limit', () => {
+    expect(resolveAccountsOptions({ offset: 20, limit: 25 })).toEqual({ offset: 20, limit: 25 });
+  });
+
+  it('defaults only the missing half of a partial options object', () => {
+    expect(resolveAccountsOptions({ offset: 30 })).toEqual({ offset: 30, limit: 10 });
+    expect(resolveAccountsOptions({ limit: 5 })).toEqual({ offset: 0, limit: 5 });
+  });
+});
+
+describe('accountsListQueryKey', () => {
+  it('appends the resolved { offset, limit } on top of the bare accountsQueryKey prefix', () => {
+    expect(accountsListQueryKey()).toEqual([...accountsQueryKey, { offset: 0, limit: 10 }]);
+    expect(accountsListQueryKey({ offset: 10, limit: 10 })).toEqual([
+      ...accountsQueryKey,
+      { offset: 10, limit: 10 },
+    ]);
+  });
+
+  it('produces a different key per page, so paged caches do not collide', () => {
+    const page1 = accountsListQueryKey({ offset: 0, limit: 10 });
+    const page2 = accountsListQueryKey({ offset: 10, limit: 10 });
+    expect(page1).not.toEqual(page2);
+  });
+
+  it('every per-page key still starts with the bare invalidation prefix', () => {
+    const key = accountsListQueryKey({ offset: 40, limit: 10 });
+    expect(key.slice(0, accountsQueryKey.length)).toEqual(accountsQueryKey);
+  });
+});

--- a/packages/hooks/src/accounts.ts
+++ b/packages/hooks/src/accounts.ts
@@ -7,13 +7,36 @@ import { useAuthSession } from './auth-session';
 
 export const accountsQueryKey = ['accounts'] as const;
 
-export function useAccounts(enabled = true) {
+export type UseAccountsOptions = {
+  offset?: number;
+  limit?: number;
+};
+
+/** Applies the default page (offset 0, limit 10 — matches the backend list default). */
+export function resolveAccountsOptions(
+  options: UseAccountsOptions = {}
+): Required<UseAccountsOptions> {
+  return { offset: options.offset ?? 0, limit: options.limit ?? 10 };
+}
+
+/**
+ * Per-page query key — the bare `accountsQueryKey` prefix with `{ offset, limit }` appended
+ * on top (same pattern as `apiKeysQueryKey` in api-keys.ts). Invalidating with the bare
+ * prefix still clears every cached page.
+ */
+export function accountsListQueryKey(options: UseAccountsOptions = {}) {
+  return [...accountsQueryKey, resolveAccountsOptions(options)] as const;
+}
+
+export function useAccounts(enabled = true, options: UseAccountsOptions = {}) {
   const { isAuthenticated } = useAuthSession();
 
+  const { offset, limit } = resolveAccountsOptions(options);
+
   const query = useQuery({
-    queryKey: accountsQueryKey,
+    queryKey: accountsListQueryKey(options),
     queryFn: async (): Promise<Account[]> => {
-      const page = await getAuthzRpcClient().accounts.list({ limit: 10, offset: 0 });
+      const page = await getAuthzRpcClient().accounts.list({ limit, offset });
       return page.items;
     },
     enabled: enabled && isAuthenticated,
@@ -127,6 +150,11 @@ export function useEnsureDefaultAccount() {
   const { session } = useAuthSession();
 
   const mutation = useMutation({
+    // Deliberately NOT threaded through UseAccountsOptions/pagination: this is an internal
+    // "does the caller already have an account" existence check (one account per JWT subject
+    // per ADR-0006, so `limit: 10` is already far more than the model allows), not a
+    // user-facing list. It only ever reads `existing.items[0]`, so a variable offset/limit
+    // would be meaningless here — leave it hardcoded.
     mutationFn: async (): Promise<Account> => {
       const existing = await getAuthzRpcClient().accounts.list({ limit: 10, offset: 0 });
 

--- a/packages/hooks/src/projects.test.ts
+++ b/packages/hooks/src/projects.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// projects.ts pulls in `./accounts` → `./auth-session` and `@lightbridge/authz-rpc` — both drag
+// in React Native's entry point transitively, which Vitest's plain Rollup/esbuild pipeline can't
+// parse (Flow syntax). Mock both so this file only ever exercises the pure query-key/defaulting
+// helpers under test, same spirit as the "import from the dedicated subpath" workaround
+// documented in apps/self-service/src/__tests__/use-pagination.test.tsx for the Jest side.
+vi.mock('./auth-session', () => ({ useAuthSession: () => ({ isAuthenticated: true }) }));
+vi.mock('./accounts', () => ({ useCurrentAccount: () => ({ data: undefined }) }));
+vi.mock('@lightbridge/authz-rpc', () => ({
+  getAuthzRpcClient: () => ({}),
+  createId: () => 'test-id',
+}));
+vi.mock('@lightbridge/i18n', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+import { projectsListQueryKey, projectsQueryKey, resolveProjectsOptions } from './projects';
+
+describe('resolveProjectsOptions', () => {
+  it('defaults to offset 0, limit 10 when nothing is passed (unchanged existing behavior)', () => {
+    expect(resolveProjectsOptions()).toEqual({ offset: 0, limit: 10 });
+    expect(resolveProjectsOptions({})).toEqual({ offset: 0, limit: 10 });
+  });
+
+  it('carries through a caller-supplied offset/limit', () => {
+    expect(resolveProjectsOptions({ offset: 20, limit: 25 })).toEqual({ offset: 20, limit: 25 });
+  });
+
+  it('defaults only the missing half of a partial options object', () => {
+    expect(resolveProjectsOptions({ offset: 30 })).toEqual({ offset: 30, limit: 10 });
+    expect(resolveProjectsOptions({ limit: 5 })).toEqual({ offset: 0, limit: 5 });
+  });
+});
+
+describe('projectsListQueryKey', () => {
+  const accountId = 'acc-1';
+
+  it('appends the resolved { offset, limit } on top of the bare projectsQueryKey(accountId) prefix', () => {
+    expect(projectsListQueryKey(accountId)).toEqual([
+      ...projectsQueryKey(accountId),
+      { offset: 0, limit: 10 },
+    ]);
+    expect(projectsListQueryKey(accountId, { offset: 10, limit: 10 })).toEqual([
+      ...projectsQueryKey(accountId),
+      { offset: 10, limit: 10 },
+    ]);
+  });
+
+  it('produces a different key per page, so paged caches do not collide', () => {
+    const page1 = projectsListQueryKey(accountId, { offset: 0, limit: 10 });
+    const page2 = projectsListQueryKey(accountId, { offset: 10, limit: 10 });
+    expect(page1).not.toEqual(page2);
+  });
+
+  it('every per-page key still starts with the bare invalidation prefix', () => {
+    const key = projectsListQueryKey(accountId, { offset: 40, limit: 10 });
+    expect(key.slice(0, projectsQueryKey(accountId).length)).toEqual(projectsQueryKey(accountId));
+  });
+
+  it('falls back to a stable placeholder key with no account, matching the enabled: !!accountId gate', () => {
+    expect(projectsListQueryKey(undefined)).toEqual(['projects', 'unknown']);
+  });
+});

--- a/packages/hooks/src/projects.ts
+++ b/packages/hooks/src/projects.ts
@@ -64,23 +64,56 @@ function toProject(project: GeneratedProject): Project {
   return project;
 }
 
-async function listProjectsForAccount(accountId: string): Promise<Project[]> {
+export type UseProjectsOptions = {
+  offset?: number;
+  limit?: number;
+};
+
+/** Applies the default page (offset 0, limit 10 — matches the backend list default). */
+export function resolveProjectsOptions(
+  options: UseProjectsOptions = {}
+): Required<UseProjectsOptions> {
+  return { offset: options.offset ?? 0, limit: options.limit ?? 10 };
+}
+
+/**
+ * Per-page query key — the bare `projectsQueryKey(accountId)` prefix with `{ offset, limit }`
+ * appended on top (same pattern as `apiKeysQueryKey` in api-keys.ts). Invalidating with the
+ * bare prefix still clears every cached page. Falls back to a stable placeholder key when
+ * there is no account yet, matching the query's own `enabled: !!accountId` gate.
+ */
+export function projectsListQueryKey(
+  accountId: string | undefined,
+  options: UseProjectsOptions = {}
+) {
+  return accountId
+    ? ([...projectsQueryKey(accountId), resolveProjectsOptions(options)] as const)
+    : (['projects', 'unknown'] as const);
+}
+
+async function listProjectsForAccount(
+  accountId: string,
+  options: UseProjectsOptions = {}
+): Promise<Project[]> {
+  const { offset, limit } = resolveProjectsOptions(options);
   const page = await getAuthzRpcClient().projects.list({
-    limit: 10,
-    offset: 0,
+    limit,
+    offset,
     filters: [{ key: 'accountId', value: accountId }],
   });
   return page.items.map(toProject);
 }
 
-export function useProjects(accountId?: string) {
+export function useProjects(accountId?: string, options: UseProjectsOptions = {}) {
   const { isAuthenticated } = useAuthSession();
 
+  const { offset, limit } = resolveProjectsOptions(options);
+
   const query = useQuery({
-    queryKey: accountId ? projectsQueryKey(accountId) : ['projects', 'unknown'],
+    queryKey: projectsListQueryKey(accountId, options),
     queryFn: async () => {
       if (!accountId) throw new Error('Account ID is required');
-      return listProjectsForAccount(accountId);
+      return listProjectsForAccount(accountId, { offset, limit });
     },
     enabled: !!accountId && isAuthenticated,
     staleTime: 5 * 60_000,
@@ -389,6 +422,10 @@ export function useEnsureDefaultProject() {
 
   const mutation = useMutation({
     mutationFn: async (accountId: string) => {
+      // Deliberately called with the default { offset: 0, limit: 10 }, not threaded through
+      // UseProjectsOptions: this is an internal "does this account already have a project"
+      // existence check (mirrors useEnsureDefaultAccount), not the user-facing project list.
+      // It only ever reads `existing[0]`, so a variable offset/limit is meaningless here.
       const existing = await listProjectsForAccount(accountId);
 
       if (existing.length > 0) {

--- a/packages/i18n/src/i18n-config.ts
+++ b/packages/i18n/src/i18n-config.ts
@@ -10,6 +10,11 @@ const resources = {
           loading: 'Loading your workspace...',
         },
       },
+      pagination: {
+        page: 'Page',
+        previous: 'Previous',
+        next: 'Next',
+      },
       project: {
         defaultName: 'Default Project',
       },


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `useAccounts` / `useProjects` accept optional `{ offset, limit }`, defaulting to today's values, and fold them into the react-query key (matching what `useApiKeys` already did).
- `api-keys-screen.tsx` now drives `useApiKeys` from `usePagination` instead of a hardcoded `offset: 0`, renders the `Pagination` component, and resets to page 1 when the account or project changes.
- Adds a `pagination` i18n namespace and tests for the new hook options and the screen wiring.

It solves:

- https://github.com/ADORSYS-GIS/converse-frontends/issues/69

---

## 2. Intent

The intent of this PR is:

> Finish server-driven pagination. Note the ticket is **partly stale**: `usePagination` (`packages/hooks/src/pagination.ts`), the `Pagination` UI component and `useApiKeys`' `offset`/`limit` support all already existed. What did not exist was any consumer — `grep -rln usePagination` matched only the hook and its own test — so `api-keys-screen.tsx` still requested a fixed first page and Next/Prev could never reach a real page 2. `useAccounts`/`useProjects` were also still hardcoded to `{ limit: 10, offset: 0 }` with no way for a caller to vary them.

---

## 3. Scope

### In Scope

- `offset`/`limit` options on the accounts and projects list hooks.
- Wiring `usePagination` + `Pagination` into the API-keys list screen.
- Tests for both.

### Out of Scope

- Backend changes — the generated SDK already supports arbitrary `offset`/`limit`.
- Cursor-based pagination — offset-based matches what the backend exposes.
- Paginating the account/project **selector strips** in the same screen: they are "pick one" controls, not paged lists.
- Wiring `account-settings-screen.tsx` / `project-settings-screen.tsx`, which have the same underlying issue and are now fixable for free. Flagged as follow-ups rather than silently widening this ticket.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
pnpm --filter @lightbridge/hooks test
pnpm --dir apps/self-service test
npx tsc --noEmit
pnpm build   # rebased onto main incl. the Metro fix in #151
```

Results:

```text
packages/hooks:    rbac 10 | accounts 6 | projects 7  — all passed
apps/self-service: 24 suites, 105 tests — all passed
tsc --noEmit:      clean
pnpm build:        turbo run build:web -> Exported: dist  (1/1 successful)

Screen behaviour asserted in apps/self-service/src/__tests__/api-keys-screen.test.tsx:
  initial request uses offset 0
  Next advances offset to 10
  Previous is disabled on page 1
  switching project resets offset to 0
```

The web export could not be verified when this work was written — `main` itself could not build (see https://github.com/ADORSYS-GIS/converse-frontends/pull/151). This branch was rebased onto the repaired `main` and `pnpm build` re-run from a clean regeneration before opening this PR.

---

## 5. Screenshots / Evidence

* Source of truth: https://github.com/ADORSYS-GIS/converse-frontends/issues/69
* Parent epic: https://github.com/ADORSYS-GIS/converse-frontends/issues/67
* Test and build output pasted above.

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [x] Medium
* [ ] High

Potential risks:

* Adding `{offset, limit}` to the react-query key could strand existing `invalidateQueries` calls, silently serving stale lists after a mutation.
* `hasMore` is a heuristic. The backend returns a bare array with no total count, so "a full page means there may be more" lands the final Next on an empty page when the total is an exact multiple of the page size.
* Not resetting the page on context switch would show page N of a different project's list.

Mitigation:

* The per-page key is `[...baseQueryKey, {offset, limit}]`, so existing prefix-match invalidation still clears every cached page — the same shape `useApiKeys` already used.
* The heuristic and its edge case are documented in `pagination.ts` and surfaced through the UI rather than hidden — called out as a known limitation in the ticket, not silently accepted.
* An effect calls `reset()` when `accountId`/`projectId` changes, covered by a test.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Refactoring
* [x] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Implemented by Claude Code (Sonnet subagent under an Opus 5 orchestrator) on behalf of @stephane-segning. The ticket's premise was re-checked against the code first, which is how the already-built half was found; the build was re-verified after rebasing onto the repaired `main`.

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

**Human attestation pending @stephane-segning's review** — an agent must not tick the accountable human's boxes on their behalf.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [x] Tests
* [ ] Maintainability
* [ ] Product intent
* [x] Edge cases

Specifically: the decision to leave `useEnsureDefaultAccount` / `useEnsureDefaultProject` hardcoded at `{limit: 10, offset: 0}`. Both are internal "does a default already exist" checks that only read `items[0]`, so a variable offset is meaningless there — but it is a deliberate inconsistency and worth a second opinion. Also worth confirming the query-key change against every existing `invalidateQueries` call site.
