### PR TITLE
feat(self-service): notify leads that model allowlists are now enforced (v3.0.0)

### DIFF
--- a/apps/self-service/src/components/__tests__/allowlist-enforcement-notice.test.tsx
+++ b/apps/self-service/src/components/__tests__/allowlist-enforcement-notice.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
+import { Platform } from 'react-native';
+import { initI18n } from '@lightbridge/i18n';
+
+// Exercise the web (localStorage) storage branch, so assertions can stay
+// synchronous. The native (SecureStore) branch is covered by
+// use-dismissible-notice.test.ts — this file is about the component's
+// rendering/dismissal behavior, not the storage mechanism itself.
+Platform.OS = 'web';
+
+class MemoryStorage {
+  private store = new Map<string, string>();
+  getItem(key: string) {
+    return this.store.has(key) ? (this.store.get(key) as string) : null;
+  }
+  setItem(key: string, value: string) {
+    this.store.set(key, String(value));
+  }
+  removeItem(key: string) {
+    this.store.delete(key);
+  }
+  clear() {
+    this.store.clear();
+  }
+}
+(globalThis as { localStorage?: Storage }).localStorage = new MemoryStorage() as unknown as Storage;
+
+import { AllowlistEnforcementNotice } from '../allowlist-enforcement-notice';
+
+const NOTICE_TEXT = /this allowlist is now enforced/;
+
+beforeAll(() => {
+  initI18n('en');
+});
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('AllowlistEnforcementNotice', () => {
+  it('renders, showing the current allowlist, when the allowlist is non-empty', async () => {
+    await render(
+      <AllowlistEnforcementNotice projectId="proj-1" models={['gpt-4o', 'claude-sonnet-5']} />
+    );
+
+    expect(
+      screen.getByText(
+        'Heads up: this allowlist is now enforced. Calls to models not on this list will be rejected. Currently allowed: gpt-4o, claude-sonnet-5.'
+      )
+    ).toBeTruthy();
+  });
+
+  it('does not render when the allowlist is empty', async () => {
+    await render(<AllowlistEnforcementNotice projectId="proj-1" models={[]} />);
+
+    expect(screen.queryByText(NOTICE_TEXT)).toBeNull();
+  });
+
+  it('dismisses on press and does not reappear on a later mount for the same project', async () => {
+    const first = await render(
+      <AllowlistEnforcementNotice projectId="proj-1" models={['gpt-4o']} />
+    );
+
+    expect(screen.getByText(NOTICE_TEXT)).toBeTruthy();
+
+    await fireEvent.press(screen.getByLabelText('Got it'));
+
+    expect(screen.queryByText(NOTICE_TEXT)).toBeNull();
+
+    await act(async () => {
+      first.unmount();
+    });
+
+    await render(<AllowlistEnforcementNotice projectId="proj-1" models={['gpt-4o']} />);
+    expect(screen.queryByText(NOTICE_TEXT)).toBeNull();
+  });
+
+  it('dismissal is scoped per project — a different project still sees the notice', async () => {
+    localStorage.setItem('lightbridge.notice.allowlist-enforced.proj-1', 'true');
+
+    await render(<AllowlistEnforcementNotice projectId="proj-2" models={['gpt-4o']} />);
+
+    expect(screen.getByText(NOTICE_TEXT)).toBeTruthy();
+  });
+});

