### PR TITLE
feat(ui): add Avatar, Spinner, DataCard, StatCard, ConfirmDialog and Toolbar primitives

### DIFF
--- a/packages/ui/src/components/avatar/component.stories.tsx
+++ b/packages/ui/src/components/avatar/component.stories.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { Stack } from '../stack';
+import { Avatar } from './component';
+
+const meta: Meta<typeof Avatar> = {
+  title: 'UI/Avatar',
+  component: Avatar,
+  args: {
+    name: 'Ada Lovelace',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Avatar>;
+
+export const Initials: Story = {};
+
+export const SingleName: Story = {
+  args: { name: 'Cher' },
+};
+
+export const WithImage: Story = {
+  args: {
+    name: 'Grace Hopper',
+    src: 'https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=128&h=128&fit=crop&crop=faces',
+  },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <Stack direction="row" gap="sm" align="center">
+      <Avatar name="Ada Lovelace" size="sm" />
+      <Avatar name="Ada Lovelace" size="md" />
+      <Avatar name="Ada Lovelace" size="lg" />
+      <Avatar name="Ada Lovelace" size="xl" />
+    </Stack>
+  ),
+};

--- a/packages/ui/src/components/avatar/component.tsx
+++ b/packages/ui/src/components/avatar/component.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+import type { TextProps, ViewProps } from 'react-native';
+
+import { cn } from '../../cn';
+import { Image } from '../image';
+import { avatarInitialsVariants, avatarVariants } from './cva';
+import type { AvatarProps } from './types';
+
+const ViewBase = View as React.ComponentType<ViewProps & { className?: string }>;
+const TextBase = Text as React.ComponentType<TextProps & { className?: string }>;
+
+/** Up to two initials from the first two words of `name` (e.g. "Ada Lovelace" -> "AL"). */
+function initialsFrom(name: string) {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '';
+  const first = parts[0]?.[0] ?? '';
+  const second = parts.length > 1 ? (parts[parts.length - 1]?.[0] ?? '') : '';
+  return (first + second).toUpperCase();
+}
+
+export function Avatar({ name, src, size, style, ...props }: AvatarProps) {
+  return (
+    <ViewBase
+      accessibilityRole="image"
+      accessibilityLabel={name}
+      className={cn(avatarVariants({ size }))}
+      style={style}
+      {...props}>
+      {src ? (
+        <Image source={{ uri: src }} style={{ width: '100%', height: '100%' }} />
+      ) : (
+        <TextBase className={cn(avatarInitialsVariants({ size }))}>{initialsFrom(name)}</TextBase>
+      )}
+    </ViewBase>
+  );
+}

--- a/packages/ui/src/components/avatar/cva.tsx
+++ b/packages/ui/src/components/avatar/cva.tsx
@@ -1,0 +1,34 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export const avatarVariants = cva(
+  'items-center justify-center overflow-hidden rounded-full bg-muted',
+  {
+    variants: {
+      size: {
+        sm: 'h-8 w-8',
+        md: 'h-10 w-10',
+        lg: 'h-12 w-12',
+        xl: 'h-16 w-16',
+      },
+    },
+    defaultVariants: {
+      size: 'md',
+    },
+  }
+);
+
+export const avatarInitialsVariants = cva('font-semibold text-soft', {
+  variants: {
+    size: {
+      sm: 'text-xs',
+      md: 'text-sm',
+      lg: 'text-base',
+      xl: 'text-xl',
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+  },
+});
+
+export type AvatarVariantProps = VariantProps<typeof avatarVariants>;

--- a/packages/ui/src/components/avatar/index.tsx
+++ b/packages/ui/src/components/avatar/index.tsx
@@ -1,0 +1,3 @@
+export { Avatar } from './component';
+export { avatarInitialsVariants, avatarVariants } from './cva';
+export type { AvatarProps } from './types';

--- a/packages/ui/src/components/avatar/types.tsx
+++ b/packages/ui/src/components/avatar/types.tsx
@@ -1,0 +1,11 @@
+import type { ViewProps } from 'react-native';
+
+import type { AvatarVariantProps } from './cva';
+
+export type AvatarProps = ViewProps &
+  AvatarVariantProps & {
+    /** Full name used to derive fallback initials and the default accessibility label. */
+    name: string;
+    /** Image URI. When omitted the initials fallback renders instead. */
+    src?: string;
+  };

--- a/packages/ui/src/components/confirm-dialog/component.stories.tsx
+++ b/packages/ui/src/components/confirm-dialog/component.stories.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { Text } from '../text';
+import { TextField } from '../text-field';
+import { ConfirmDialog } from './component';
+
+const meta: Meta<typeof ConfirmDialog> = {
+  title: 'UI/ConfirmDialog',
+  component: ConfirmDialog,
+  args: {
+    title: 'Revoke this key?',
+    message: 'Any requests made with this key will start failing immediately.',
+    confirmLabel: 'Revoke',
+    cancelLabel: 'Cancel',
+    onCancel: () => undefined,
+    onConfirm: () => undefined,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 420 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ConfirmDialog>;
+
+/** Named component (not an inline arrow) so the `useState` below is a real
+ * React component's hook, not a Storybook `render` closure — Storybook's
+ * `render` functions aren't components by React's rules, so hooks called
+ * directly inside one trip `react-hooks/rules-of-hooks`. */
+function TypedConfirmationDemo(args: React.ComponentProps<typeof ConfirmDialog>) {
+  const target = 'my-account';
+  const [value, setValue] = useState('');
+  return (
+    <ConfirmDialog {...args} confirmDisabled={value.trim() !== target}>
+      <Text intent="caption">
+        Type <Text intent="bodyStrong">{target}</Text> to confirm.
+      </Text>
+      <TextField
+        value={value}
+        onChangeText={setValue}
+        placeholder={target}
+        autoCapitalize="none"
+        autoCorrect={false}
+      />
+    </ConfirmDialog>
+  );
+}
+
+export const Neutral: Story = {};
+
+export const Danger: Story = {
+  args: {
+    tone: 'danger',
+    title: 'Delete this project?',
+    message: 'This permanently deletes the project and everything in it. This cannot be undone.',
+    confirmLabel: 'Delete project',
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    tone: 'danger',
+    title: 'Delete this project?',
+    message: 'This permanently deletes the project and everything in it. This cannot be undone.',
+    confirmLabel: 'Deleting…',
+    loading: true,
+  },
+};
+
+/**
+ * Typed-confirmation gate for the most destructive actions (account/project
+ * deletion): the caller owns the input + matching logic and drives
+ * `confirmDisabled`, mirroring the app's existing delete-account/
+ * delete-project views.
+ */
+export const TypedConfirmation: Story = {
+  args: {
+    tone: 'danger',
+    title: 'Delete this account?',
+    message: 'This permanently deletes your account and all of its data.',
+    confirmLabel: 'Delete account',
+  },
+  render: (args) => <TypedConfirmationDemo {...args} />,
+};

--- a/packages/ui/src/components/confirm-dialog/component.tsx
+++ b/packages/ui/src/components/confirm-dialog/component.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { View } from 'react-native';
+import type { ViewProps } from 'react-native';
+
+import { cn } from '../../cn';
+import { Button } from '../button';
+import { Stack } from '../stack';
+import { Text } from '../text';
+import { confirmDialogVariants } from './cva';
+import type { ConfirmDialogProps } from './types';
+
+const ViewBase = View as React.ComponentType<ViewProps & { className?: string }>;
+
+/**
+ * A self-contained "confirm or cancel" surface — present it as the content
+ * of an imperative sheet:
+ *
+ * ```tsx
+ * const sheet = useSheet();
+ * sheet.present(({ dismiss }) => (
+ *   <ConfirmDialog
+ *     title={t('revoke.title')}
+ *     message={t('revoke.message', { name })}
+ *     confirmLabel={t('revoke.confirm')}
+ *     cancelLabel={t('revoke.cancel')}
+ *     tone="danger"
+ *     loading={revoke.isPending}
+ *     onCancel={dismiss}
+ *     onConfirm={async () => { await revoke.mutateAsync(id); dismiss(); }}
+ *   />
+ * ));
+ * ```
+ *
+ * This is exactly the shape useSheet()'s own doc example anticipates
+ * (`sheet.present(({ dismiss }) => <ConfirmView onCancel={dismiss} … />)`),
+ * generalized out of the app's repeated delete/revoke views. For a typed
+ * "type PROJECT-NAME to confirm" affordance, pass a TextField as `children`
+ * and drive `confirmDisabled` from its value — see the app's
+ * delete-project/delete-account views for that pattern; this primitive
+ * only owns the disable-until-ready gate, not the string-matching logic
+ * (which stays app-owned since it's tied to i18n'd fallback copy).
+ *
+ * Not a modal/overlay itself — it has no backdrop or dismiss-on-outside-tap.
+ * Host it in `<Sheet>`/`useSheet()` (imperative bottom sheet) for that, or
+ * inline in a page for a non-modal confirmation.
+ */
+export function ConfirmDialog({
+  title,
+  message,
+  icon,
+  confirmLabel,
+  cancelLabel,
+  onConfirm,
+  onCancel,
+  loading = false,
+  confirmDisabled = false,
+  tone,
+  children,
+  ...props
+}: ConfirmDialogProps) {
+  return (
+    <ViewBase className={cn(confirmDialogVariants({ tone }))} {...props}>
+      <Stack gap="md">
+        <Stack direction="row" gap="sm" align="start">
+          {icon}
+          <Stack gap="xs" style={{ flex: 1 }}>
+            <Text intent="bodyStrong">{title}</Text>
+            {message ? (
+              typeof message === 'string' ? (
+                <Text intent="body">{message}</Text>
+              ) : (
+                message
+              )
+            ) : null}
+          </Stack>
+        </Stack>
+        {children}
+        <Stack direction="row" gap="sm">
+          <Button variant="ghost" onPress={onCancel} disabled={loading} style={{ flex: 1 }}>
+            {cancelLabel}
+          </Button>
+          <Button
+            variant={tone === 'danger' ? 'danger' : 'primary'}
+            onPress={onConfirm}
+            disabled={loading || confirmDisabled}
+            style={{ flex: 1 }}>
+            {confirmLabel}
+          </Button>
+        </Stack>
+      </Stack>
+    </ViewBase>
+  );
+}

--- a/packages/ui/src/components/confirm-dialog/cva.tsx
+++ b/packages/ui/src/components/confirm-dialog/cva.tsx
@@ -1,0 +1,17 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+
+// Mirrors SectionCard's default/danger tones: a confirm dialog is a card
+// whose only job is to ask one question and offer two ways out.
+export const confirmDialogVariants = cva('w-full rounded-2xl bg-surface', {
+  variants: {
+    tone: {
+      neutral: 'p-6 shadow-sm',
+      danger: 'border border-error p-6',
+    },
+  },
+  defaultVariants: {
+    tone: 'neutral',
+  },
+});
+
+export type ConfirmDialogVariantProps = VariantProps<typeof confirmDialogVariants>;

--- a/packages/ui/src/components/confirm-dialog/index.tsx
+++ b/packages/ui/src/components/confirm-dialog/index.tsx
@@ -1,0 +1,3 @@
+export { ConfirmDialog } from './component';
+export { confirmDialogVariants } from './cva';
+export type { ConfirmDialogProps } from './types';

--- a/packages/ui/src/components/confirm-dialog/types.tsx
+++ b/packages/ui/src/components/confirm-dialog/types.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from 'react';
+import type { ViewProps } from 'react-native';
+
+import type { ConfirmDialogVariantProps } from './cva';
+
+export type ConfirmDialogProps = ViewProps &
+  ConfirmDialogVariantProps & {
+    title: string;
+    message?: ReactNode;
+    /** Leading icon slot, e.g. a Div-wrapped Feather glyph. */
+    icon?: ReactNode;
+    confirmLabel: string;
+    cancelLabel: string;
+    onConfirm: () => void;
+    /** Typically the sheet's `dismiss` — see useSheet(). */
+    onCancel: () => void;
+    loading?: boolean;
+    /** Gate confirm without hiding it — e.g. while a typed-confirmation input doesn't match. */
+    confirmDisabled?: boolean;
+    /** Content between the message and the action row — a typed-confirmation TextField, a checkbox, etc. */
+    children?: ReactNode;
+  };

--- a/packages/ui/src/components/data-card/component.stories.tsx
+++ b/packages/ui/src/components/data-card/component.stories.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { Avatar } from '../avatar';
+import { Badge } from '../badge';
+import { Button } from '../button';
+import { DataCard } from './component';
+
+const meta: Meta<typeof DataCard> = {
+  title: 'UI/DataCard',
+  component: DataCard,
+  args: {
+    title: 'Production key',
+    subtitle: 'sk_live_••••8f2a',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 420 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof DataCard>;
+
+export const Default: Story = {
+  args: {
+    status: <Badge tone="success">Active</Badge>,
+    items: [
+      { label: 'Environment', value: 'Production' },
+      { label: 'Created', value: 'Jul 2, 2026' },
+      { label: 'Last used', value: '2 hours ago' },
+      { label: 'Requests (24h)', value: '4,208' },
+    ],
+  },
+};
+
+export const WithAvatarAndActions: Story = {
+  args: {
+    title: 'Personal projects',
+    subtitle: '12 members',
+    leading: <Avatar name="Personal projects" size="md" />,
+    trailing: (
+      <Button variant="ghost" size="sm">
+        Manage
+      </Button>
+    ),
+    items: [
+      { label: 'Plan', value: 'Team' },
+      { label: 'Region', value: 'eu-central' },
+    ],
+  },
+};
+
+export const Muted: Story = {
+  args: {
+    tone: 'muted',
+    title: 'Revoked key',
+    subtitle: 'sk_test_••••11c4',
+    status: <Badge tone="neutral">Revoked</Badge>,
+  },
+};
+
+export const Pressable: Story = {
+  args: {
+    title: 'Open the docs project',
+    subtitle: 'Last deploy 3 days ago',
+    onPress: () => undefined,
+    items: [{ label: 'Status', value: 'Healthy' }],
+  },
+};

--- a/packages/ui/src/components/data-card/component.tsx
+++ b/packages/ui/src/components/data-card/component.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { Pressable, View } from 'react-native';
+import type { PressableProps, ViewProps } from 'react-native';
+
+import { cn } from '../../cn';
+import { KeyValue } from '../key-value';
+import { Stack } from '../stack';
+import { Text } from '../text';
+import { dataCardVariants } from './cva';
+import type { DataCardProps } from './types';
+
+const ViewBase = View as React.ComponentType<ViewProps & { className?: string }>;
+const PressableBase = Pressable as React.ComponentType<PressableProps & { className?: string }>;
+
+function renderHeading(value: React.ReactNode) {
+  return typeof value === 'string' ? (
+    <Text intent="bodyStrong" numberOfLines={1}>
+      {value}
+    </Text>
+  ) : (
+    value
+  );
+}
+
+function renderSubheading(value: React.ReactNode) {
+  return typeof value === 'string' ? (
+    <Text intent="caption" numberOfLines={1}>
+      {value}
+    </Text>
+  ) : (
+    value
+  );
+}
+
+/**
+ * Card presenting one record — an API key, a project, a member — as a
+ * header (leading icon/avatar, title/subtitle, status badge, trailing
+ * action) plus an optional wrapping grid of metadata pairs. For a compact
+ * row inside a list use ListRow instead; DataCard is the card-sized version
+ * for grids and detail summaries.
+ */
+export function DataCard({
+  title,
+  subtitle,
+  leading,
+  status,
+  trailing,
+  items,
+  footer,
+  tone,
+  onPress,
+  ...props
+}: DataCardProps) {
+  const className = cn(dataCardVariants({ tone }));
+
+  const content = (
+    <Stack gap="md">
+      <Stack direction="row" align="start" justify="between" gap="sm" width="full">
+        <Stack direction="row" align="start" gap="sm" style={{ flex: 1 }}>
+          {leading}
+          <Stack gap="xs" style={{ flex: 1 }}>
+            {renderHeading(title)}
+            {subtitle ? renderSubheading(subtitle) : null}
+          </Stack>
+        </Stack>
+        {status}
+        {trailing}
+      </Stack>
+      {items && items.length > 0 ? (
+        <Stack direction="row" wrap="wrap" gap="md">
+          {items.map((item) => (
+            <View key={item.label} style={{ minWidth: 140, flexGrow: 1 }}>
+              <KeyValue label={item.label} value={item.value} layout="stacked" />
+            </View>
+          ))}
+        </Stack>
+      ) : null}
+      {footer}
+    </Stack>
+  );
+
+  if (onPress) {
+    return (
+      <PressableBase
+        accessibilityRole="button"
+        className={className}
+        onPress={onPress}
+        {...(props as PressableProps)}>
+        {content}
+      </PressableBase>
+    );
+  }
+
+  return (
+    <ViewBase className={className} {...(props as ViewProps)}>
+      {content}
+    </ViewBase>
+  );
+}

--- a/packages/ui/src/components/data-card/cva.tsx
+++ b/packages/ui/src/components/data-card/cva.tsx
@@ -1,0 +1,15 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export const dataCardVariants = cva('w-full rounded-2xl', {
+  variants: {
+    tone: {
+      default: 'bg-surface p-6 shadow-sm',
+      muted: 'bg-muted p-4',
+    },
+  },
+  defaultVariants: {
+    tone: 'default',
+  },
+});
+
+export type DataCardVariantProps = VariantProps<typeof dataCardVariants>;

--- a/packages/ui/src/components/data-card/index.tsx
+++ b/packages/ui/src/components/data-card/index.tsx
@@ -1,0 +1,3 @@
+export { DataCard } from './component';
+export { dataCardVariants } from './cva';
+export type { DataCardItem, DataCardProps } from './types';

--- a/packages/ui/src/components/data-card/types.tsx
+++ b/packages/ui/src/components/data-card/types.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react';
+import type { PressableProps, ViewProps } from 'react-native';
+
+import type { DataCardVariantProps } from './cva';
+
+export type DataCardItem = {
+  label: string;
+  value: ReactNode;
+};
+
+export type DataCardProps = (ViewProps | PressableProps) &
+  DataCardVariantProps & {
+    title: ReactNode;
+    subtitle?: ReactNode;
+    /** Slot before the title — an Avatar, an icon Div, etc. */
+    leading?: ReactNode;
+    /** Slot after the title/subtitle column — typically a Badge. */
+    status?: ReactNode;
+    /** Slot at the far end of the header row — a button or menu trigger. */
+    trailing?: ReactNode;
+    /** Record metadata rendered as a wrapping grid of label/value pairs. */
+    items?: DataCardItem[];
+    /** Content below the metadata grid — tags, a divider + actions, etc. */
+    footer?: ReactNode;
+    onPress?: PressableProps['onPress'];
+  };

--- a/packages/ui/src/components/spinner/component.stories.tsx
+++ b/packages/ui/src/components/spinner/component.stories.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { Div } from '../div';
+import { Stack } from '../stack';
+import { Spinner } from './component';
+
+const meta: Meta<typeof Spinner> = {
+  title: 'UI/Spinner',
+  component: Spinner,
+};
+
+export default meta;
+type Story = StoryObj<typeof Spinner>;
+
+export const Default: Story = {};
+
+export const Sizes: Story = {
+  render: () => (
+    <Stack direction="row" gap="md" align="center">
+      <Spinner size="sm" />
+      <Spinner size="md" />
+      <Spinner size="lg" />
+    </Stack>
+  ),
+};
+
+export const Tones: Story = {
+  render: () => (
+    <Stack direction="row" gap="md" align="center">
+      <Spinner tone="brand" />
+      <Spinner tone="neutral" />
+      <Div tone="brand" pad="md" rounded="md">
+        <Spinner tone="inverse" />
+      </Div>
+    </Stack>
+  ),
+};

--- a/packages/ui/src/components/spinner/component.tsx
+++ b/packages/ui/src/components/spinner/component.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { View } from 'react-native';
+import type { ViewProps } from 'react-native';
+
+import { cn } from '../../cn';
+import { spinnerVariants } from './cva';
+import type { SpinnerProps } from './types';
+
+const ViewBase = View as React.ComponentType<ViewProps & { className?: string }>;
+
+/**
+ * Indeterminate loading indicator — a rotating two-tone ring, driven by
+ * NativeWind's `animate-spin` (a CSS animation on web, translated to
+ * Reanimated on native) rather than a manually-wired RN `Animated.Value`.
+ * Pairs with Skeleton (content-shaped placeholders) for the other loading
+ * affordance: Spinner is for "an action is in flight" (button/inline
+ * loading), Skeleton is for "content hasn't arrived yet".
+ */
+export function Spinner({
+  size,
+  tone,
+  style,
+  accessibilityLabel = 'Loading',
+  ...props
+}: Readonly<SpinnerProps>) {
+  return (
+    <ViewBase
+      accessibilityRole="progressbar"
+      accessibilityLabel={accessibilityLabel}
+      className={cn('animate-spin', spinnerVariants({ size, tone }))}
+      style={style}
+      {...props}
+    />
+  );
+}

--- a/packages/ui/src/components/spinner/cva.tsx
+++ b/packages/ui/src/components/spinner/cva.tsx
@@ -1,0 +1,25 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+
+// A ring built from a full circular border plus a differently-coloured top
+// edge, then rotated — cheaper than an SVG/arc and matches Skeleton's
+// Animated-driven-by-className approach (no extra deps).
+export const spinnerVariants = cva('rounded-full border-transparent', {
+  variants: {
+    size: {
+      sm: 'h-4 w-4 border-2',
+      md: 'h-6 w-6 border-2',
+      lg: 'h-9 w-9 border-[3px]',
+    },
+    tone: {
+      neutral: 'border-t-soft border-r-soft',
+      brand: 'border-t-primary border-r-primary',
+      inverse: 'border-t-surface border-r-surface',
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+    tone: 'brand',
+  },
+});
+
+export type SpinnerVariantProps = VariantProps<typeof spinnerVariants>;

--- a/packages/ui/src/components/spinner/index.tsx
+++ b/packages/ui/src/components/spinner/index.tsx
@@ -1,0 +1,3 @@
+export { Spinner } from './component';
+export { spinnerVariants } from './cva';
+export type { SpinnerProps } from './types';

--- a/packages/ui/src/components/spinner/types.tsx
+++ b/packages/ui/src/components/spinner/types.tsx
@@ -1,0 +1,9 @@
+import type { ViewProps } from 'react-native';
+
+import type { SpinnerVariantProps } from './cva';
+
+export type SpinnerProps = ViewProps &
+  SpinnerVariantProps & {
+    /** Screen-reader label. Defaults to "Loading". */
+    accessibilityLabel?: string;
+  };

--- a/packages/ui/src/components/stat-card/component.stories.tsx
+++ b/packages/ui/src/components/stat-card/component.stories.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { Stack } from '../stack';
+import { StatCard } from './component';
+
+const meta: Meta<typeof StatCard> = {
+  title: 'UI/StatCard',
+  component: StatCard,
+  args: {
+    label: 'Total requests',
+    value: '11,207',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 220 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof StatCard>;
+
+export const Default: Story = {};
+
+export const WithTrendUp: Story = {
+  args: {
+    label: 'Daily average',
+    value: '2,802',
+    trend: { direction: 'up', label: '+12% vs last week' },
+  },
+};
+
+export const WithTrendDown: Story = {
+  args: {
+    label: 'Error rate',
+    value: '0.4%',
+    trend: { direction: 'down', label: '-0.2pt vs last week' },
+  },
+};
+
+export const WithDescription: Story = {
+  args: {
+    label: 'Peak day',
+    value: '7,080',
+    description: 'Jun 4, 2026',
+  },
+};
+
+/** Three stat cards in a row, the layout this primitive is designed for. */
+export const Row: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: 700 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  render: () => (
+    <Stack direction="row" gap="md">
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <StatCard label="Total usage" value="11,207" />
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <StatCard label="Daily avg" value="2,802" trend={{ direction: 'up', label: '+12%' }} />
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <StatCard label="Peak day" value="7,080" description="Jun 4, 2026" />
+      </div>
+    </Stack>
+  ),
+};

--- a/packages/ui/src/components/stat-card/component.tsx
+++ b/packages/ui/src/components/stat-card/component.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+import type { TextProps, ViewProps } from 'react-native';
+
+import { cn } from '../../cn';
+import { Stack } from '../stack';
+import { Text as UiText } from '../text';
+import { statCardTrendVariants, statCardVariants } from './cva';
+import type { StatCardProps } from './types';
+
+const ViewBase = View as React.ComponentType<ViewProps & { className?: string }>;
+const TextBase = Text as React.ComponentType<TextProps & { className?: string }>;
+
+const TREND_GLYPH = {
+  up: '↑',
+  down: '↓',
+  flat: '→',
+} as const;
+
+/**
+ * Compact metric tile — label, headline number, optional trend delta. Built
+ * from the same surface (Card-style bg-surface/shadow-sm/rounded-2xl) and
+ * text tokens (`eyebrow`, `display`) already used elsewhere, so a row of
+ * StatCards reads as part of the same system as SectionCard/DataCard. Does
+ * not render a chart — a charting primitive is explicitly out of scope for
+ * this epic (see #79); `trend` is a plain formatted delta.
+ */
+export function StatCard({
+  label,
+  value,
+  icon,
+  trend,
+  description,
+  size,
+  ...props
+}: StatCardProps) {
+  return (
+    <ViewBase className={cn(statCardVariants({ size }))} {...props}>
+      <Stack gap="xs">
+        <Stack direction="row" align="center" justify="between" gap="sm">
+          <UiText intent="eyebrow">{label}</UiText>
+          {icon}
+        </Stack>
+        <UiText intent="display">{value}</UiText>
+        {trend || description ? (
+          <Stack direction="row" align="center" gap="xs">
+            {trend ? (
+              <TextBase className={cn(statCardTrendVariants({ direction: trend.direction }))}>
+                {TREND_GLYPH[trend.direction ?? 'flat']} {trend.label}
+              </TextBase>
+            ) : null}
+            {description ? <UiText intent="caption">{description}</UiText> : null}
+          </Stack>
+        ) : null}
+      </Stack>
+    </ViewBase>
+  );
+}

--- a/packages/ui/src/components/stat-card/cva.tsx
+++ b/packages/ui/src/components/stat-card/cva.tsx
@@ -1,0 +1,31 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+
+// Same surface treatment as SectionCard/Card's default tone — a KPI tile is
+// just a card whose body is one big number, not a distinct visual language.
+export const statCardVariants = cva('w-full rounded-2xl bg-surface shadow-sm', {
+  variants: {
+    size: {
+      sm: 'p-4',
+      md: 'p-6',
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+  },
+});
+
+export const statCardTrendVariants = cva('text-xs font-semibold', {
+  variants: {
+    direction: {
+      up: 'text-success',
+      down: 'text-error',
+      flat: 'text-subtle',
+    },
+  },
+  defaultVariants: {
+    direction: 'flat',
+  },
+});
+
+export type StatCardVariantProps = VariantProps<typeof statCardVariants>;
+export type StatCardTrendVariantProps = VariantProps<typeof statCardTrendVariants>;

--- a/packages/ui/src/components/stat-card/index.tsx
+++ b/packages/ui/src/components/stat-card/index.tsx
@@ -1,0 +1,3 @@
+export { StatCard } from './component';
+export { statCardTrendVariants, statCardVariants } from './cva';
+export type { StatCardProps, StatCardTrend } from './types';

--- a/packages/ui/src/components/stat-card/types.tsx
+++ b/packages/ui/src/components/stat-card/types.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+import type { ViewProps } from 'react-native';
+
+import type { StatCardTrendVariantProps, StatCardVariantProps } from './cva';
+
+export type StatCardTrend = StatCardTrendVariantProps & {
+  /** Pre-formatted delta text, e.g. "+12% vs last week". The app owns i18n/number formatting. */
+  label: string;
+};
+
+export type StatCardProps = ViewProps &
+  StatCardVariantProps & {
+    label: string;
+    /** The headline number. Pre-formatted by the caller (locale, currency, units). */
+    value: ReactNode;
+    /** Optional icon slot, rendered opposite the label. */
+    icon?: ReactNode;
+    trend?: StatCardTrend;
+    /** Small caption under the value/trend row, e.g. "Last 30 days". */
+    description?: string;
+  };

--- a/packages/ui/src/components/toolbar/component.stories.tsx
+++ b/packages/ui/src/components/toolbar/component.stories.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { Button } from '../button';
+import { Heading } from '../heading';
+import { TextField } from '../text-field';
+import { Toolbar } from './component';
+
+const meta: Meta<typeof Toolbar> = {
+  title: 'UI/Toolbar',
+  component: Toolbar,
+  decorators: [
+    (Story) => (
+      <div style={{ width: 640 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Toolbar>;
+
+export const SearchAndCreate: Story = {
+  args: {
+    leading: (
+      <div style={{ maxWidth: 320, width: '100%' }}>
+        <TextField placeholder="Search API keys" />
+      </div>
+    ),
+    trailing: <Button size="sm">New key</Button>,
+  },
+};
+
+export const TitleWithActions: Story = {
+  args: {
+    leading: <Heading tone="subtitle">4 active keys</Heading>,
+    trailing: (
+      <>
+        <Button variant="neutral" size="sm">
+          Filter
+        </Button>
+        <Button size="sm">New key</Button>
+      </>
+    ),
+  },
+};
+
+export const WithBottomBorder: Story = {
+  args: {
+    border: true,
+    leading: <Heading tone="subtitle">Projects</Heading>,
+    trailing: <Button size="sm">New project</Button>,
+  },
+};

--- a/packages/ui/src/components/toolbar/component.tsx
+++ b/packages/ui/src/components/toolbar/component.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { View } from 'react-native';
+import type { ViewProps } from 'react-native';
+
+import { cn } from '../../cn';
+import { Stack } from '../stack';
+import { toolbarVariants } from './cva';
+import type { ToolbarProps } from './types';
+
+const ViewBase = View as React.ComponentType<ViewProps & { className?: string }>;
+
+/**
+ * Horizontal action bar for the space above a list or table — search/filters
+ * on the left, primary/secondary actions on the right. Unlike PageHeader and
+ * Pagination this is not page-level chrome: it lives inside a page's content
+ * column (a Card, a Page body), so it doesn't own its own max-width centering.
+ */
+export function Toolbar({ leading, trailing, border, style, ...props }: ToolbarProps) {
+  return (
+    <ViewBase className={cn(toolbarVariants({ border }))} style={style} {...props}>
+      <Stack direction="row" align="center" gap="sm" wrap="wrap" style={{ flex: 1, minWidth: 0 }}>
+        {leading}
+      </Stack>
+      {trailing ? (
+        <Stack direction="row" align="center" gap="sm" wrap="wrap">
+          {trailing}
+        </Stack>
+      ) : null}
+    </ViewBase>
+  );
+}

--- a/packages/ui/src/components/toolbar/cva.tsx
+++ b/packages/ui/src/components/toolbar/cva.tsx
@@ -1,0 +1,15 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export const toolbarVariants = cva('w-full flex-row flex-wrap items-center justify-between gap-3', {
+  variants: {
+    border: {
+      true: 'border-b border-border pb-4',
+      false: '',
+    },
+  },
+  defaultVariants: {
+    border: false,
+  },
+});
+
+export type ToolbarVariantProps = VariantProps<typeof toolbarVariants>;

--- a/packages/ui/src/components/toolbar/index.tsx
+++ b/packages/ui/src/components/toolbar/index.tsx
@@ -1,0 +1,3 @@
+export { Toolbar } from './component';
+export { toolbarVariants } from './cva';
+export type { ToolbarProps } from './types';

--- a/packages/ui/src/components/toolbar/types.tsx
+++ b/packages/ui/src/components/toolbar/types.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from 'react';
+import type { ViewProps } from 'react-native';
+
+import type { ToolbarVariantProps } from './cva';
+
+export type ToolbarProps = ViewProps &
+  ToolbarVariantProps & {
+    /** Left-hand slot — search field, filter chips, a section title. Grows to fill available space. */
+    leading?: ReactNode;
+    /** Right-hand slot — action buttons. Never shrinks below its content. */
+    trailing?: ReactNode;
+  };

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -68,6 +68,18 @@ export { PageHeader, pageHeaderVariants } from './components/page-header';
 export type { PageHeaderProps } from './components/page-header';
 export { Pagination, paginationVariants } from './components/pagination';
 export type { PaginationProps } from './components/pagination';
+export { Avatar, avatarInitialsVariants, avatarVariants } from './components/avatar';
+export type { AvatarProps } from './components/avatar';
+export { ConfirmDialog, confirmDialogVariants } from './components/confirm-dialog';
+export type { ConfirmDialogProps } from './components/confirm-dialog';
+export { DataCard, dataCardVariants } from './components/data-card';
+export type { DataCardItem, DataCardProps } from './components/data-card';
+export { Spinner, spinnerVariants } from './components/spinner';
+export type { SpinnerProps } from './components/spinner';
+export { StatCard, statCardTrendVariants, statCardVariants } from './components/stat-card';
+export type { StatCardProps, StatCardTrend } from './components/stat-card';
+export { Toolbar, toolbarVariants } from './components/toolbar';
+export type { ToolbarProps } from './components/toolbar';
 // NOTE: Sheet is intentionally NOT re-exported from this barrel. It pulls in
 // @gorhom/bottom-sheet → react-native-reanimated → worklets, which crash under
 // jest and bloat any importer. Import it from the dedicated subpath instead:


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds six primitives to `packages/ui`: `Avatar`, `Spinner`, `DataCard`, `StatCard`, `ConfirmDialog`, `Toolbar` — each with a Storybook story, following the `component.tsx`/`cva.tsx`/`types.tsx`/`index.tsx` shape of the existing 31.
- Exports them from `packages/ui/src/index.ts`.
- Nothing outside `packages/ui/` is touched. Purely additive: 31 files, +990 lines, 0 deletions.

It solves:

- Phase 2 of https://github.com/ADORSYS-GIS/converse-frontends/issues/79

---

## 2. Intent

The intent of this PR is:

> Close the remaining gap in the epic's micro/macro component set so screens compose instead of hand-rolling layout.
>
> **The epic body is stale** and was not followed literally. It claims "recurring patterns available as named components: ~0"; `packages/ui` already had 31, including every Phase 1 component it names. Scope here was set from an audit posted as https://github.com/ADORSYS-GIS/converse-frontends/issues/79#issuecomment-5301294187 — the six genuinely missing components. `Icon` and `FieldLabel` were checked and found already covered by the existing `icon`/`form-field`, so neither was rebuilt.

---

## 3. Scope

### In Scope

- The six components above, their stories, and the export barrel.

### Out of Scope

- **Refactoring app views to consume them.** That is the other half of the epic and would collide with the budget-UI work landing in parallel. Natural next slice.
- Any redesign or rebrand — this keeps the existing token direction, per the epic.
- A charting primitive. `StatCard`'s trend is a plain coloured delta, not a sparkline, because the epic explicitly puts charting out of scope.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
pnpm -r --if-present run test
pnpm lint
pnpm build
pnpm build-storybook
```

Results:

```text
tests:            118/118 self-service + all authz-rpc/hooks suites passed
pnpm build:       turbo run build:web -> 1 successful
pnpm build-storybook: 1 successful
lint:             6 pre-existing rules-of-hooks errors in existing .stories.tsx files
                  (checkbox/pagination/segmented-control/select) — unchanged from baseline,
                  none in the new files
```

`pnpm build` and `pnpm build-storybook` were additionally re-run independently on this branch by the orchestrator rather than taken from the implementing agent's report.

---

## 5. Screenshots / Evidence

**No screenshots are attached.** They were viewed during development but never written to disk, so there is no artifact to include. For six new visual primitives that is a real gap in this PR's evidence — reviewers should run `pnpm build-storybook` (or `pnpm storybook`) and look at the six new stories directly.

Design research (via the `refero-design` skill, Refero MCP live) that grounded the work:

* Exa "Agent ACUs" dashboard — the 3-card KPI row (uppercase muted label + large bold number) behind `StatCard`.
* Fingerprint API-keys page — tabs + filter dropdown + CTA, behind `Toolbar`'s leading/trailing slot shape.
* Fingerprint API-key-detail page — the 2-card stat grid.
* Rox customers page — search + filter pill + ghost-button treatment.
* OpenAI Developers / shadcn / Linear-changelog styles — confirming the restrained monochrome direction the epic already commits to.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* Additive-only, but a new export barrel entry can shadow or conflict with an existing name.
* A new primitive can drift from the established API conventions and fragment the system.

Mitigation:

* Verified against the existing 31 components' naming and file structure before adding; no name collisions.
* `ConfirmDialog` composes with the existing `SheetProvider`/`useSheet` system rather than competing with it — it implements the `ConfirmView` shape `useSheet`'s own doc comment already anticipated, and generalises the near-duplicate `delete-account-view` / `delete-project-view` / `delete-api-key-view` / `revoke-api-key-view` pattern.
* **`packages/ui`'s zero i18n coupling is preserved** — all labels are props, no `@lightbridge/i18n` dependency added. This is what lets design-system work proceed without contending with feature work over the shared i18n file.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [x] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Implemented by Claude Code (Sonnet subagent under an Opus 5 orchestrator) on behalf of @stephane-segning. Scope was set from a fresh audit of the package rather than the epic's stale body, and the duplicate check against `icon`/`form-field` was run before building.

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

**Human attestation pending @stephane-segning's review** — an agent must not tick the accountable human's boxes on their behalf. Given this is visual work shipping without screenshots, a look at Storybook is worth more than usual here.

---

## 8. Reviewer Focus

Please focus your review on:

* [ ] Correctness
* [x] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [x] Product intent
* [ ] Edge cases

Specifically the **visual result** in Storybook, and `ConfirmDialog`'s API — whether it genuinely absorbs the four existing danger-zone views or whether they have divergent needs that would make it a fifth variant rather than a replacement.

### Latent bug found in passing (not fixed here)

While building `Spinner`, the existing `Skeleton` pattern — `Animated.createAnimatedComponent(View)` with a `className` — was observed rendering with no utility classes on web. Corroborating: there is **no `cssInterop`/`remapProps` registration anywhere** in the repo, `skeleton` is the **only** component using `createAnimatedComponent`, and it is the **only** component directory with no story, which is why nothing has ever rendered it on web to notice. `Skeleton` is used in four shipped loading states (`home-view`, `api-keys-list-view`, `account-settings-view`, `project-settings-view`). `Spinner` therefore uses NativeWind's `animate-spin` utility instead. Deliberately left out of this PR's scope — it needs its own change, starting with a browser confirmation of the exact symptom, since the inline `style` prop still applies width/height/opacity and the failure is likely partial rather than total.
