### PR TITLE
feat(self-service): budget refill request + admin review queue

### DIFF
--- a/apps/self-service/src/app/settings-budget-review.tsx
+++ b/apps/self-service/src/app/settings-budget-review.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { BudgetReviewScreen } from '../screens/budget-review-screen';
+
+export default function SettingsBudgetReviewRoute() {
+  return <BudgetReviewScreen />;
+}

--- a/apps/self-service/src/app/settings-budget.tsx
+++ b/apps/self-service/src/app/settings-budget.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { BudgetRefillScreen } from '../screens/budget-refill-screen';
+
+export default function SettingsBudgetRoute() {
+  return <BudgetRefillScreen />;
+}

--- a/apps/self-service/src/navigation/settings-categories.ts
+++ b/apps/self-service/src/navigation/settings-categories.ts
@@ -1,14 +1,22 @@
 import type { IconName } from '@lightbridge/ui';
+import type { Permission } from '@lightbridge/hooks';
 
 type FeatherIconName = IconName;
 
-export type SettingsCategoryKey = 'account' | 'project';
+export type SettingsCategoryKey = 'account' | 'project' | 'budget' | 'budget-review';
 
 export type SettingsCategory = {
   key: SettingsCategoryKey;
   titleKey: string;
   iconName: FeatherIconName;
   route: `/${string}`;
+  /**
+   * When set, the category is only shown to a caller who holds this permission (#148) --
+   * `budget:self-refill`/`budget:review` are unresolved-by-role as of ADORSYS-GIS/
+   * lightbridge-authz#294, so both budget rows must stay hidden by default rather than shown to
+   * everyone. `account`/`project` have no gate: every authenticated caller can reach them.
+   */
+  requiredPermission?: Permission;
 };
 
 // The API-key category lands in a follow-up ticket (#55 is delivered as
@@ -26,5 +34,19 @@ export const settingsCategories: SettingsCategory[] = [
     titleKey: 'settings.categories.project',
     iconName: 'folder',
     route: '/settings-project',
+  },
+  {
+    key: 'budget',
+    titleKey: 'settings.categories.budget',
+    iconName: 'dollar-sign',
+    route: '/settings-budget',
+    requiredPermission: 'budget:self-refill',
+  },
+  {
+    key: 'budget-review',
+    titleKey: 'settings.categories.budgetReview',
+    iconName: 'inbox',
+    route: '/settings-budget-review',
+    requiredPermission: 'budget:review',
   },
 ];

--- a/apps/self-service/src/screens/budget-refill-screen.tsx
+++ b/apps/self-service/src/screens/budget-refill-screen.tsx
@@ -1,13 +1,13 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useRouter } from 'expo-router';
 import {
   createBudgetIdempotencyKey,
+  currentBudgetPeriod,
   getApiErrorStatus,
   useCurrentAccount,
   usePermissions,
   useRequestBudgetRefill,
 } from '@lightbridge/hooks';