--- a/apps/self-service/src/components/allowlist-enforcement-notice.tsx
+++ b/apps/self-service/src/components/allowlist-enforcement-notice.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { useTranslation } from '@lightbridge/i18n';
+import { Button, Callout, designTokens, Icon as Feather, Stack } from '@lightbridge/ui';
+
+import { useThemeColors } from '../hooks/use-theme-colors';
+import { useDismissibleNotice } from '../hooks/use-dismissible-notice';
+
+type AllowlistEnforcementNoticeProps = {
+  /** Scopes the dismissal (and the copy's model list) to one project. */
+  projectId: string;
+  /** The project's current `allowedModels`. Empty ⇒ this project's behavior didn't change. */
+  models: string[];
+};
+
+/**
+ * One-time notice for a project lead whose project already had a non-empty
+ * model allowlist configured before `lightbridge-authz` v3.0.0 started
+ * actually enforcing it (ADORSYS-GIS/lightbridge-authz#282, #283 — the
+ * allowlist was silently never enforced until that release). Projects with an
+ * empty allowlist never render this: their behavior didn't change.
+ *
+ * Dismissal is per project and persists across visits (see
+ * `useDismissibleNotice`), so a lead who has already acknowledged it won't
+ * see it again.
+ */
+export function AllowlistEnforcementNotice({
+  projectId,
+  models,
+}: Readonly<AllowlistEnforcementNoticeProps>) {
+  const { t } = useTranslation();
+  const colors = useThemeColors();
+  const { isDismissed, isReady, dismiss } = useDismissibleNotice(`allowlist-enforced.${projectId}`);
+
+  if (models.length === 0 || !isReady || isDismissed) {
+    return null;
+  }
+
+  return (
+    <Stack direction="row" gap="sm" align="start" width="full">
+      <Stack flex="grow">
+        <Callout
+          tone="info"
+          icon={<Feather name="info" size={designTokens.icon.action} color={colors.primary} />}>
+          {t('settings.project.allowlistEnforcedNotice', { models: models.join(', ') })}
+        </Callout>
+      </Stack>
+      <Button
+        variant="ghost"
+        size="iconSm"
+        onPress={dismiss}
+        accessibilityLabel={t('settings.project.allowlistEnforcedDismiss')}>
+        <Feather name="x" size={designTokens.icon.action} color={colors.subtle} />
+      </Button>
+    </Stack>
+  );
+}

--- a/apps/self-service/src/hooks/__tests__/use-dismissible-notice-web.test.ts
+++ b/apps/self-service/src/hooks/__tests__/use-dismissible-notice-web.test.ts
@@ -1,0 +1,66 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { Platform } from 'react-native';
+
+// Force the web branch (localStorage-backed) for this file. jest-expo's
+// default test platform is 'ios' — see use-dismissible-notice.test.ts for the
+// native (SecureStore) branch.
+Platform.OS = 'web';
+
+// The jest-expo env is node (no jsdom) → no `localStorage`. Same shim used by
+// apps/self-service/src/theme/__tests__/theme-preference.test.tsx.
+class MemoryStorage {
+  private store = new Map<string, string>();
+  getItem(key: string) {
+    return this.store.has(key) ? (this.store.get(key) as string) : null;
+  }
+  setItem(key: string, value: string) {
+    this.store.set(key, String(value));
+  }
+  removeItem(key: string) {
+    this.store.delete(key);
+  }
+  clear() {
+    this.store.clear();
+  }
+}
+(globalThis as { localStorage?: Storage }).localStorage = new MemoryStorage() as unknown as Storage;
+
+import { useDismissibleNotice } from '../use-dismissible-notice';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('useDismissibleNotice (web)', () => {
+  it('is ready synchronously and reports not-dismissed when nothing is stored', async () => {
+    const { result } = await renderHook(() => useDismissibleNotice('test-notice'));
+
+    expect(result.current.isReady).toBe(true);
+    expect(result.current.isDismissed).toBe(false);
+  });
+
+  it('hydrates a prior dismissal from localStorage synchronously', async () => {
+    localStorage.setItem('lightbridge.notice.test-notice', 'true');
+
+    const { result } = await renderHook(() => useDismissibleNotice('test-notice'));
+
+    expect(result.current.isDismissed).toBe(true);
+  });
+
+  it('dismiss() persists to localStorage and does not reappear on a later mount', async () => {
+    const { result, unmount } = await renderHook(() => useDismissibleNotice('test-notice'));
+
+    await act(async () => {
+      result.current.dismiss();
+    });
+
+    expect(localStorage.getItem('lightbridge.notice.test-notice')).toBe('true');
+
+    await act(async () => {
+      unmount();
+    });
+
+    const { result: remounted } = await renderHook(() => useDismissibleNotice('test-notice'));
+    expect(remounted.current.isDismissed).toBe(true);
+  });
+});

--- a/apps/self-service/src/hooks/__tests__/use-dismissible-notice.test.ts
+++ b/apps/self-service/src/hooks/__tests__/use-dismissible-notice.test.ts
@@ -1,0 +1,78 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(),
+  setItemAsync: jest.fn(),
+}));
+
+import * as SecureStore from 'expo-secure-store';
+import { useDismissibleNotice } from '../use-dismissible-notice';
+
+const mockGetItemAsync = SecureStore.getItemAsync as jest.Mock;
+const mockSetItemAsync = SecureStore.setItemAsync as jest.Mock;
+
+// jest-expo's default test platform is 'ios' (confirmed by inspection), so this
+// file exercises the native (SecureStore) branch. The web (localStorage)
+// branch is covered separately in use-dismissible-notice-web.test.ts.
+describe('useDismissibleNotice (native)', () => {
+  beforeEach(() => {
+    mockGetItemAsync.mockReset();
+    mockSetItemAsync.mockReset();
+    mockSetItemAsync.mockResolvedValue(undefined);
+  });
+
+  it('is not ready until the SecureStore read resolves, then reports not-dismissed', async () => {
+    let resolveRead: (value: string | null) => void = () => undefined;
+    mockGetItemAsync.mockImplementation(
+      () =>
+        new Promise<string | null>((resolve) => {
+          resolveRead = resolve;
+        })
+    );
+
+    const { result } = await renderHook(() => useDismissibleNotice('test-notice'));
+
+    expect(result.current.isReady).toBe(false);
+    expect(mockGetItemAsync).toHaveBeenCalledWith('lightbridge.notice.test-notice');
+
+    await act(async () => {
+      resolveRead(null);
+    });
+
+    expect(result.current.isReady).toBe(true);
+    expect(result.current.isDismissed).toBe(false);
+  });
+
+  it('reports dismissed when a prior dismissal was persisted', async () => {
+    mockGetItemAsync.mockResolvedValue('true');
+
+    const { result } = await renderHook(() => useDismissibleNotice('test-notice'));
+
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+    expect(result.current.isDismissed).toBe(true);
+  });
+
+  it('dismiss() flips state immediately and persists via SecureStore', async () => {
+    mockGetItemAsync.mockResolvedValue(null);
+
+    const { result } = await renderHook(() => useDismissibleNotice('test-notice'));
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+
+    await act(async () => {
+      result.current.dismiss();
+    });
+
+    expect(result.current.isDismissed).toBe(true);
+    expect(mockSetItemAsync).toHaveBeenCalledWith('lightbridge.notice.test-notice', 'true');
+  });
+
+  it('scopes storage keys per notice id, so two ids never collide', async () => {
+    mockGetItemAsync.mockResolvedValue(null);
+
+    await renderHook(() => useDismissibleNotice('allowlist-enforced.proj-1'));
+    await renderHook(() => useDismissibleNotice('allowlist-enforced.proj-2'));
+
+    expect(mockGetItemAsync).toHaveBeenCalledWith('lightbridge.notice.allowlist-enforced.proj-1');
+    expect(mockGetItemAsync).toHaveBeenCalledWith('lightbridge.notice.allowlist-enforced.proj-2');
+  });
+});