-import type { BudgetTier } from '@lightbridge/hooks';
 import { BudgetRefillView } from '../views/settings/budget-refill-view';
 
 /**
@@ -15,6 +15,13 @@ import { BudgetRefillView } from '../views/settings/budget-refill-view';
  * not project-scoped, so unlike the project-settings/api-keys screens this deliberately has no
  * account/project selector -- it always acts on the caller's own account
  * (`useCurrentAccount`, one account per person per ADR-0006).
+ *
+ * There is no tier/amount picker here, and deliberately so: `RequestBudgetRefillInput`
+ * (packages/authz-rpc/schema/authz.cstack) has no field for the caller to specify one --
+ * `RefillService::request_refill` decides the tier server-side (auto grant or `pending_review`)
+ * per that schema's own doc comment. `AugmentationRequest.requestedTier` on the RESPONSE is what
+ * the server assigned, revealed after the fact, not selected beforehand. Ticket #148's original
+ * "tier picker" framing was corrected against this: https://github.com/ADORSYS-GIS/converse-frontends/issues/148#issuecomment-5301445859
  */
 export function BudgetRefillScreen({ embedded = false }: Readonly<{ embedded?: boolean }>) {
   const router = useRouter();
@@ -24,34 +31,29 @@ export function BudgetRefillScreen({ embedded = false }: Readonly<{ embedded?: b
   const { data: account } = useCurrentAccount();
   const requestRefill = useRequestBudgetRefill();
 
-  const [selectedTier, setSelectedTier] = useState<BudgetTier | undefined>();
+  // Stable for the lifetime of this screen instance -- the current calendar month at mount.
+  const period = useMemo(() => currentBudgetPeriod(), []);
   const [idempotencyKey, setIdempotencyKey] = useState<string | null>(null);
 
-  const submit = (tier: BudgetTier, key: string) => {
+  const submit = (key: string) => {
     if (!account?.id) return;
-    setSelectedTier(tier);
     setIdempotencyKey(key);
-    // `tier` is intentionally not part of this payload -- `RequestBudgetRefillInput`
-    // (packages/authz-rpc/schema/authz.cstack) has no field for the caller to specify which
-    // tier/amount they want. See the comment on `RequestBudgetRefillArgs` in
-    // packages/hooks/src/budget.ts for the full explanation; this is a real backend-contract gap,
-    // not an oversight here.
     void requestRefill
-      .mutateAsync({ accountId: account.id, idempotencyKey: key })
+      .mutateAsync({ accountId: account.id, period, idempotencyKey: key })
       .catch(() => undefined);
   };
 
-  const handleSelectTier = (tier: BudgetTier) => {
-    // Every tile click starts a brand-new attempt -- always a fresh idempotency key, never reused
-    // for a fresh submit (only `handleRetry` below reuses one).
-    submit(tier, createBudgetIdempotencyKey());
+  const handleSubmit = () => {
+    // Every submit starts a brand-new attempt -- always a fresh idempotency key, never reused for
+    // a fresh submit (only `handleRetry` below reuses one).
+    submit(createBudgetIdempotencyKey());
   };
 
   const handleRetry = () => {
-    if (!selectedTier || !idempotencyKey) return;
+    if (!idempotencyKey) return;
     // Retries the exact same failed attempt -- reuses the SAME idempotency key so the backend's
     // `RefillService::find_existing` recognizes it rather than evaluating a second time.
-    submit(selectedTier, idempotencyKey);
+    submit(idempotencyKey);
   };
 
   const isSubmitting = requestRefill.isPending;
@@ -66,9 +68,9 @@ export function BudgetRefillScreen({ embedded = false }: Readonly<{ embedded?: b
       showBackButton={!embedded}
       onBack={() => router.back()}
       canRefill={canRefill}
-      selectedTier={selectedTier}
+      period={period}
       isSubmitting={isSubmitting}
-      onSelectTier={handleSelectTier}
+      onSubmit={handleSubmit}
       result={result}
       errorStatus={errorStatus}
       canRetry={canRetry}

--- a/apps/self-service/src/screens/budget-refill-screen.tsx
+++ b/apps/self-service/src/screens/budget-refill-screen.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import { useRouter } from 'expo-router';
+import {
+  createBudgetIdempotencyKey,
+  getApiErrorStatus,
+  useCurrentAccount,
+  usePermissions,
+  useRequestBudgetRefill,
+} from '@lightbridge/hooks';
+import type { BudgetTier } from '@lightbridge/hooks';
+import { BudgetRefillView } from '../views/settings/budget-refill-view';
+
+/**
+ * Self-service budget refill (lightbridge-authz ADR-0007/0008, #191). Budget is account-scoped,
+ * not project-scoped, so unlike the project-settings/api-keys screens this deliberately has no
+ * account/project selector -- it always acts on the caller's own account
+ * (`useCurrentAccount`, one account per person per ADR-0006).
+ */
+export function BudgetRefillScreen({ embedded = false }: Readonly<{ embedded?: boolean }>) {
+  const router = useRouter();
+  const { has } = usePermissions();
+  const canRefill = has('budget:self-refill');
+
+  const { data: account } = useCurrentAccount();
+  const requestRefill = useRequestBudgetRefill();
+
+  const [selectedTier, setSelectedTier] = useState<BudgetTier | undefined>();
+  const [idempotencyKey, setIdempotencyKey] = useState<string | null>(null);
+
+  const submit = (tier: BudgetTier, key: string) => {
+    if (!account?.id) return;
+    setSelectedTier(tier);
+    setIdempotencyKey(key);
+    // `tier` is intentionally not part of this payload -- `RequestBudgetRefillInput`
+    // (packages/authz-rpc/schema/authz.cstack) has no field for the caller to specify which
+    // tier/amount they want. See the comment on `RequestBudgetRefillArgs` in
+    // packages/hooks/src/budget.ts for the full explanation; this is a real backend-contract gap,
+    // not an oversight here.
+    void requestRefill
+      .mutateAsync({ accountId: account.id, idempotencyKey: key })
+      .catch(() => undefined);
+  };
+
+  const handleSelectTier = (tier: BudgetTier) => {
+    // Every tile click starts a brand-new attempt -- always a fresh idempotency key, never reused
+    // for a fresh submit (only `handleRetry` below reuses one).
+    submit(tier, createBudgetIdempotencyKey());
+  };
+
+  const handleRetry = () => {
+    if (!selectedTier || !idempotencyKey) return;
+    // Retries the exact same failed attempt -- reuses the SAME idempotency key so the backend's
+    // `RefillService::find_existing` recognizes it rather than evaluating a second time.
+    submit(selectedTier, idempotencyKey);
+  };
+
+  const isSubmitting = requestRefill.isPending;
+  // Don't show a stale result/error from the previous attempt while a new one is in flight.
+  const errorStatus = isSubmitting ? undefined : getApiErrorStatus(requestRefill.error);
+  const result = isSubmitting ? null : (requestRefill.data ?? null);
+  // 403 is a hard permission denial, not retryable; any other thrown error is (network/5xx).
+  const canRetry = errorStatus !== undefined && errorStatus !== 403;
+
+  return (
+    <BudgetRefillView
+      showBackButton={!embedded}
+      onBack={() => router.back()}
+      canRefill={canRefill}
+      selectedTier={selectedTier}
+      isSubmitting={isSubmitting}
+      onSelectTier={handleSelectTier}
+      result={result}
+      errorStatus={errorStatus}
+      canRetry={canRetry}
+      onRetry={handleRetry}
+    />
+  );
+}

--- a/apps/self-service/src/screens/budget-review-screen.tsx
+++ b/apps/self-service/src/screens/budget-review-screen.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { useRouter } from 'expo-router';
+import {
+  getApiErrorMessage,
+  useApproveAugmentationRequest,
+  usePendingAugmentationRequests,
+  usePermissions,
+  useRejectAugmentationRequest,
+} from '@lightbridge/hooks';
+import { BudgetReviewView } from '../views/settings/budget-review-view';
+
+/**
+ * Admin review queue for pending self-service budget refill requests (#191, PR 3.3/3.4).
+ * `budgetAccountId` deliberately omitted from `usePendingAugmentationRequests` -- this is the
+ * global, cross-account queue, matching `listPendingAugmentationRequests`'s own documented
+ * default.
+ */
+export function BudgetReviewScreen({ embedded = false }: Readonly<{ embedded?: boolean }>) {
+  const router = useRouter();
+  const { has } = usePermissions();
+  const canReview = has('budget:review');
+
+  const { data: items, isLoading } = usePendingAugmentationRequests(undefined, canReview);
+
+  const approve = useApproveAugmentationRequest();
+  const reject = useRejectAugmentationRequest();
+
+  const [pendingRequestId, setPendingRequestId] = useState<string | null>(null);
+
+  const handleApprove = (requestId: string) => {
+    setPendingRequestId(requestId);
+    void approve
+      .mutateAsync({ requestId })
+      .catch(() => undefined)
+      .finally(() => setPendingRequestId(null));
+  };
+
+  const handleReject = (requestId: string, reason: string) => {
+    setPendingRequestId(requestId);
+    void reject
+      .mutateAsync({ requestId, reason })
+      .catch(() => undefined)
+      .finally(() => setPendingRequestId(null));
+  };
+
+  const actionError = approve.error
+    ? getApiErrorMessage(approve.error)
+    : reject.error
+      ? getApiErrorMessage(reject.error)
+      : null;
+
+  return (
+    <BudgetReviewView
+      showBackButton={!embedded}
+      onBack={() => router.back()}
+      canReview={canReview}
+      items={items}
+      isLoading={isLoading}
+      onApprove={handleApprove}
+      onReject={handleReject}
+      pendingRequestId={pendingRequestId}
+      actionError={actionError}
+    />
+  );
+}

--- a/apps/self-service/src/screens/settings-screen.tsx
+++ b/apps/self-service/src/screens/settings-screen.tsx
@@ -1,31 +1,47 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useRouter } from 'expo-router';
 import { Stack } from '@lightbridge/ui';
+import { usePermissions } from '@lightbridge/hooks';
 import { SettingsCategoryListView } from '../views/settings/settings-category-list-view';
 import { settingsCategories } from '../navigation/settings-categories';
 import type { SettingsCategoryKey } from '../navigation/settings-categories';
 import { useIsDesktop } from '../navigation/use-is-desktop';
 import { AccountSettingsScreen } from './account-settings-screen';
 import { ProjectSettingsScreen } from './project-settings-screen';
+import { BudgetRefillScreen } from './budget-refill-screen';
+import { BudgetReviewScreen } from './budget-review-screen';
 
 const categoryScreens: Record<SettingsCategoryKey, React.ComponentType<{ embedded?: boolean }>> = {
   account: AccountSettingsScreen,
   project: ProjectSettingsScreen,
+  budget: BudgetRefillScreen,
+  'budget-review': BudgetReviewScreen,
 };
 
 export function SettingsScreen() {
   const isDesktop = useIsDesktop();
   const router = useRouter();
+  const { has } = usePermissions();
   const [activeKey, setActiveKey] = useState<SettingsCategoryKey>('account');
 
+  // A category with `requiredPermission` (#148's budget rows) is hidden entirely for a caller
+  // without the grant — same "the permission gate itself, not a feature flag, hides the entry
+  // point" pattern the ticket calls for, mirroring `canManageMembers` in project-settings-view.
+  const visibleCategories = useMemo(
+    () => settingsCategories.filter((category) => !category.requiredPermission || has(category.requiredPermission)),
+    [has]
+  );
+
   if (isDesktop) {
-    const ActiveDetail = categoryScreens[activeKey];
+    const activeCategoryVisible = visibleCategories.some((category) => category.key === activeKey);
+    const resolvedKey = activeCategoryVisible ? activeKey : (visibleCategories[0]?.key ?? activeKey);
+    const ActiveDetail = categoryScreens[resolvedKey];
 
     return (
       <Stack direction="row" style={{ flex: 1 }}>
         <SettingsCategoryListView
-          categories={settingsCategories}
-          activeKey={activeKey}
+          categories={visibleCategories}
+          activeKey={resolvedKey}
           onSelect={(category) => setActiveKey(category.key)}
           variant="rail"
         />
@@ -38,7 +54,7 @@ export function SettingsScreen() {
 
   return (
     <SettingsCategoryListView
-      categories={settingsCategories}
+      categories={visibleCategories}
       onSelect={(category) => router.push(category.route)}
     />
   );

--- a/apps/self-service/src/views/settings/__tests__/budget-refill-view.test.tsx
+++ b/apps/self-service/src/views/settings/__tests__/budget-refill-view.test.tsx
@@ -1,0 +1,186 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { initI18n } from '@lightbridge/i18n';
+import type { AugmentationRequest } from '@lightbridge/hooks';
+
+import { BudgetRefillView } from '../budget-refill-view';
+
+const noop = () => undefined;
+
+beforeAll(() => {
+  initI18n('en');
+});
+
+function renderView(overrides: Partial<React.ComponentProps<typeof BudgetRefillView>> = {}) {
+  return render(<BudgetRefillView onBack={noop} onSelectTier={noop} {...overrides} />);
+}
+
+function baseRequest(overrides: Partial<AugmentationRequest> = {}): AugmentationRequest {
+  return {
+    id: 'req-1',
+    budgetAccountId: 'acc-1',
+    accountId: 'acc-1',
+    projectId: null,
+    period: '2026-08',
+    requestedTier: 'b-30',
+    requestedAmountMicros: '30000000',
+    status: 'auto_approved',
+    policyEffect: 'auto_approve',
+    policyReasonCodes: [],
+    matchedRuleIds: [],
+    policyRevision: null,
+    approvedAmountMicros: '30000000',
+    grantId: 'grant-1',
+    idempotencyKey: 'key-1',
+    reviewedBy: null,
+    rejectionReason: null,
+    createdAt: '2026-08-15T00:00:00Z',
+    reviewedAt: null,
+    ...overrides,
+  };
+}
+
+describe('BudgetRefillView tier picker', () => {
+  it('renders every tier as a discrete, labeled tile', async () => {
+    await renderView();
+
+    expect(screen.getByText('$15')).toBeTruthy();
+    expect(screen.getByText('$30')).toBeTruthy();
+    expect(screen.getByText('$60')).toBeTruthy();
+    expect(screen.getByText('$120')).toBeTruthy();
+    expect(screen.getByText('$250')).toBeTruthy();
+    expect(screen.getByText('$500')).toBeTruthy();
+    expect(screen.getByText('$1,000')).toBeTruthy();
+  });
+
+  it('renders exactly one discrete radio tile per ladder entry -- no free-text amount input anywhere', async () => {
+    await renderView();
+
+    // The tier picker is `accessibilityRole="radio"` tiles only (see BudgetRefillView) -- exactly
+    // BUDGET_TIERS.length of them, and no placeholder-bearing text input anywhere in the tree.
+    expect(screen.getAllByRole('radio')).toHaveLength(7);
+    expect(screen.queryAllByPlaceholderText(/.+/)).toHaveLength(0);
+  });
+
+  it('calls onSelectTier with the tile pressed', async () => {
+    const onSelectTier = jest.fn();
+    await renderView({ onSelectTier });
+
+    await fireEvent.press(screen.getByText('$60'));
+
+    expect(onSelectTier).toHaveBeenCalledWith('b-60');
+  });
+
+  it('disables every tile while a submission is in flight', async () => {
+    await renderView({ isSubmitting: true, selectedTier: 'b-30' });
+
+    const tile = screen.getByLabelText('Request the $60 budget tier');
+    expect(tile.props.accessibilityState.disabled).toBe(true);
+  });
+
+  it('does not disable tiles when idle', async () => {
+    await renderView();
+
+    const tile = screen.getByLabelText('Request the $60 budget tier');
+    expect(tile.props.accessibilityState.disabled).toBe(false);
+  });
+});
+
+describe('BudgetRefillView permission gate', () => {
+  it('shows a generic permission-denied message and no tier picker when canRefill is false', async () => {
+    await renderView({ canRefill: false });
+
+    expect(screen.getByText("You don't have permission to request a budget refill.")).toBeTruthy();
+    expect(screen.queryByText('$30')).toBeNull();
+  });
+});
+
+describe('BudgetRefillView result states', () => {
+  it('shows the token-refresh notice on auto_approved', async () => {
+    await renderView({ result: baseRequest({ status: 'auto_approved' }) });
+
+    expect(
+      screen.getByText(
+        "Granted. This takes effect the next time your access token silently refreshes in the background — not immediately, and you won't need to log in again."
+      )
+    ).toBeTruthy();
+  });
+
+  it('shows the token-refresh notice on approved', async () => {
+    await renderView({ result: baseRequest({ status: 'approved' }) });
+
+    expect(screen.getByText(/Granted\. This takes effect/)).toBeTruthy();
+  });
+
+  it('shows the token-refresh notice on partially_approved, plus the approved amount', async () => {
+    await renderView({
+      result: baseRequest({ status: 'partially_approved', approvedAmountMicros: '15000000' }),
+    });
+
+    expect(screen.getByText(/Granted\. This takes effect/)).toBeTruthy();
+    expect(screen.getByText('Approved amount: $15.00')).toBeTruthy();
+  });
+
+  it('shows under-review copy with no ETA on pending_review', async () => {
+    await renderView({ result: baseRequest({ status: 'pending_review', approvedAmountMicros: null }) });
+
+    expect(
+      screen.getByText("This request is under review by an admin. There's no estimated time for a decision.")
+    ).toBeTruthy();
+  });
+
+  it('shows the verbatim rejectionReason on denied when present', async () => {
+    await renderView({
+      result: baseRequest({
+        status: 'denied',
+        approvedAmountMicros: null,
+        rejectionReason: 'Your account has exceeded its monthly review cap.',
+      }),
+    });
+
+    expect(screen.getByText('Your account has exceeded its monthly review cap.')).toBeTruthy();
+  });
+
+  it('falls back to a mapped reason-code copy on denied with no rejectionReason', async () => {
+    await renderView({
+      result: baseRequest({
+        status: 'denied',
+        approvedAmountMicros: null,
+        rejectionReason: null,
+        policyReasonCodes: ['account_suspended'],
+      }),
+    });
+
+    expect(
+      screen.getByText("Your account is suspended, so refill requests can't be processed.")
+    ).toBeTruthy();
+  });
+
+  it('falls back to the generic denied copy for an unrecognized reason code', async () => {
+    await renderView({
+      result: baseRequest({
+        status: 'denied',
+        approvedAmountMicros: null,
+        rejectionReason: null,
+        policyReasonCodes: ['some_future_code_not_in_the_table'],
+      }),
+    });
+
+    expect(screen.getByText('This request was denied. Contact support if you have questions.')).toBeTruthy();
+  });
+
+  it('shows generic permission-denied copy on a 403, without a retry action', async () => {
+    await renderView({ errorStatus: 403, canRetry: false });
+
+    expect(screen.getByText("You don't have permission to request a budget refill.")).toBeTruthy();
+    expect(screen.queryByText('Retry')).toBeNull();
+  });
+
+  it('shows a retry action for a non-403 thrown error', async () => {
+    const onRetry = jest.fn();
+    await renderView({ errorStatus: 500, canRetry: true, onRetry });
+
+    await fireEvent.press(screen.getByText('Retry'));
+    expect(onRetry).toHaveBeenCalled();
+  });
+});

--- a/apps/self-service/src/views/settings/__tests__/budget-refill-view.test.tsx
+++ b/apps/self-service/src/views/settings/__tests__/budget-refill-view.test.tsx
@@ -6,13 +6,14 @@ import type { AugmentationRequest } from '@lightbridge/hooks';
 import { BudgetRefillView } from '../budget-refill-view';
 
 const noop = () => undefined;
+const PERIOD = '2026-08';
 
 beforeAll(() => {
   initI18n('en');
 });
 
 function renderView(overrides: Partial<React.ComponentProps<typeof BudgetRefillView>> = {}) {
-  return render(<BudgetRefillView onBack={noop} onSelectTier={noop} {...overrides} />);
+  return render(<BudgetRefillView onBack={noop} onSubmit={noop} period={PERIOD} {...overrides} />);
 }
 
 function baseRequest(overrides: Partial<AugmentationRequest> = {}): AugmentationRequest {
@@ -21,7 +22,7 @@ function baseRequest(overrides: Partial<AugmentationRequest> = {}): Augmentation
     budgetAccountId: 'acc-1',
     accountId: 'acc-1',
     projectId: null,
-    period: '2026-08',
+    period: PERIOD,
     requestedTier: 'b-30',
     requestedAmountMicros: '30000000',
     status: 'auto_approved',
@@ -40,65 +41,60 @@ function baseRequest(overrides: Partial<AugmentationRequest> = {}): Augmentation
   };
 }
 
-describe('BudgetRefillView tier picker', () => {
-  it('renders every tier as a discrete, labeled tile', async () => {
+describe('BudgetRefillView -- no tier/amount picker of any kind', () => {
+  it('shows the current period and a single submit action, nothing selectable', async () => {
     await renderView();
 
-    expect(screen.getByText('$15')).toBeTruthy();
-    expect(screen.getByText('$30')).toBeTruthy();
-    expect(screen.getByText('$60')).toBeTruthy();
-    expect(screen.getByText('$120')).toBeTruthy();
-    expect(screen.getByText('$250')).toBeTruthy();
-    expect(screen.getByText('$500')).toBeTruthy();
-    expect(screen.getByText('$1,000')).toBeTruthy();
-  });
-
-  it('renders exactly one discrete radio tile per ladder entry -- no free-text amount input anywhere', async () => {
-    await renderView();
-
-    // The tier picker is `accessibilityRole="radio"` tiles only (see BudgetRefillView) -- exactly
-    // BUDGET_TIERS.length of them, and no placeholder-bearing text input anywhere in the tree.
-    expect(screen.getAllByRole('radio')).toHaveLength(7);
+    expect(screen.getByText('For 2026-08')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Request a refill' })).toBeTruthy();
+    // Confirms the old tier ladder is gone -- these dollar tiles must never render again.
+    expect(screen.queryByText('$15')).toBeNull();
+    expect(screen.queryByText('$30')).toBeNull();
+    expect(screen.queryByText('$1,000')).toBeNull();
+    expect(screen.queryAllByRole('radio')).toHaveLength(0);
     expect(screen.queryAllByPlaceholderText(/.+/)).toHaveLength(0);
   });
 
-  it('calls onSelectTier with the tile pressed', async () => {
-    const onSelectTier = jest.fn();
-    await renderView({ onSelectTier });
+  it('calls onSubmit on press -- a bare trigger, never carrying a tier/amount payload', async () => {
+    const onSubmit = jest.fn();
+    await renderView({ onSubmit });
 
-    await fireEvent.press(screen.getByText('$60'));
+    await fireEvent.press(screen.getByRole('button', { name: 'Request a refill' }));
 
-    expect(onSelectTier).toHaveBeenCalledWith('b-60');
+    expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 
-  it('disables every tile while a submission is in flight', async () => {
-    await renderView({ isSubmitting: true, selectedTier: 'b-30' });
+  it('disables the submit control while a request is in flight', async () => {
+    await renderView({ isSubmitting: true });
 
-    const tile = screen.getByLabelText('Request the $60 budget tier');
-    expect(tile.props.accessibilityState.disabled).toBe(true);
+    expect(
+      screen.getByRole('button', { name: 'Requesting…' }).props.accessibilityState.disabled
+    ).toBe(true);
   });
 
-  it('does not disable tiles when idle', async () => {
+  it('does not disable submit when idle', async () => {
     await renderView();
 
-    const tile = screen.getByLabelText('Request the $60 budget tier');
-    expect(tile.props.accessibilityState.disabled).toBe(false);
+    expect(
+      screen.getByRole('button', { name: 'Request a refill' }).props.accessibilityState.disabled
+    ).toBe(false);
   });
 });
 
 describe('BudgetRefillView permission gate', () => {
-  it('shows a generic permission-denied message and no tier picker when canRefill is false', async () => {
+  it('shows a generic permission-denied message and no request control when canRefill is false', async () => {
     await renderView({ canRefill: false });
 
     expect(screen.getByText("You don't have permission to request a budget refill.")).toBeTruthy();
-    expect(screen.queryByText('$30')).toBeNull();
+    expect(screen.queryByText('Request a refill')).toBeNull();
   });
 });
 
-describe('BudgetRefillView result states', () => {
-  it('shows the token-refresh notice on auto_approved', async () => {
-    await renderView({ result: baseRequest({ status: 'auto_approved' }) });
+describe('BudgetRefillView result states -- tier revealed from the response, never chosen upfront', () => {
+  it('shows the token-refresh notice and the server-assigned tier on auto_approved', async () => {
+    await renderView({ result: baseRequest({ status: 'auto_approved', requestedTier: 'b-30' }) });
 
+    expect(screen.getByText('Requested tier: $30')).toBeTruthy();
     expect(
       screen.getByText(
         "Granted. This takes effect the next time your access token silently refreshes in the background — not immediately, and you won't need to log in again."
@@ -121,9 +117,12 @@ describe('BudgetRefillView result states', () => {
     expect(screen.getByText('Approved amount: $15.00')).toBeTruthy();
   });
 
-  it('shows under-review copy with no ETA on pending_review', async () => {
-    await renderView({ result: baseRequest({ status: 'pending_review', approvedAmountMicros: null }) });
+  it('shows under-review copy with no ETA on pending_review, and still reveals the requested tier', async () => {
+    await renderView({
+      result: baseRequest({ status: 'pending_review', approvedAmountMicros: null, requestedTier: 'b-250' }),
+    });
 
+    expect(screen.getByText('Requested tier: $250')).toBeTruthy();
     expect(
       screen.getByText("This request is under review by an admin. There's no estimated time for a decision.")
     ).toBeTruthy();
@@ -167,6 +166,14 @@ describe('BudgetRefillView result states', () => {
     });
 
     expect(screen.getByText('This request was denied. Contact support if you have questions.')).toBeTruthy();
+  });
+
+  it('falls back to computing the amount from requestedAmountMicros when requestedTier is not a recognized ladder value', async () => {
+    await renderView({
+      result: baseRequest({ status: 'auto_approved', requestedTier: 'b-999', requestedAmountMicros: '999000000' }),
+    });
+
+    expect(screen.getByText('Requested tier: $999.00')).toBeTruthy();
   });
 
   it('shows generic permission-denied copy on a 403, without a retry action', async () => {

--- a/apps/self-service/src/views/settings/__tests__/budget-review-view.test.tsx
+++ b/apps/self-service/src/views/settings/__tests__/budget-review-view.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { initI18n } from '@lightbridge/i18n';
+import type { AugmentationRequest } from '@lightbridge/hooks';
+
+import { BudgetReviewView } from '../budget-review-view';
+
+const noop = () => undefined;
+
+beforeAll(() => {
+  initI18n('en');
+});
+
+function request(overrides: Partial<AugmentationRequest> = {}): AugmentationRequest {
+  return {
+    id: 'req-1',
+    budgetAccountId: 'acc-1',
+    accountId: 'acc-1',
+    projectId: null,
+    period: '2026-08',
+    requestedTier: 'b-250',
+    requestedAmountMicros: '250000000',
+    status: 'pending_review',
+    policyEffect: 'manual_review',
+    policyReasonCodes: [],
+    matchedRuleIds: [],
+    policyRevision: null,
+    approvedAmountMicros: null,
+    grantId: null,
+    idempotencyKey: 'key-1',
+    reviewedBy: null,
+    rejectionReason: null,
+    createdAt: '2026-08-15T00:00:00Z',
+    reviewedAt: null,
+    ...overrides,
+  };
+}
+
+function renderView(overrides: Partial<React.ComponentProps<typeof BudgetReviewView>> = {}) {
+  return render(<BudgetReviewView onBack={noop} onApprove={noop} onReject={noop} {...overrides} />);
+}
+
+describe('BudgetReviewView permission gate', () => {
+  it('shows generic permission-denied copy and no list when canReview is false', async () => {
+    await renderView({ canReview: false, items: [request()] });
+
+    expect(screen.getByText("You don't have permission to review budget requests.")).toBeTruthy();
+    expect(screen.queryByText('Requested $250.00')).toBeNull();
+  });
+});
+
+describe('BudgetReviewView empty state', () => {
+  it('renders the centered EmptyState component when there are no pending requests', async () => {
+    await renderView({ items: [] });
+
+    expect(
+      screen.getByText('No pending requests. New requests that need review will show up here.')
+    ).toBeTruthy();
+  });
+});
+
+describe('BudgetReviewView approve flow', () => {
+  it('is a single action with no confirm dialog', async () => {
+    const onApprove = jest.fn();
+    await renderView({ items: [request()], onApprove });
+
+    await fireEvent.press(screen.getByText('Approve'));
+
+    expect(onApprove).toHaveBeenCalledWith('req-1');
+  });
+
+  it('disables the approve button while that request is in flight', async () => {
+    await renderView({ items: [request()], pendingRequestId: 'req-1' });
+
+    const button = screen.getByLabelText('Approve request req-1');
+    expect(button.props.accessibilityState.disabled).toBe(true);
+  });
+
+  it('does not disable approve for a request that is not the one in flight', async () => {
+    await renderView({
+      items: [request({ id: 'req-1' }), request({ id: 'req-2' })],
+      pendingRequestId: 'req-2',
+    });
+
+    const button = screen.getByLabelText('Approve request req-1');
+    expect(button.props.accessibilityState.disabled).toBe(false);
+  });
+});
+
+describe('BudgetReviewView reject flow', () => {
+  it('disables the reject submit until a reason is entered', async () => {
+    await renderView({ items: [request()] });
+
+    const rejectButton = screen.getByLabelText('Reject request req-1');
+    expect(rejectButton.props.accessibilityState.disabled).toBe(true);
+  });
+
+  it('enables reject once a non-empty reason is typed, and submits with it', async () => {
+    const onReject = jest.fn();
+    await renderView({ items: [request()], onReject });
+
+    await fireEvent.changeText(
+      screen.getByLabelText('Reason for the requester (required)'),
+      'Exceeds this account’s policy ceiling.'
+    );
+
+    const rejectButton = screen.getByLabelText('Reject request req-1');
+    expect(rejectButton.props.accessibilityState.disabled).toBe(false);
+
+    await fireEvent.press(rejectButton);
+    expect(onReject).toHaveBeenCalledWith('req-1', "Exceeds this account’s policy ceiling.");
+  });
+
+  it('keeps reject disabled for a whitespace-only reason', async () => {
+    await renderView({ items: [request()] });
+
+    await fireEvent.changeText(screen.getByLabelText('Reason for the requester (required)'), '   ');
+
+    const rejectButton = screen.getByLabelText('Reject request req-1');
+    expect(rejectButton.props.accessibilityState.disabled).toBe(true);
+  });
+});

--- a/apps/self-service/src/views/settings/budget-refill-view.tsx
+++ b/apps/self-service/src/views/settings/budget-refill-view.tsx
@@ -1,0 +1,242 @@
+import React from 'react';
+import { useTranslation } from '@lightbridge/i18n';
+import {
+  Badge,
+  Button,
+  Callout,
+  Card,
+  designTokens,
+  Div,
+  Heading,
+  Icon as Feather,
+  PageHeader,
+  Scroll,
+  SectionCard,
+  Stack,
+  Text,
+} from '@lightbridge/ui';
+import type { AugmentationRequest } from '@lightbridge/hooks';
+// Pure helpers only, from the dependency-free `./budget-tiers` subpath -- NOT the `@lightbridge/hooks`
+// barrel, which pulls in `@lightbridge/authz-rpc` (and transitively `cborg`, which Jest's resolver
+// can't follow) at runtime. See packages/hooks/src/budget-tiers.ts's module-level comment.
+import type { BudgetTier } from '@lightbridge/hooks/budget-tiers';
+import { BUDGET_TIERS, formatBudgetTierAmount, formatMicroUsd } from '@lightbridge/hooks/budget-tiers';
+import { useThemeColors } from '../../hooks/use-theme-colors';
+
+/**
+ * Best-effort copy for `AugmentationRequest.policyReasonCodes` when a request is `denied` with no
+ * `rejectionReason` set (an admin-authored rejection always has one -- see `rejectAugmentationRequest`
+ * -- so this table only ever applies to an AUTOMATIC policy denial). The canonical reason-code
+ * enum lives in `lightbridge-authz-budget`'s Rust source, which this frontend repo does not have
+ * a checkout of -- these entries are illustrative starting points, not a verified exhaustive
+ * list. Any code not listed here falls through to `settings.budget.deniedGenericReason`, so an
+ * unrecognized code never renders as a raw machine string.
+ */
+const DENIED_REASON_CODE_I18N_KEYS: Record<string, string> = {
+  self_service_disabled: 'settings.budget.deniedReasonCodes.self_service_disabled',
+  account_suspended: 'settings.budget.deniedReasonCodes.account_suspended',
+  policy_denied: 'settings.budget.deniedReasonCodes.policy_denied',
+};
+
+export type BudgetRefillViewProps = {
+  showBackButton?: boolean;
+  onBack: () => void;
+  /** `usePermissions().has('budget:self-refill')` -- defensive re-check, not just the hidden nav entry. */
+  canRefill?: boolean;
+  selectedTier?: BudgetTier;
+  isSubmitting?: boolean;
+  onSelectTier: (tier: BudgetTier) => void;
+  /** The last successful decision, if any (auto_approved/approved/partially_approved/pending_review/denied). */
+  result?: AugmentationRequest | null;
+  /** HTTP status of the last thrown error, when the mutation itself failed (network/5xx/403). */
+  errorStatus?: number;
+  /** True once a thrown (non-403) failure can be retried by re-sending the same idempotency key. */
+  canRetry?: boolean;
+  onRetry?: () => void;
+};
+
+export function BudgetRefillView({
+  showBackButton = true,
+  onBack,
+  canRefill = true,
+  selectedTier,
+  isSubmitting = false,
+  onSelectTier,
+  result = null,
+  errorStatus,
+  canRetry = false,
+  onRetry,
+}: Readonly<BudgetRefillViewProps>) {
+  const { t } = useTranslation();
+  const colors = useThemeColors();
+
+  const isPermissionError = errorStatus === 403;
+  const isOtherError = errorStatus !== undefined && !isPermissionError;
+
+  const renderResult = () => {
+    if (isPermissionError) {
+      return (
+        <Callout
+          tone="error"
+          icon={<Feather name="lock" size={designTokens.icon.action} color={colors.error} />}>
+          {t('settings.budget.permissionDenied')}
+        </Callout>
+      );
+    }
+
+    if (isOtherError) {
+      return (
+        <Stack gap="sm">
+          <Callout
+            tone="error"
+            icon={
+              <Feather name="alert-triangle" size={designTokens.icon.action} color={colors.error} />
+            }>
+            {t('settings.budget.retryHint')}
+          </Callout>
+          {canRetry ? (
+            <Button
+              variant="neutral"
+              size="sm"
+              onPress={onRetry}
+              disabled={isSubmitting}
+              style={{ alignSelf: 'flex-start' }}>
+              {t('settings.budget.retry')}
+            </Button>
+          ) : null}
+        </Stack>
+      );
+    }
+
+    if (!result) {
+      return null;
+    }
+
+    if (
+      result.status === 'auto_approved' ||
+      result.status === 'approved' ||
+      result.status === 'partially_approved'
+    ) {
+      return (
+        <Stack gap="sm">
+          <Callout
+            tone="success"
+            icon={<Feather name="check-circle" size={designTokens.icon.action} color={colors.success} />}>
+            {t('settings.budget.tokenRefreshNotice')}
+          </Callout>
+          {result.approvedAmountMicros ? (
+            <Text intent="caption">
+              {t('settings.budget.approvedAmountLabel', {
+                amount: formatMicroUsd(result.approvedAmountMicros),
+              })}
+            </Text>
+          ) : null}
+        </Stack>
+      );
+    }
+
+    if (result.status === 'pending_review') {
+      return (
+        <Callout
+          tone="warning"
+          icon={<Feather name="clock" size={designTokens.icon.action} color={colors.secondary} />}>
+          {t('settings.budget.pendingReview')}
+        </Callout>
+      );
+    }
+
+    if (result.status === 'denied') {
+      const reasonCode = result.policyReasonCodes.find((code) => code in DENIED_REASON_CODE_I18N_KEYS);
+      const deniedCopy = result.rejectionReason
+        ? result.rejectionReason
+        : reasonCode
+          ? t(DENIED_REASON_CODE_I18N_KEYS[reasonCode])
+          : t('settings.budget.deniedGenericReason');
+
+      return (
+        <Callout
+          tone="error"
+          icon={<Feather name="x-circle" size={designTokens.icon.action} color={colors.error} />}>
+          {deniedCopy}
+        </Callout>
+      );
+    }
+
+    return null;
+  };
+
+  return (
+    <Div tone="muted" width="full" style={{ flex: 1 }}>
+      {showBackButton ? (
+        <PageHeader
+          title={t('settings.budget.title')}
+          leading={
+            <Stack direction="row" align="center" gap="sm">
+              <Button
+                variant="ghost"
+                size="iconSm"
+                onPress={onBack}
+                accessibilityLabel={t('apiKeys.back')}>
+                <Feather name="arrow-left" size={designTokens.icon.nav} color={colors.ink} />
+              </Button>
+              <Text intent="caption">{t('nav.settings')}</Text>
+              <Feather name="chevron-right" size={14} color={colors.subtle} />
+            </Stack>
+          }
+        />
+      ) : null}
+
+      <Scroll tone="muted" pad="md" style={{ flex: 1 }}>
+        <Stack gap="lg">
+          {!showBackButton ? <Heading tone="title">{t('settings.budget.title')}</Heading> : null}
+          <Text intent="body">{t('settings.budget.subtitle')}</Text>
+
+          {!canRefill ? (
+            <Card size="md">
+              <Callout
+                tone="error"
+                icon={<Feather name="lock" size={designTokens.icon.action} color={colors.error} />}>
+                {t('settings.budget.permissionDenied')}
+              </Callout>
+            </Card>
+          ) : (
+            <>
+              <SectionCard
+                title={t('settings.budget.tierSection')}
+                description={t('settings.budget.tierSectionDescription')}>
+                <Stack direction="row" wrap="wrap" gap="sm" accessibilityRole="radiogroup">
+                  {BUDGET_TIERS.map((tier) => {
+                    const isSelected = tier === selectedTier;
+                    return (
+                      <Button
+                        key={tier}
+                        variant={isSelected ? 'primary' : 'neutral'}
+                        size="md"
+                        disabled={isSubmitting}
+                        onPress={() => onSelectTier(tier)}
+                        accessibilityRole="radio"
+                        accessibilityState={{ selected: isSelected, disabled: isSubmitting }}
+                        accessibilityLabel={t('settings.budget.selectTier', {
+                          amount: formatBudgetTierAmount(tier),
+                        })}
+                        style={{ minWidth: 88 }}>
+                        {formatBudgetTierAmount(tier)}
+                      </Button>
+                    );
+                  })}
+                </Stack>
+                {isSubmitting ? (
+                  <Stack direction="row" gap="sm" align="center" top="md">
+                    <Badge tone="neutral">{t('settings.budget.submitting')}</Badge>
+                  </Stack>
+                ) : null}
+              </SectionCard>
+
+              {renderResult() ? <Card size="sm">{renderResult()}</Card> : null}
+            </>
+          )}
+        </Stack>
+      </Scroll>
+    </Div>
+  );
+}

--- a/apps/self-service/src/views/settings/budget-refill-view.tsx
+++ b/apps/self-service/src/views/settings/budget-refill-view.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useTranslation } from '@lightbridge/i18n';
 import {
-  Badge,
   Button,
   Callout,
   Card,
@@ -19,8 +18,7 @@ import type { AugmentationRequest } from '@lightbridge/hooks';
 // Pure helpers only, from the dependency-free `./budget-tiers` subpath -- NOT the `@lightbridge/hooks`
 // barrel, which pulls in `@lightbridge/authz-rpc` (and transitively `cborg`, which Jest's resolver
 // can't follow) at runtime. See packages/hooks/src/budget-tiers.ts's module-level comment.
-import type { BudgetTier } from '@lightbridge/hooks/budget-tiers';
-import { BUDGET_TIERS, formatBudgetTierAmount, formatMicroUsd } from '@lightbridge/hooks/budget-tiers';
+import { formatBudgetTierAmount, formatMicroUsd, isBudgetTier } from '@lightbridge/hooks/budget-tiers';
 import { useThemeColors } from '../../hooks/use-theme-colors';
 
 /**
@@ -38,14 +36,28 @@ const DENIED_REASON_CODE_I18N_KEYS: Record<string, string> = {
   policy_denied: 'settings.budget.deniedReasonCodes.policy_denied',
 };
 
+/**
+ * Renders `AugmentationRequest.requestedTier` (the tier the SERVER assigned -- see the module
+ * comment on `packages/hooks/src/budget-tiers.ts`) as a dollar label. Falls back to computing the
+ * amount directly from `requestedAmountMicros` if the tier string isn't one of the ladder values
+ * this UI's lookup table knows about, so an unrecognized/future tier still renders a real number
+ * instead of a raw machine string.
+ */
+function requestedTierLabel(result: AugmentationRequest): string {
+  return isBudgetTier(result.requestedTier)
+    ? formatBudgetTierAmount(result.requestedTier)
+    : formatMicroUsd(result.requestedAmountMicros);
+}
+
 export type BudgetRefillViewProps = {
   showBackButton?: boolean;
   onBack: () => void;
   /** `usePermissions().has('budget:self-refill')` -- defensive re-check, not just the hidden nav entry. */
   canRefill?: boolean;
-  selectedTier?: BudgetTier;
+  /** The calendar month (`'YYYY-MM'`) this request is for -- client-computed, current month. */
+  period: string;
   isSubmitting?: boolean;
-  onSelectTier: (tier: BudgetTier) => void;
+  onSubmit: () => void;
   /** The last successful decision, if any (auto_approved/approved/partially_approved/pending_review/denied). */
   result?: AugmentationRequest | null;
   /** HTTP status of the last thrown error, when the mutation itself failed (network/5xx/403). */
@@ -59,9 +71,9 @@ export function BudgetRefillView({
   showBackButton = true,
   onBack,
   canRefill = true,
-  selectedTier,
+  period,
   isSubmitting = false,
-  onSelectTier,
+  onSubmit,
   result = null,
   errorStatus,
   canRetry = false,
@@ -112,6 +124,15 @@ export function BudgetRefillView({
       return null;
     }
 
+    // The tier is revealed from the RESPONSE, never chosen by the caller -- `request_refill`
+    // decides it server-side (see budget-tiers.ts's module comment). Shown for every outcome, not
+    // just a grant, since it's the answer to "what did I actually request" regardless of decision.
+    const requestedLine = (
+      <Text intent="caption">
+        {t('settings.budget.requestedTierLabel', { amount: requestedTierLabel(result) })}
+      </Text>
+    );
+
     if (
       result.status === 'auto_approved' ||
       result.status === 'approved' ||
@@ -119,6 +140,7 @@ export function BudgetRefillView({
     ) {
       return (
         <Stack gap="sm">
+          {requestedLine}
           <Callout
             tone="success"
             icon={<Feather name="check-circle" size={designTokens.icon.action} color={colors.success} />}>
@@ -137,11 +159,14 @@ export function BudgetRefillView({
 
     if (result.status === 'pending_review') {
       return (
-        <Callout
-          tone="warning"
-          icon={<Feather name="clock" size={designTokens.icon.action} color={colors.secondary} />}>
-          {t('settings.budget.pendingReview')}
-        </Callout>
+        <Stack gap="sm">
+          {requestedLine}
+          <Callout
+            tone="warning"
+            icon={<Feather name="clock" size={designTokens.icon.action} color={colors.secondary} />}>
+            {t('settings.budget.pendingReview')}
+          </Callout>
+        </Stack>
       );
     }
 
@@ -154,11 +179,14 @@ export function BudgetRefillView({
           : t('settings.budget.deniedGenericReason');
 
       return (
-        <Callout
-          tone="error"
-          icon={<Feather name="x-circle" size={designTokens.icon.action} color={colors.error} />}>
-          {deniedCopy}
-        </Callout>
+        <Stack gap="sm">
+          {requestedLine}
+          <Callout
+            tone="error"
+            icon={<Feather name="x-circle" size={designTokens.icon.action} color={colors.error} />}>
+            {deniedCopy}
+          </Callout>
+        </Stack>
       );
     }
 
@@ -202,34 +230,19 @@ export function BudgetRefillView({
           ) : (
             <>
               <SectionCard
-                title={t('settings.budget.tierSection')}
-                description={t('settings.budget.tierSectionDescription')}>
-                <Stack direction="row" wrap="wrap" gap="sm" accessibilityRole="radiogroup">
-                  {BUDGET_TIERS.map((tier) => {
-                    const isSelected = tier === selectedTier;
-                    return (
-                      <Button
-                        key={tier}
-                        variant={isSelected ? 'primary' : 'neutral'}
-                        size="md"
-                        disabled={isSubmitting}
-                        onPress={() => onSelectTier(tier)}
-                        accessibilityRole="radio"
-                        accessibilityState={{ selected: isSelected, disabled: isSubmitting }}
-                        accessibilityLabel={t('settings.budget.selectTier', {
-                          amount: formatBudgetTierAmount(tier),
-                        })}
-                        style={{ minWidth: 88 }}>
-                        {formatBudgetTierAmount(tier)}
-                      </Button>
-                    );
-                  })}
+                title={t('settings.budget.requestSection')}
+                description={t('settings.budget.requestSectionDescription')}>
+                <Stack gap="md" align="start">
+                  <Text intent="caption">{t('settings.budget.periodLabel', { period })}</Text>
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    disabled={isSubmitting}
+                    onPress={onSubmit}
+                    style={{ alignSelf: 'flex-start' }}>
+                    {isSubmitting ? t('settings.budget.submitting') : t('settings.budget.submit')}
+                  </Button>
                 </Stack>
-                {isSubmitting ? (
-                  <Stack direction="row" gap="sm" align="center" top="md">
-                    <Badge tone="neutral">{t('settings.budget.submitting')}</Badge>
-                  </Stack>
-                ) : null}
               </SectionCard>
 
               {renderResult() ? <Card size="sm">{renderResult()}</Card> : null}

--- a/apps/self-service/src/views/settings/budget-review-view.tsx
+++ b/apps/self-service/src/views/settings/budget-review-view.tsx
@@ -1,0 +1,217 @@
+import React, { useState } from 'react';
+import { useTranslation } from '@lightbridge/i18n';
+import {
+  Badge,
+  Button,
+  Callout,
+  Card,
+  designTokens,
+  Div,
+  Heading,
+  Icon as Feather,
+  PageHeader,
+  Scroll,
+  Skeleton,
+  Stack,
+  Text,
+  TextField,
+  EmptyState,
+} from '@lightbridge/ui';
+import type { AugmentationRequest } from '@lightbridge/hooks';
+// Pure helper only, from the dependency-free `./budget-tiers` subpath -- NOT the `@lightbridge/hooks`
+// barrel, which pulls in `@lightbridge/authz-rpc` (and transitively `cborg`, which Jest's resolver
+// can't follow) at runtime. See packages/hooks/src/budget-tiers.ts's module-level comment.
+import { formatMicroUsd } from '@lightbridge/hooks/budget-tiers';
+import { useThemeColors } from '../../hooks/use-theme-colors';
+import { formatDate } from '../api-keys-list-view';
+
+export type BudgetReviewViewProps = {
+  showBackButton?: boolean;
+  onBack: () => void;
+  /** `usePermissions().has('budget:review')` -- defensive re-check, not just the hidden nav entry. */
+  canReview?: boolean;
+  items?: AugmentationRequest[];
+  isLoading?: boolean;
+  onApprove: (requestId: string) => void;
+  onReject: (requestId: string, reason: string) => void;
+  /** Per-request in-flight state, keyed by `requestId` -- only the acted-on row disables. */
+  pendingRequestId?: string | null;
+  actionError?: string | null;
+};
+
+export function BudgetReviewView({
+  showBackButton = true,
+  onBack,
+  canReview = true,
+  items = [],
+  isLoading = false,
+  onApprove,
+  onReject,
+  pendingRequestId = null,
+  actionError = null,
+}: Readonly<BudgetReviewViewProps>) {
+  const { t, i18n } = useTranslation();
+  const colors = useThemeColors();
+  const [reasonDrafts, setReasonDrafts] = useState<Record<string, string>>({});
+
+  const setReasonDraft = (requestId: string, value: string) =>
+    setReasonDrafts((prev) => ({ ...prev, [requestId]: value }));
+
+  return (
+    <Div tone="muted" width="full" style={{ flex: 1 }}>
+      {showBackButton ? (
+        <PageHeader
+          title={t('settings.budgetReview.title')}
+          leading={
+            <Stack direction="row" align="center" gap="sm">
+              <Button
+                variant="ghost"
+                size="iconSm"
+                onPress={onBack}
+                accessibilityLabel={t('apiKeys.back')}>
+                <Feather name="arrow-left" size={designTokens.icon.nav} color={colors.ink} />
+              </Button>
+              <Text intent="caption">{t('nav.settings')}</Text>
+              <Feather name="chevron-right" size={14} color={colors.subtle} />
+            </Stack>
+          }
+        />
+      ) : null}
+
+      <Scroll tone="muted" pad="md" style={{ flex: 1 }}>
+        <Stack gap="lg">
+          {!showBackButton ? <Heading tone="title">{t('settings.budgetReview.title')}</Heading> : null}
+          <Text intent="body">{t('settings.budgetReview.subtitle')}</Text>
+
+          {!canReview ? (
+            <Card size="md">
+              <Callout
+                tone="error"
+                icon={<Feather name="lock" size={designTokens.icon.action} color={colors.error} />}>
+                {t('settings.budgetReview.permissionDenied')}
+              </Callout>
+            </Card>
+          ) : (
+            <>
+              {actionError ? (
+                <Callout
+                  tone="error"
+                  icon={
+                    <Feather name="alert-triangle" size={designTokens.icon.action} color={colors.error} />
+                  }>
+                  {actionError}
+                </Callout>
+              ) : null}
+
+              {isLoading ? (
+                <Stack gap="md">
+                  {[0, 1].map((key) => (
+                    <Card key={key} size="md">
+                      <Stack gap="md">
+                        <Skeleton width="45%" height={16} />
+                        <Skeleton width="65%" height={12} />
+                        <Stack direction="row" gap="sm" width="full">
+                          <Skeleton height={36} rounded="xl" style={{ flex: 1 }} />
+                          <Skeleton height={36} rounded="xl" style={{ flex: 1 }} />
+                        </Stack>
+                      </Stack>
+                    </Card>
+                  ))}
+                </Stack>
+              ) : items.length === 0 ? (
+                <Card size="md">
+                  <EmptyState
+                    icon={<Feather name="inbox" size={28} color={colors.subtle} />}
+                    title={t('settings.budgetReview.empty')}
+                  />
+                </Card>
+              ) : (
+                <Stack gap="md">
+                  {items.map((item) => {
+                    const isActing = pendingRequestId === item.id;
+                    const reasonDraft = reasonDrafts[item.id] ?? '';
+                    const trimmedReason = reasonDraft.trim();
+
+                    return (
+                      <Card key={item.id} size="md">
+                        <Stack gap="md">
+                          <Stack direction="row" align="center" justify="between" gap="sm">
+                            <Text intent="bodyStrong">
+                              {t('settings.budgetReview.requestedLabel', {
+                                amount: formatMicroUsd(item.requestedAmountMicros),
+                              })}
+                            </Text>
+                            <Badge tone="warning">{t('settings.budgetReview.statusPending')}</Badge>
+                          </Stack>
+
+                          <Stack direction="row" gap="md" wrap="wrap">
+                            <Text intent="caption">
+                              {t('settings.budgetReview.requestedFor', { accountId: item.accountId })}
+                            </Text>
+                            <Text intent="caption">
+                              {t('settings.budgetReview.periodLabel', { period: item.period })}
+                            </Text>
+                            <Text intent="caption">
+                              {t('settings.budgetReview.createdOn', {
+                                date: formatDate(item.createdAt, i18n.language),
+                              })}
+                            </Text>
+                          </Stack>
+
+                          <Stack direction="row" gap="sm" width="full">
+                            <Button
+                              variant="primary"
+                              size="sm"
+                              disabled={isActing}
+                              onPress={() => onApprove(item.id)}
+                              accessibilityLabel={t('settings.budgetReview.approveNamed', {
+                                id: item.id,
+                              })}
+                              style={{ flex: 1 }}>
+                              {isActing
+                                ? t('settings.budgetReview.approving')
+                                : t('settings.budgetReview.approve')}
+                            </Button>
+                          </Stack>
+
+                          <Stack gap="xs">
+                            <TextField
+                              value={reasonDraft}
+                              onChangeText={(value) => setReasonDraft(item.id, value)}
+                              placeholder={t('settings.budgetReview.reasonPlaceholder')}
+                              editable={!isActing}
+                              multiline
+                              accessibilityLabel={t('settings.budgetReview.reasonPlaceholder')}
+                            />
+                            <Button
+                              variant="danger"
+                              size="sm"
+                              disabled={isActing || trimmedReason.length === 0}
+                              onPress={() => onReject(item.id, trimmedReason)}
+                              accessibilityLabel={t('settings.budgetReview.rejectNamed', {
+                                id: item.id,
+                              })}
+                              style={{ alignSelf: 'flex-start' }}>
+                              {isActing
+                                ? t('settings.budgetReview.rejecting')
+                                : t('settings.budgetReview.reject')}
+                            </Button>
+                            {trimmedReason.length === 0 ? (
+                              <Text intent="caption" style={{ color: colors.subtle }}>
+                                {t('settings.budgetReview.reasonRequired')}
+                              </Text>
+                            ) : null}
+                          </Stack>
+                        </Stack>
+                      </Card>
+                    );
+                  })}
+                </Stack>
+              )}
+            </>
+          )}
+        </Stack>
+      </Scroll>
+    </Div>
+  );
+}

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./pagination": "./src/pagination.ts",
-    "./use-query-state": "./src/use-query-state.ts"
+    "./use-query-state": "./src/use-query-state.ts",
+    "./budget-tiers": "./src/budget-tiers.ts"
   },
   "dependencies": {
     "@lightbridge/api-native": "workspace:*",

--- a/packages/hooks/src/budget-tiers.ts
+++ b/packages/hooks/src/budget-tiers.ts
@@ -1,0 +1,108 @@
+/**
+ * Pure, dependency-free budget helpers (tier ladder, dollar formatting, error-status extraction).
+ * Deliberately split out of `./budget.ts`: that file also defines the mutation/query hooks, which
+ * import `@lightbridge/authz-rpc` at the top level -- and that package's `codec.ts` imports
+ * `cborg`, whose package.json `exports` map Jest's resolver cannot follow (fails with "Cannot
+ * find module 'cborg'") when this app's Jest config resolves it transitively. `./pagination` and
+ * `./use-query-state` already use this same "small dependency-free leaf module + its own package
+ * subpath export" pattern for exactly this reason -- a presentational *view* component can import
+ * this module directly (`@lightbridge/hooks/budget-tiers`) without ever pulling in
+ * `@lightbridge/authz-rpc`, keeping it testable the same way `project-settings-view.test.tsx`
+ * tests `ProjectSettingsView` -- no `jest.mock('@lightbridge/hooks', ...)` required.
+ */
+
+/**
+ * The self-service refill ladder (lightbridge-authz ADR-0008, "refills are discrete budget
+ * tiers"). Each entry's wire value is the opaque tier string the backend expects (e.g. `"b-30"`)
+ * -- there is no free-text amount anywhere in this domain, by design (ADR-0008's whole point).
+ * The dollar amount below has no server-side representation at all; it is a UI-only convenience
+ * table so the tier picker can show "$30" instead of "b-30". Keep it in sync with ADR-0008 by
+ * hand -- there is nothing on the wire to derive it from.
+ */
+export const BUDGET_TIERS = ['b-15', 'b-30', 'b-60', 'b-120', 'b-250', 'b-500', 'b-1000'] as const;
+
+export type BudgetTier = (typeof BUDGET_TIERS)[number];
+
+export const BUDGET_TIER_AMOUNT_USD: Record<BudgetTier, number> = {
+  'b-15': 15,
+  'b-30': 30,
+  'b-60': 60,
+  'b-120': 120,
+  'b-250': 250,
+  'b-500': 500,
+  'b-1000': 1000,
+};
+
+export function isBudgetTier(value: string): value is BudgetTier {
+  return (BUDGET_TIERS as readonly string[]).includes(value);
+}
+
+/** Formats a tier's UI-only dollar amount, e.g. `formatBudgetTierAmount('b-30') === '$30'`. */
+export function formatBudgetTierAmount(tier: BudgetTier): string {
+  return `$${BUDGET_TIER_AMOUNT_USD[tier].toLocaleString('en-US')}`;
+}
+
+/**
+ * Formats a decimal-string micro-USD amount (`requestedAmountMicros`/`approvedAmountMicros`) as
+ * a dollar string for display, e.g. `formatMicroUsd('30000000') === '$30.00'`.
+ *
+ * Deliberately BigInt-based end to end, never `Number()` -- those fields are decimal *strings*
+ * specifically because cratestack's TypeScript codegen types the schema's `Int` as a plain JS
+ * `number`, lossy above 2^53 (see `authz.cstack`'s own comment on `AugmentationRequest`). This
+ * function is display-only; its result must never be sent back to an RPC call -- if a raw
+ * micro-USD string needs to travel back to the wire, pass the original string through unchanged.
+ */
+export function formatMicroUsd(micros: string): string {
+  const trimmed = micros.trim();
+  const negative = trimmed.startsWith('-');
+  const digits = negative ? trimmed.slice(1) : trimmed;
+
+  if (!/^\d+$/.test(digits)) {
+    // Unexpected shape -- fail visibly rather than guess.
+    return micros;
+  }
+
+  const value = BigInt(digits);
+  const whole = value / 1_000_000n;
+  const fractionMicros = value % 1_000_000n;
+
+  // Round to the nearest cent using only integer arithmetic.
+  const centsFloor = fractionMicros / 10_000n;
+  const centsRemainder = fractionMicros % 10_000n;
+  const roundedUp = centsRemainder * 2n >= 10_000n;
+  const cents = roundedUp ? centsFloor + 1n : centsFloor;
+  const carries = cents >= 100n;
+
+  const finalWhole = carries ? whole + 1n : whole;
+  const finalCents = carries ? cents - 100n : cents;
+  const sign = negative ? '-' : '';
+
+  return `${sign}$${finalWhole.toString()}.${finalCents.toString().padStart(2, '0')}`;
+}
+
+/** The current calendar month as `'YYYY-MM'` (`lightbridge_authz_budget::Period`'s wire format). */
+export function currentBudgetPeriod(date: Date = new Date()): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  return `${year}-${month}`;
+}
+
+/**
+ * Extracts the HTTP status code from an error thrown by the generated API client, when present.
+ * Mirrors `getApiErrorMessage` in `./api-error.ts` but for the status code rather than the
+ * message -- needed here specifically to distinguish a `403` (permission denied, not retryable)
+ * from any other failure (network/5xx, retryable via the same idempotency key).
+ */
+export function getApiErrorStatus(error: unknown): number | undefined {
+  if (error && typeof error === 'object') {
+    const status = (error as { response?: { status?: unknown } }).response?.status;
+    if (typeof status === 'number') {
+      return status;
+    }
+  }
+  return undefined;
+}
+
+export function isPermissionDeniedError(error: unknown): boolean {
+  return getApiErrorStatus(error) === 403;
+}

--- a/packages/hooks/src/budget-tiers.ts
+++ b/packages/hooks/src/budget-tiers.ts
@@ -13,11 +13,20 @@
 
 /**
  * The self-service refill ladder (lightbridge-authz ADR-0008, "refills are discrete budget
- * tiers"). Each entry's wire value is the opaque tier string the backend expects (e.g. `"b-30"`)
- * -- there is no free-text amount anywhere in this domain, by design (ADR-0008's whole point).
+ * tiers"). Each entry's wire value is the opaque tier string the backend expects/returns (e.g.
+ * `"b-30"`) -- there is no free-text amount anywhere in this domain, by design (ADR-0008's whole
+ * point).
+ *
+ * IMPORTANT: this ladder is the SERVER's decision space, not a client selector. Confirmed by
+ * `authz.cstack`'s own comment directly above `RequestBudgetRefillInput`: a caller asks for more
+ * budget for `budgetAccountId`/`period`, and `RefillService::request_refill` DECIDES which tier
+ * to grant (or queue for review) -- there is deliberately no tier/amount argument anywhere on
+ * that input type. `AugmentationRequest.requestedTier` lives on the RESPONSE precisely because
+ * it is what the service assigned, not what the caller picked. This module's job is therefore
+ * purely a display lookup -- turning the tier the server already chose (e.g. `"b-250"`) into a
+ * dollar label (`"$250"`) for the result screen -- never a picker for the user to choose from.
  * The dollar amount below has no server-side representation at all; it is a UI-only convenience
- * table so the tier picker can show "$30" instead of "b-30". Keep it in sync with ADR-0008 by
- * hand -- there is nothing on the wire to derive it from.
+ * table. Keep it in sync with ADR-0008 by hand -- there is nothing on the wire to derive it from.
  */
 export const BUDGET_TIERS = ['b-15', 'b-30', 'b-60', 'b-120', 'b-250', 'b-500', 'b-1000'] as const;
 

--- a/packages/hooks/src/budget.test.ts
+++ b/packages/hooks/src/budget.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// budget.ts pulls in `./auth-session` → `@lightbridge/authz-rpc`, both of which drag in React
+// Native's entry point transitively (Flow syntax Vitest's Rollup/esbuild pipeline can't parse).
+// Mock both so this file only exercises the pure helpers under test — same pattern as
+// projects.test.ts.
+vi.mock('./auth-session', () => ({ useAuthSession: () => ({ isAuthenticated: true }) }));
+vi.mock('@lightbridge/authz-rpc', () => ({
+  getAuthzRpcClient: () => ({}),
+  createId: () => 'test-id',
+}));
+
+import {
+  BUDGET_TIER_AMOUNT_USD,
+  BUDGET_TIERS,
+  createBudgetIdempotencyKey,
+  currentBudgetPeriod,
+  formatBudgetTierAmount,
+  formatMicroUsd,
+  getApiErrorStatus,
+  isBudgetTier,
+  isPermissionDeniedError,
+  pendingAugmentationRequestsListQueryKey,
+  pendingAugmentationRequestsQueryKey,
+} from './budget';
+
+describe('BUDGET_TIERS', () => {
+  it('is the ADR-0008 discrete ladder, in ascending order', () => {
+    expect(BUDGET_TIERS).toEqual(['b-15', 'b-30', 'b-60', 'b-120', 'b-250', 'b-500', 'b-1000']);
+  });
+
+  it('every tier has a matching dollar amount', () => {
+    for (const tier of BUDGET_TIERS) {
+      expect(BUDGET_TIER_AMOUNT_USD[tier]).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('isBudgetTier', () => {
+  it('accepts every ladder value', () => {
+    for (const tier of BUDGET_TIERS) {
+      expect(isBudgetTier(tier)).toBe(true);
+    }
+  });
+
+  it('rejects a free-text/non-ladder value', () => {
+    expect(isBudgetTier('b-30.5')).toBe(false);
+    expect(isBudgetTier('unlimited')).toBe(false);
+    expect(isBudgetTier('')).toBe(false);
+  });
+});
+
+describe('formatBudgetTierAmount', () => {
+  it('formats the small tiers without a thousands separator', () => {
+    expect(formatBudgetTierAmount('b-15')).toBe('$15');
+    expect(formatBudgetTierAmount('b-30')).toBe('$30');
+  });
+
+  it('formats the four-figure tier with a thousands separator', () => {
+    expect(formatBudgetTierAmount('b-1000')).toBe('$1,000');
+  });
+});
+
+describe('formatMicroUsd', () => {
+  it('formats a whole-dollar amount', () => {
+    expect(formatMicroUsd('30000000')).toBe('$30.00');
+  });
+
+  it('formats a sub-dollar fractional amount', () => {
+    expect(formatMicroUsd('1500000')).toBe('$1.50');
+  });
+
+  it('rounds to the nearest cent', () => {
+    expect(formatMicroUsd('1999999')).toBe('$2.00');
+    expect(formatMicroUsd('1994000')).toBe('$1.99');
+    expect(formatMicroUsd('1995000')).toBe('$2.00');
+  });
+
+  it('handles a value at 2^53 and beyond without precision loss (the whole reason this is BigInt-based)', () => {
+    // Number.MAX_SAFE_INTEGER is 9007199254740991; one above it would silently round in `Number()`.
+    expect(formatMicroUsd('9007199254740993000000')).toBe('$9007199254740993.00');
+  });
+
+  it('handles a negative amount', () => {
+    expect(formatMicroUsd('-2500000')).toBe('-$2.50');
+  });
+
+  it('returns the raw input unchanged for an unparseable shape rather than throwing', () => {
+    expect(formatMicroUsd('not-a-number')).toBe('not-a-number');
+  });
+});
+
+describe('currentBudgetPeriod', () => {
+  it("formats a date as the 'YYYY-MM' wire format", () => {
+    expect(currentBudgetPeriod(new Date('2026-08-15T00:00:00Z'))).toBe('2026-08');
+  });
+
+  it('pads single-digit months', () => {
+    expect(currentBudgetPeriod(new Date('2026-01-05T00:00:00Z'))).toBe('2026-01');
+  });
+});
+
+describe('createBudgetIdempotencyKey', () => {
+  it('delegates to createId (cuid2), same generator projects.ts uses for ids', () => {
+    expect(createBudgetIdempotencyKey()).toBe('test-id');
+  });
+});
+
+describe('getApiErrorStatus / isPermissionDeniedError', () => {
+  it('extracts a numeric status from an axios-shaped error', () => {
+    const error = { response: { status: 403, data: 'Forbidden' } };
+    expect(getApiErrorStatus(error)).toBe(403);
+    expect(isPermissionDeniedError(error)).toBe(true);
+  });
+
+  it('treats a non-403 status as not permission-denied', () => {
+    const error = { response: { status: 500 } };
+    expect(getApiErrorStatus(error)).toBe(500);
+    expect(isPermissionDeniedError(error)).toBe(false);
+  });
+
+  it('returns undefined for an error with no response status', () => {
+    expect(getApiErrorStatus(new Error('network down'))).toBeUndefined();
+    expect(isPermissionDeniedError(new Error('network down'))).toBe(false);
+  });
+});
+
+describe('pendingAugmentationRequestsListQueryKey', () => {
+  it('appends the resolved budgetAccountId on top of the bare prefix', () => {
+    expect(pendingAugmentationRequestsListQueryKey('acc-1')).toEqual([
+      ...pendingAugmentationRequestsQueryKey,
+      'acc-1',
+    ]);
+  });
+
+  it("falls back to 'all' when scoping is omitted (the review queue's global default)", () => {
+    expect(pendingAugmentationRequestsListQueryKey()).toEqual([
+      ...pendingAugmentationRequestsQueryKey,
+      'all',
+    ]);
+  });
+});

--- a/packages/hooks/src/budget.ts
+++ b/packages/hooks/src/budget.ts
@@ -1,0 +1,151 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { AugmentationRequest } from '@lightbridge/authz-rpc';
+import { createId, getAuthzRpcClient } from '@lightbridge/authz-rpc';
+import { useAuthSession } from './auth-session';
+import { currentBudgetPeriod } from './budget-tiers';
+
+export type { AugmentationRequest } from '@lightbridge/authz-rpc';
+
+// Pure formatting/tier constants live in ./budget-tiers.ts (its own dependency-free package
+// subpath) specifically so a presentational view can import them without pulling in
+// `@lightbridge/authz-rpc` -- see that file's module-level comment. Re-exported here so the
+// `@lightbridge/hooks` barrel still carries everything for screens/other hook consumers.
+export * from './budget-tiers';
+
+/**
+ * A fresh idempotency key for one refill attempt. Callers must generate a new key per user-
+ * initiated submit and reuse the SAME key only when retrying that exact same failed attempt
+ * (`RefillService::find_existing` on the backend uses it to recognize a genuine retry and avoid
+ * evaluating/granting twice) -- never on a fresh submit, even of the same tier.
+ */
+export function createBudgetIdempotencyKey(): string {
+  return createId();
+}
+
+/**
+ * NOTE ON THE MISSING `tier` ARGUMENT: `RequestBudgetRefillInput` (packages/authz-rpc/schema/
+ * authz.cstack) has no field of any kind for the caller to specify which tier/amount they are
+ * requesting -- confirmed by reading the schema directly (`budgetAccountId`, `accountId`,
+ * `projectId?`, `period`, `idempotencyKey?` only). `AugmentationRequest.requestedTier` exists on
+ * the RETURN type, but nothing on the INPUT lets a caller drive it. This mutation intentionally
+ * does NOT accept a `tier` parameter as a result -- there is nowhere on the wire to put it, and
+ * inventing an undeclared field to smuggle one across would be presenting an unverified
+ * assumption as a real integration. See this ticket's implementation report for the full
+ * write-up; the caller-selected tier is UI-only until `RequestBudgetRefillInput` gains a field
+ * for it upstream.
+ */
+export type RequestBudgetRefillArgs = {
+  accountId: string;
+  /**
+   * Defaults to `accountId`. There is no separate "list my budget accounts" RPC in scope for
+   * this ticket and, per ADR-0006, one account is one person -- so the caller's own account id
+   * is the only budget-account identifier this screen has available. Pass an explicit value if a
+   * future screen ever has one.
+   */
+  budgetAccountId?: string;
+  /** Carried through but NOT used to scope the request -- budget is account-scoped, not project-scoped. */
+  projectId?: string;
+  /** Defaults to the current calendar month. */
+  period?: string;
+  idempotencyKey: string;
+};
+
+export function useRequestBudgetRefill() {
+  const mutation = useMutation({
+    mutationFn: async ({
+      accountId,
+      budgetAccountId,
+      projectId,
+      period,
+      idempotencyKey,
+    }: RequestBudgetRefillArgs): Promise<AugmentationRequest> =>
+      getAuthzRpcClient().procedures.requestBudgetRefill({
+        args: {
+          accountId,
+          budgetAccountId: budgetAccountId ?? accountId,
+          projectId,
+          period: period ?? currentBudgetPeriod(),
+          idempotencyKey,
+        },
+      }),
+  });
+
+  return {
+    isPending: mutation.isPending,
+    isError: mutation.isError,
+    error: mutation.error,
+    data: mutation.data,
+    reset: mutation.reset,
+    mutateAsync: mutation.mutateAsync,
+  };
+}
+
+/** Bare prefix -- invalidating with this alone clears every `budgetAccountId` scoping. */
+export const pendingAugmentationRequestsQueryKey = ['budget', 'pending-augmentation-requests'] as const;
+
+export function pendingAugmentationRequestsListQueryKey(budgetAccountId?: string) {
+  return [...pendingAugmentationRequestsQueryKey, budgetAccountId ?? 'all'] as const;
+}
+
+/**
+ * The admin review queue's read path. `budgetAccountId` omitted (the default) lists the whole
+ * cross-account queue -- this ticket's review screen is a global admin view, not scoped to one
+ * account.
+ */
+export function usePendingAugmentationRequests(budgetAccountId?: string, enabled = true) {
+  const { isAuthenticated } = useAuthSession();
+
+  const query = useQuery({
+    queryKey: pendingAugmentationRequestsListQueryKey(budgetAccountId),
+    queryFn: async (): Promise<AugmentationRequest[]> =>
+      getAuthzRpcClient().procedures.listPendingAugmentationRequests({
+        args: { budgetAccountId },
+      }),
+    enabled: enabled && isAuthenticated,
+    staleTime: 30_000,
+  });
+
+  return { ...query, data: query.data ?? [] };
+}
+
+export function useApproveAugmentationRequest() {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async ({ requestId }: { requestId: string }): Promise<AugmentationRequest> =>
+      getAuthzRpcClient().procedures.approveAugmentationRequest({ args: { requestId } }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: pendingAugmentationRequestsQueryKey });
+    },
+  });
+
+  return {
+    isPending: mutation.isPending,
+    error: mutation.error,
+    mutateAsync: mutation.mutateAsync,
+  };
+}
+
+export function useRejectAugmentationRequest() {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async ({
+      requestId,
+      reason,
+    }: {
+      requestId: string;
+      reason: string;
+    }): Promise<AugmentationRequest> =>
+      getAuthzRpcClient().procedures.rejectAugmentationRequest({ args: { requestId, reason } }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: pendingAugmentationRequestsQueryKey });
+    },
+  });
+
+  return {
+    isPending: mutation.isPending,
+    error: mutation.error,
+    mutateAsync: mutation.mutateAsync,
+  };
+}

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -3,6 +3,7 @@ export * from './api-error';
 export * from './api-keys';
 export * from './authz-types';
 export * from './auth-session';
+export * from './budget';
 export * from './keycloak-login';
 export * from './locale-sync';
 export * from './pagination';

--- a/packages/i18n/src/i18n-config.ts
+++ b/packages/i18n/src/i18n-config.ts
@@ -151,6 +151,8 @@ const resources = {
           account: 'Account',
           project: 'Project',
           apiKeys: 'API Keys',
+          budget: 'Budget',
+          budgetReview: 'Budget Review',
         },
         account: {
           title: 'Account settings',
@@ -266,6 +268,61 @@ const resources = {
           dangerDescriptionDefault:
             'This is your account’s default project and cannot be permanently deleted. Set another project as default first.',
           deleteProject: 'Delete project',
+        },
+        // Self-service budget refill (#148). "Budget tier" is deliberately never called "quota
+        // tier" anywhere in this block -- `project.quotaTier` (roster, per-member request-rate
+        // ceiling) and this "budget tier" (per-account monthly spend ceiling) are unrelated
+        // fields that would both read as "tier" in support tickets if the copy collided.
+        budget: {
+          title: 'Budget refill',
+          subtitle: "Request an increase to your account's monthly spending ceiling.",
+          tierSection: 'Choose a budget tier',
+          tierSectionDescription:
+            "Refills are fixed amounts, not a custom figure — pick the tier closest to what you need. This resets this month's spending ceiling to the selected amount; it doesn't add on top of what you already have.",
+          selectTier: 'Request the {{amount}} budget tier',
+          submitting: 'Submitting…',
+          permissionDenied: "You don't have permission to request a budget refill.",
+          // Non-negotiable per the ticket: never implies the new amount is usable right now, and
+          // names the concrete mechanism (a silent, refresh-token-based token refresh — see
+          // packages/authz-rpc/src/runtime.ts's proactive-refresh/401-retry logic and
+          // packages/hooks/src/auth/use-auth-session.ts's `refreshAuth` wiring) rather than
+          // leaving "next refresh" abstract. No re-login is required for this to take effect.
+          tokenRefreshNotice:
+            "Granted. This takes effect the next time your access token silently refreshes in the background — not immediately, and you won't need to log in again.",
+          approvedAmountLabel: 'Approved amount: {{amount}}',
+          pendingReview:
+            "This request is under review by an admin. There's no estimated time for a decision.",
+          deniedGenericReason: 'This request was denied. Contact support if you have questions.',
+          // Best-effort copy for `policyReasonCodes` when a request is denied automatically (no
+          // `rejectionReason`). Not a verified exhaustive list of the backend's reason-code enum
+          // — see the code comment on DENIED_REASON_CODE_I18N_KEYS in budget-refill-view.tsx.
+          deniedReasonCodes: {
+            self_service_disabled: 'Self-service refills are currently disabled for your account.',
+            account_suspended: "Your account is suspended, so refill requests can't be processed.",
+            policy_denied: "This request doesn't meet the current budget policy.",
+          },
+          retry: 'Retry',
+          retryHint:
+            "Something went wrong sending this request. Retrying reuses the same request so it won't be processed twice.",
+        },
+        budgetReview: {
+          title: 'Budget review queue',
+          subtitle: 'Pending self-service budget refill requests awaiting an admin decision.',
+          permissionDenied: "You don't have permission to review budget requests.",
+          empty: 'No pending requests. New requests that need review will show up here.',
+          statusPending: 'Pending review',
+          requestedLabel: 'Requested {{amount}}',
+          requestedFor: 'Account {{accountId}}',
+          periodLabel: 'Period {{period}}',
+          createdOn: 'Submitted {{date}}',
+          approve: 'Approve',
+          approving: 'Approving…',
+          approveNamed: 'Approve request {{id}}',
+          reject: 'Reject',
+          rejecting: 'Rejecting…',
+          rejectNamed: 'Reject request {{id}}',
+          reasonPlaceholder: 'Reason for the requester (required)',
+          reasonRequired: 'A reason is required before you can reject.',
         },
       },
       createProject: {

--- a/packages/i18n/src/i18n-config.ts
+++ b/packages/i18n/src/i18n-config.ts
@@ -273,14 +273,19 @@ const resources = {
         // tier" anywhere in this block -- `project.quotaTier` (roster, per-member request-rate
         // ceiling) and this "budget tier" (per-account monthly spend ceiling) are unrelated
         // fields that would both read as "tier" in support tickets if the copy collided.
+        // No tier/amount picker: `RequestBudgetRefillInput` has no field for the caller to
+        // specify one -- the server decides the tier server-side (see the comment on
+        // `packages/hooks/src/budget-tiers.ts` and budget-refill-screen.tsx). This screen only
+        // ever reveals the server-assigned tier AFTER a decision, via `requestedTierLabel`.
         budget: {
           title: 'Budget refill',
           subtitle: "Request an increase to your account's monthly spending ceiling.",
-          tierSection: 'Choose a budget tier',
-          tierSectionDescription:
-            "Refills are fixed amounts, not a custom figure — pick the tier closest to what you need. This resets this month's spending ceiling to the selected amount; it doesn't add on top of what you already have.",
-          selectTier: 'Request the {{amount}} budget tier',
-          submitting: 'Submitting…',
+          requestSection: 'Request a refill',
+          requestSectionDescription:
+            "The amount is determined automatically by your account's budget policy — you'll see what was requested once a decision comes back.",
+          periodLabel: 'For {{period}}',
+          submit: 'Request a refill',
+          submitting: 'Requesting…',
           permissionDenied: "You don't have permission to request a budget refill.",
           // Non-negotiable per the ticket: never implies the new amount is usable right now, and
           // names the concrete mechanism (a silent, refresh-token-based token refresh — see
@@ -289,6 +294,7 @@ const resources = {
           // leaving "next refresh" abstract. No re-login is required for this to take effect.
           tokenRefreshNotice:
             "Granted. This takes effect the next time your access token silently refreshes in the background — not immediately, and you won't need to log in again.",
+          requestedTierLabel: 'Requested tier: {{amount}}',
           approvedAmountLabel: 'Approved amount: {{amount}}',
           pendingReview:
             "This request is under review by an admin. There's no estimated time for a decision.",


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds `packages/hooks/src/budget.ts` (RPC hooks) and `budget-tiers.ts` (pure display helpers, exposed on its own subpath).
- Adds two screens: a self-service budget refill (`budget:self-refill`) and an admin review queue (`budget:review`), with routes and a permission-filtered settings category.
- Adds i18n copy for both.

It solves:

- https://github.com/ADORSYS-GIS/converse-frontends/issues/148

---

## 2. Intent

The intent of this PR is:

> Build the user-facing surface of the backend's budget domain. Both prerequisites are already in: #147 landed the `budget:*` RBAC mirror, and the schema carries all five budget procedures.

**This PR deliberately does NOT implement the ticket's tier picker.** `RequestBudgetRefillInput` is `{ budgetAccountId, accountId, projectId?, period, idempotencyKey? }` — there is no tier or amount field. `requestedTier` exists only on the *response*, because the tier is **server-determined**; the schema's own commentary above the input type says `RefillService::request_refill` decides. The ticket was drafted against prose docs rather than the input type. Full evidence: https://github.com/ADORSYS-GIS/converse-frontends/issues/148#issuecomment-5301445859

Building the picker as specified would have produced a screen where selecting `b-250` and `b-15` emit byte-identical RPC calls while the UI confirms the choice — the same failure mode as https://github.com/ADORSYS-GIS/lightbridge-authz/issues/282, which #143 exists to apologise for. Screen 1 instead requests a refill for the current period and reveals the server-assigned tier from the response.

---

## 3. Scope

### In Scope

- **Screen 1 (refill):** period-scoped request, fresh idempotency key per submit (same key only on retry of a failed attempt), disable-while-in-flight, all five `status` result states, the token-refresh notice on every grant path, defensive `403`.
- **Screen 2 (review queue):** `listPendingAugmentationRequests` (global, `budgetAccountId` omitted), approve with no confirm dialog, reject with a required reason, centered `EmptyState`.
- `budget-tiers.ts` as a **display-only** `b-250` → `$250` lookup for rendering the server's assigned tier.

### Out of Scope

- A tier/amount picker — see Intent.
- "Current balance" and "my request history" — no RPC exists for either.
- Review-queue pagination.
- Platform-admin policy screens (`activateBudgetPolicy`/`simulateBudgetPolicy`/`getBudgetPolicyStatus`) — platform-wide singletons belonging in an internal ops tool.
- Any change to `packages/ui` — existing primitives are composed; the new primitives land separately in #157.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [x] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
pnpm --filter @lightbridge/authz-rpc run codegen:cratestack
pnpm -r --if-present run test
pnpm lint
pnpm build
npx tsc --noEmit    # in apps/self-service — Metro does not typecheck
```

Results:

```text
tests:      227/227 passed — authz-rpc 14, hooks 52 (20 new in budget.test.ts),
            self-service 141 across 29 suites
tsc:        clean
pnpm build: turbo run build:web -> succeeded
lint:       6 pre-existing errors, all outside this change and confirmed present on
            origin/main (packages/ui/**/*.stories.tsx rules-of-hooks x5, gitignored
            generated/react-query.ts x1). Targeted lint of the 15 touched files: 0 errors.

Covered: each status result state's copy; 403 vs retryable error; fresh-key-per-submit
vs reused-key-on-retry; approve/reject including the reason-required gate.
```

`pnpm build` was re-run independently on this branch by the orchestrator, along with greps confirming no `selectedTier`/`onSelectTier`/`selectTier`/`tierSection` path survives anywhere, and that no micro-USD value is converted via `Number()`/`parseInt`/`parseFloat`.

---

## 5. Screenshots / Evidence

**No screenshots.** These screens are Keycloak-gated and a live capture needs a running auth stack, which was not available. Behaviour is covered by the 23 view tests listed above. Flagging this explicitly rather than leaving the section looking complete.

* Source of truth: https://github.com/ADORSYS-GIS/converse-frontends/issues/148
* Contract correction: https://github.com/ADORSYS-GIS/converse-frontends/issues/148#issuecomment-5301445859
* Backend story: https://github.com/ADORSYS-GIS/lightbridge-authz/issues/191

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [x] Medium
* [ ] High

Potential risks:

* **Precision loss on money.** `requestedAmountMicros`/`approvedAmountMicros` are decimal strings in micro-USD; `Number()` is lossy above 2^53.
* **Duplicate grants** if an idempotency key were reused across distinct submissions, or regenerated on a genuine retry.
* **A screen nobody can reach** — which role carries `budget:self-refill` is unresolved (https://github.com/ADORSYS-GIS/lightbridge-authz/issues/294).
* **Copy collision:** roster `quota_tier` (per-member request rate) vs. budget tier (per-account spend) both read as "tier".

Mitigation:

* Amounts are handled as strings end to end and only divided for display; verified by grep that no `Number()`/`parseInt`/`parseFloat` touches a `*Micros` value.
* Fresh key per submit, same key only on retry of the same failed attempt, covered by tests.
* Shipped **live behind the permission gate**, not a feature flag — the gate simply renders nothing for callers without the grant, and a defensive `403` handler covers the direct-call case. No dormant code, no toggle to remember to flip.
* New copy says "budget tier"/"spending ceiling" and never bare "tier" or "quota"; the roster's copy is untouched. Recorded in an i18n comment.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Refactoring
* [x] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Implemented by Claude Code (Sonnet subagent under an Opus 5 orchestrator) on behalf of @stephane-segning. Two things worth noting for reviewers: the agent **refused to invent an undeclared `tier` field** to satisfy the ticket, surfacing the contract mismatch instead; and the session-refresh copy names a concrete mechanism because the agent traced `tryProactiveRefresh()` through `use-auth-session.ts` → `_layout.tsx` → `runtime.ts` and confirmed it is a silent refresh-token refresh, not a re-login.

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

**Human attestation pending @stephane-segning's review** — an agent must not tick the accountable human's boxes on their behalf.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [x] Security
* [ ] Performance
* [ ] Tests
* [x] Product intent
* [x] Edge cases

Specifically:

1. **The refill screen's product shape.** With no picker, it is "request a refill for 2026-08" and the server decides the amount. Confirm that matches the intended UX before this reaches users — it is a materially different screen from the one the ticket describes.
2. **The token-refresh copy**, which is the ticket's stated defence against "it didn't work" support load: *"Granted. This takes effect the next time your access token silently refreshes in the background — not immediately, and you won't need to log in again."*
3. Whether the denial reason-code table (`self_service_disabled`, `account_suspended`, `policy_denied`) matches what the backend actually emits — it was written best-effort and falls back to a generic line for anything unrecognised.