--- a/apps/self-service/src/hooks/use-dismissible-notice.ts
+++ b/apps/self-service/src/hooks/use-dismissible-notice.ts
@@ -1,0 +1,104 @@
+import { useEffect, useState } from 'react';
+import { Platform } from 'react-native';
+import * as SecureStore from 'expo-secure-store';
+
+const KEY_PREFIX = 'lightbridge.notice.';
+
+/**
+ * Storage for one-time, dismissible in-app notices. Mirrors the platform
+ * split used by `packages/hooks/src/auth/auth-storage.ts` (SecureStore on
+ * native), but reads/writes web state through `localStorage` instead of
+ * `idb-keyval` — the same web-storage mechanism `ThemePreferenceProvider`
+ * (`apps/self-service/src/theme/theme-preference.tsx`) already relies on in
+ * this app — rather than adding a new dependency to this package for a
+ * single boolean flag per notice.
+ */
+function readDismissedSync(key: string): boolean {
+  if (typeof localStorage === 'undefined') {
+    return false;
+  }
+  try {
+    return localStorage.getItem(key) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+async function readDismissed(key: string): Promise<boolean> {
+  if (Platform.OS === 'web') {
+    return readDismissedSync(key);
+  }
+  try {
+    const raw = await SecureStore.getItemAsync(key);
+    return raw === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function writeDismissed(key: string): void {
+  if (Platform.OS === 'web') {
+    try {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem(key, 'true');
+      }
+    } catch {
+      // Best-effort: private-mode/blocked storage just means the notice may
+      // reappear next visit, which is an acceptable degradation.
+    }
+    return;
+  }
+  void SecureStore.setItemAsync(key, 'true').catch(() => undefined);
+}
+
+/**
+ * Tracks whether a one-time notice identified by `id` has already been
+ * dismissed, persisting the acknowledgement so it does not reappear on later
+ * visits.
+ *
+ * On web the stored value is available synchronously (`localStorage`), so
+ * `isReady` starts `true` and there's no flash of the notice before its
+ * dismissed state is known. On native, `SecureStore` is async, so callers
+ * should treat `isReady === false` as "don't render yet" to avoid a flash of
+ * a notice that turns out to already be dismissed.
+ */
+export function useDismissibleNotice(id: string): {
+  isDismissed: boolean;
+  isReady: boolean;
+  dismiss: () => void;
+} {
+  const key = `${KEY_PREFIX}${id}`;
+  const [isDismissed, setIsDismissed] = useState<boolean>(() =>
+    Platform.OS === 'web' ? readDismissedSync(key) : false
+  );
+  const [isReady, setIsReady] = useState<boolean>(Platform.OS === 'web');
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (Platform.OS === 'web') {
+      setIsDismissed(readDismissedSync(key));
+      setIsReady(true);
+      return;
+    }
+
+    setIsReady(false);
+    void readDismissed(key).then((value) => {
+      if (!cancelled) {
+        setIsDismissed(value);
+        setIsReady(true);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [key]);
+
+  const dismiss = () => {
+    setIsDismissed(true);
+    writeDismissed(key);
+  };
+
+  return { isDismissed, isReady, dismiss };
+}

--- a/apps/self-service/src/views/settings/__tests__/project-settings-view.test.tsx
+++ b/apps/self-service/src/views/settings/__tests__/project-settings-view.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react-native';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import { initI18n } from '@lightbridge/i18n';
 import type { Account, Project } from '@lightbridge/hooks';
 
@@ -143,6 +143,21 @@ describe('ProjectSettingsView', () => {
     expect(screen.getByText('All models are allowed.')).toBeTruthy();
   });
 
+  it('shows the allowlist-enforcement notice for a project with a non-empty allowlist', async () => {
+    await renderView();
+
+    await waitFor(() => expect(screen.getByText(/this allowlist is now enforced/)).toBeTruthy());
+  });
+
+  it('never shows the allowlist-enforcement notice for a project with an empty allowlist', async () => {
+    await renderView({ project: { ...project, allowedModels: [] } });
+
+    // Give any pending storage-read effects a turn — the notice must stay
+    // absent either way, since an empty allowlist means nothing changed.
+    await waitFor(() => expect(screen.getByText('All models are allowed.')).toBeTruthy());
+    expect(screen.queryByText(/this allowlist is now enforced/)).toBeNull();
+  });
+
   it('calls onSaveLimits with parsed limits, mapping empty drafts to null', async () => {
     const onSaveLimits = jest.fn();
     await renderView({ onSaveLimits });
@@ -213,11 +228,25 @@ describe('ProjectSettingsView', () => {
     expect(onCreateProject).toHaveBeenCalled();
   });
 
-  it('renders the roster with each member\'s role and quota tier', async () => {
+  it("renders the roster with each member's role and quota tier", async () => {
     await renderView({
       members: [
-        { id: 'proj-1:sub-lead', projectId: 'proj-1', accountId: 'sub-lead', role: 'lead', quotaTier: 't-m', createdAt: '' },
-        { id: 'proj-1:sub-plain', projectId: 'proj-1', accountId: 'sub-plain', role: 'member', quotaTier: null, createdAt: '' },
+        {
+          id: 'proj-1:sub-lead',
+          projectId: 'proj-1',
+          accountId: 'sub-lead',
+          role: 'lead',
+          quotaTier: 't-m',
+          createdAt: '',
+        },
+        {
+          id: 'proj-1:sub-plain',
+          projectId: 'proj-1',
+          accountId: 'sub-plain',
+          role: 'member',
+          quotaTier: null,
+          createdAt: '',
+        },
       ],
     });
 
@@ -253,7 +282,14 @@ describe('ProjectSettingsView', () => {
     const onSetMemberRole = jest.fn();
     await renderView({
       members: [
-        { id: 'proj-1:sub-plain', projectId: 'proj-1', accountId: 'sub-plain', role: 'member', quotaTier: null, createdAt: '' },
+        {
+          id: 'proj-1:sub-plain',
+          projectId: 'proj-1',
+          accountId: 'sub-plain',
+          role: 'member',
+          quotaTier: null,
+          createdAt: '',
+        },
       ],
       onSetMemberRole,
     });
@@ -268,9 +304,7 @@ describe('ProjectSettingsView', () => {
     // role=lead, so the UI must show the 403 rather than silently doing nothing.
     await renderView({ memberError: 'Forbidden: only a project lead may change the roster' });
 
-    expect(
-      screen.getByText('Forbidden: only a project lead may change the roster')
-    ).toBeTruthy();
+    expect(screen.getByText('Forbidden: only a project lead may change the roster')).toBeTruthy();
   });
 
   it('hides the members section entirely without the project:member capability', async () => {

--- a/apps/self-service/src/views/settings/project-settings-view.tsx
+++ b/apps/self-service/src/views/settings/project-settings-view.tsx
@@ -20,6 +20,7 @@ import {
   TextField,
 } from '@lightbridge/ui';
 import type { Account, Project, ProjectMember } from '@lightbridge/hooks';
+import { AllowlistEnforcementNotice } from '../../components/allowlist-enforcement-notice';
 import { useThemeColors } from '../../hooks/use-theme-colors';
 import { formatDate } from '../api-keys-list-view';
 
@@ -408,6 +409,10 @@ export function ProjectSettingsView({
               ) : null}
 
               {canUpdate ? (
+                <AllowlistEnforcementNotice projectId={project.id} models={models} />
+              ) : null}
+
+              {canUpdate ? (
                 <SectionCard
                   title={t('settings.project.modelsSection')}
                   description={t('settings.project.modelsDescription')}>
@@ -584,10 +589,7 @@ export function ProjectSettingsView({
                                     size="sm"
                                     disabled={isSavingMembers}
                                     onPress={() =>
-                                      onSetMemberRole(
-                                        member.accountId,
-                                        isLead ? 'member' : 'lead'
-                                      )
+                                      onSetMemberRole(member.accountId, isLead ? 'member' : 'lead')
                                     }>
                                     {isLead
                                       ? t('settings.project.memberDemote')

--- a/packages/i18n/src/i18n-config.ts
+++ b/packages/i18n/src/i18n-config.ts
@@ -205,6 +205,9 @@ const resources = {
           modelsDescription:
             'Models that API keys in this project may call. Leave empty to allow all models.',
           modelsEmpty: 'All models are allowed.',
+          allowlistEnforcedNotice:
+            'Heads up: this allowlist is now enforced. Calls to models not on this list will be rejected. Currently allowed: {{models}}.',
+          allowlistEnforcedDismiss: 'Got it',
           modelAddPlaceholder: 'gpt-4o, claude-sonnet-5, ...',
           modelAdd: 'Add',
           modelRemove: 'Remove {{name}}',


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds `AllowlistEnforcementNotice` (`apps/self-service/src/components/allowlist-enforcement-notice.tsx`), composing the existing `Callout` primitive.
- Adds a reusable `useDismissibleNotice` hook with platform-split persistence (`expo-secure-store` native, `localStorage` web).
- Renders the notice in `project-settings-view.tsx`, above the allowed-models section, only when the project's allowlist is non-empty.
- Adds copy under the existing `settings.project` i18n block, plus tests.

It solves:

- https://github.com/ADORSYS-GIS/converse-frontends/issues/143

---

## 2. Intent

The intent of this PR is:

> Stop project leads being blindsided. `lightbridge-authz` v3.0.0 (live in production since 2026-08-14) shipped https://github.com/ADORSYS-GIS/lightbridge-authz/pull/283, which fixed a bug where `projects.allowed_models` was **silently never enforced** — every model was permitted regardless of what a lead configured on this app's settings screen. The fix is correct, but for any project that already had a non-empty allowlist it is a live behaviour change: calls to unlisted models now fail. The UI was never wrong; the backend ignored it. So the remedy here is purely comms — no API or schema change.

---

## 3. Scope

### In Scope

- A one-time, dismissible inline notice shown only for projects with a non-empty allowlist, showing the current list inline.
- Per-project dismissal persistence.

### Out of Scope

- Any `lightbridge-authz` change — the backend fix already shipped in v3.0.0.
- A general-purpose in-app changelog/announcement system.
- **The cross-project audit AC** — see Risk Assessment. It needs backend support that does not exist.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
pnpm --dir apps/self-service test
npx tsc --noEmit
pnpm lint
pnpm build   # rebased onto main incl. the Metro fix in #151
```

Results:

```text
apps/self-service: 26 suites, 114 tests — all passed
tsc --noEmit:      clean
pnpm build:        turbo run build:web -> Exported: dist  (1/1 successful)

Covered by tests:
  renders for a non-empty allowlist
  does NOT render for an empty allowlist
  does not reappear after dismissal
  dismissing project A does not suppress the notice for project B
```

The web export could not be verified when this work was written — `main` itself could not build (see https://github.com/ADORSYS-GIS/converse-frontends/pull/151). This branch was rebased onto the repaired `main` and `pnpm build` re-run before opening this PR.

---

## 5. Screenshots / Evidence

* Source of truth: https://github.com/ADORSYS-GIS/converse-frontends/issues/143
* The bug: https://github.com/ADORSYS-GIS/lightbridge-authz/issues/282 — the fix: https://github.com/ADORSYS-GIS/lightbridge-authz/pull/283
* Release that made it live: https://github.com/ADORSYS-GIS/lightbridge-authz/releases/tag/v3.0.0
* Copy shipped: *"Heads up: this allowlist is now enforced. Calls to models not on this list will be rejected. Currently allowed: {{models}}."*
* No screenshots: the screens are Keycloak-gated, so a live capture needs a running auth stack. Behaviour is covered by the component tests above instead.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* **The ticket's audit AC is not met.** It asks for an audit identifying every live project with a non-empty allowlist. No such query exists, and it is architecturally foreclosed rather than merely absent: every `Project` and `Account` read in `authz.cstack` is row-level-policy-scoped to `auth().id`, and the schema defines no service/admin principal, so there is not even an N+1 workaround. Leads whose projects are already failing will only see this on their next visit.
* Notices that reappear after dismissal are worse than no notice.
* Copy collision: "quota tier" (per-member request rate) vs. the budget "tier" concept arriving in #148.

Mitigation:

* The audit gap is reported, not papered over — it needs a service-scoped backend query, exactly as the ticket anticipated. Filed as a follow-up rather than inventing a backend dependency here.
* Dismissal is keyed per project (`lightbridge.notice.allowlist-enforced.<projectId>`) and covered by a cross-project test. `localStorage` was chosen on web over `idb-keyval` because it is synchronous (no flash-of-notice), matches what `ThemePreferenceProvider` already uses, and avoids adding a dependency.
* This notice's copy says "allowlist", never "tier".

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [x] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Implemented by Claude Code (Sonnet subagent under an Opus 5 orchestrator) on behalf of @stephane-segning. The audit-feasibility claim comes from reading the schema's row-level policies directly; no all-projects query was invented to satisfy an AC that the backend cannot currently support.

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

**Human attestation pending @stephane-segning's review** — an agent must not tick the accountable human's boxes on their behalf.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [x] Product intent
* [x] Edge cases

Specifically: **the copy** — this is the entire deliverable, and it needs to land for someone whose integration may already be broken without being alarmist. Also whether a passive per-visit notice is sufficient given the ticket's own note that affected consumers may be failing right now, or whether direct outreach is warranted alongside it. That is a product call the ticket explicitly flagged rather than assumed.
