### PR TITLE
fix(authz-rpc): make `pnpm install` regenerate the RPC client

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -35,53 +35,13 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
 
+      # Also regenerates the gitignored packages/authz-rpc/generated/ via the root
+      # postinstall (`codegen:all`) — @cratestack/cli is a devDependency of that
+      # package, so no separately installed tooling is needed. The CLI version is
+      # an exact pin held in lockstep with the backend; see
+      # packages/authz-rpc/README.md for why that matters.
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Cache cratestack-cli
-        id: cratestack-cache
-        uses: actions/cache@v6
-        with:
-          path: ~/.local/bin/cratestack
-          key: cratestack-cli-0.7.16-${{ runner.os }}-${{ runner.arch }}
-
-      # 0.4.16+ ships prebuilt binaries on GH Releases — no Rust toolchain needed.
-      # This MUST match lightbridge-authz's `cratestack`/`cratestack-pg` pin
-      # (root Cargo.toml [workspace.dependencies]) exactly — nothing here enforces that
-      # automatically, it is a manual convention. A drift between this pin and the deployed
-      # backend's is exactly how lightbridge-authz#282 happened: cratestack 0.7.11 changed
-      # `Value`'s wire format from externally-tagged to untagged, this generator stayed on 0.4.16
-      # and kept hand-tagging `Json` fields to match the old shape, and the untagged-`Value`
-      # backend decoded the stale tagged payload without error (`deserialize_any` treats any JSON
-      # object as `Value::Map`), storing `{"List": [...]}` literally and silently defeating the
-      # `allowedModels` governance allowlist. See lightbridge-authz#282 / converse-frontends#149.
-      - name: Install cratestack-cli
-        if: steps.cratestack-cache.outputs.cache-hit != 'true'
-        env:
-          CRATESTACK_VERSION: '0.7.16'
-        run: |
-          set -euo pipefail
-          case "$(uname -m)" in
-            x86_64) target="x86_64-unknown-linux-gnu" ;;
-            aarch64|arm64) target="aarch64-unknown-linux-gnu" ;;
-            *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;;
-          esac
-          asset="cratestack-cli-${target}-v${CRATESTACK_VERSION}.tar.gz"
-          base_url="https://github.com/cratestack/cratestack/releases/download/v${CRATESTACK_VERSION}"
-          curl -fsSL -o "$asset" "${base_url}/${asset}"
-          curl -fsSL -o "${asset}.sha256" "${base_url}/${asset}.sha256"
-          sha256sum -c "${asset}.sha256"
-          tar xzf "$asset"
-          mkdir -p ~/.local/bin
-          install -m 755 cratestack ~/.local/bin/cratestack
-
-      - name: Add ~/.local/bin to PATH
-        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-      # generated/ is gitignored (codegen output, not something CI's Node/pnpm
-      # install can produce) — regenerate it before the bundle needs it.
-      - name: Generate authz-rpc bindings
-        run: pnpm --filter @lightbridge/authz-rpc run codegen:cratestack
 
       # Build the static web export on the runner. Turbo pulls from / writes to
       # the runner's integrated Turbo cache — no Docker/BuildKit layer cache.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,53 +26,13 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
 
+      # Also regenerates the gitignored packages/authz-rpc/generated/ via the root
+      # postinstall (`codegen:all`) — @cratestack/cli is a devDependency of that
+      # package, so no separately installed tooling is needed. The CLI version is
+      # an exact pin held in lockstep with the backend; see
+      # packages/authz-rpc/README.md for why that matters.
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Cache cratestack-cli
-        id: cratestack-cache
-        uses: actions/cache@v6
-        with:
-          path: ~/.local/bin/cratestack
-          key: cratestack-cli-0.7.16-${{ runner.os }}-${{ runner.arch }}
-
-      # 0.4.16+ ships prebuilt binaries on GH Releases — no Rust toolchain needed.
-      # This MUST match lightbridge-authz's `cratestack`/`cratestack-pg` pin
-      # (root Cargo.toml [workspace.dependencies]) exactly — nothing here enforces that
-      # automatically, it is a manual convention. A drift between this pin and the deployed
-      # backend's is exactly how lightbridge-authz#282 happened: cratestack 0.7.11 changed
-      # `Value`'s wire format from externally-tagged to untagged, this generator stayed on 0.4.16
-      # and kept hand-tagging `Json` fields to match the old shape, and the untagged-`Value`
-      # backend decoded the stale tagged payload without error (`deserialize_any` treats any JSON
-      # object as `Value::Map`), storing `{"List": [...]}` literally and silently defeating the
-      # `allowedModels` governance allowlist. See lightbridge-authz#282 / converse-frontends#149.
-      - name: Install cratestack-cli
-        if: steps.cratestack-cache.outputs.cache-hit != 'true'
-        env:
-          CRATESTACK_VERSION: '0.7.16'
-        run: |
-          set -euo pipefail
-          case "$(uname -m)" in
-            x86_64) target="x86_64-unknown-linux-gnu" ;;
-            aarch64|arm64) target="aarch64-unknown-linux-gnu" ;;
-            *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;;
-          esac
-          asset="cratestack-cli-${target}-v${CRATESTACK_VERSION}.tar.gz"
-          base_url="https://github.com/cratestack/cratestack/releases/download/v${CRATESTACK_VERSION}"
-          curl -fsSL -o "$asset" "${base_url}/${asset}"
-          curl -fsSL -o "${asset}.sha256" "${base_url}/${asset}.sha256"
-          sha256sum -c "${asset}.sha256"
-          tar xzf "$asset"
-          mkdir -p ~/.local/bin
-          install -m 755 cratestack ~/.local/bin/cratestack
-
-      - name: Add ~/.local/bin to PATH
-        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-      # generated/ is gitignored (codegen output, not something CI's Node/pnpm
-      # install can produce) — regenerate it before tests import it.
-      - name: Generate authz-rpc bindings
-        run: pnpm --filter @lightbridge/authz-rpc run codegen:cratestack
 
       - name: Run tests
         run: pnpm test

--- a/docs/knowledge/architecture-conventions.md
+++ b/docs/knowledge/architecture-conventions.md
@@ -32,13 +32,21 @@ converse-frontends/
 The AuthZ API (accounts/projects/api-keys) has no OpenAPI spec — it's schema-first cratestack RPC.
 Its source of truth is `packages/authz-rpc/schema/authz.cstack` (copied from the backend repo),
 turned into the generated client under `packages/authz-rpc/generated/` by the official
-`cratestack generate-typescript` CLI (`cratestack-cli`, a Rust binary — not an npm dependency).
+`cratestack generate-typescript` CLI, which ships as the `@cratestack/cli` npm package (a thin
+wrapper whose postinstall downloads the matching Rust binary from GitHub Releases).
 `generated/` is gitignored, same as every other package's codegen output (e.g. `api-rest`'s
-`src/client/`) — it's a build artifact, not source. Regenerate it locally with
-`pnpm --filter @lightbridge/authz-rpc codegen:cratestack`; CI (`test.yml`, `docker-image.yml`)
-installs a cached `cratestack-cli` (pinned to `0.7.16`, matching lightbridge-authz's deployed
-`cratestack`/`cratestack-pg` version — see `.github/workflows/test.yml` for why this must stay
-in lockstep) and runs the same command before tests/build.
+`src/client/`) — it's a build artifact, not source.
+
+`@cratestack/cli` is a `devDependency` of `packages/authz-rpc`, and that package's codegen
+script is named plain `codegen`, so the repo-root `postinstall` → `codegen:all` chain picks it
+up: a bare `pnpm install` regenerates it, locally and in CI alike, with no separately installed
+tooling. (Its postinstall is allowlisted under `allowBuilds` in `pnpm-workspace.yaml`; pnpm
+does not run dependency build scripts otherwise.) Regenerate it by hand with
+`pnpm --filter @lightbridge/authz-rpc run codegen`.
+
+The CLI is pinned to an **exact** version (`0.7.16`) that must stay in lockstep with
+lightbridge-authz's deployed `cratestack`/`cratestack-pg` version — see
+`packages/authz-rpc/README.md` for the incident that makes this non-negotiable.
 
 Since `cratestack-cli` 0.4.14 (issue #182), the generated runtime accepts a composable
 `links?: RpcLink[]` interceptor chain, threaded through as `AuthzRpcRuntimeOptions.links`

--- a/docs/knowledge/development-setup.md
+++ b/docs/knowledge/development-setup.md
@@ -35,7 +35,9 @@ corepack enable
 pnpm install
 ```
 
-> `postinstall` automatically runs `pnpm codegen:all`, which regenerates the `@lightbridge/api-rest` client from the OpenAPI specs in `openapi/`. This must succeed before you can start the app.
+> `postinstall` automatically runs `pnpm codegen:all`, which regenerates both generated clients: `@lightbridge/api-rest` from the OpenAPI specs in `openapi/`, and `@lightbridge/authz-rpc` from `packages/authz-rpc/schema/authz.cstack`. Both are gitignored build artifacts, and this must succeed before you can start the app.
+>
+> The AuthZ generator (`@cratestack/cli`) is an ordinary `devDependency`, so no manually installed tooling is required — but its postinstall downloads a binary from GitHub Releases, so the first install needs network access to `github.com`.
 
 ### 3. Configure Environment Variables
 
@@ -136,14 +138,17 @@ Both commands run ESLint + Prettier across all `*.{js,jsx,ts,tsx,json,css,md}` f
 The `packages/api-rest` client is **auto-generated** from OpenAPI specs. Never hand-edit files in `packages/api-rest/src/`.
 
 ```bash
-# Regenerate the API client
+# Regenerate the REST client only (packages/api-rest, from openapi/)
 pnpm codegen
 
-# Regenerate all packages that support codegen
+# Regenerate every package that has a `codegen` script — api-rest *and*
+# authz-rpc. This is what `postinstall` runs.
 pnpm codegen:all
 ```
 
-This is triggered automatically on `pnpm install` (via `postinstall`).
+`pnpm codegen:all` is triggered automatically on `pnpm install` (via `postinstall`). Note that
+`pnpm codegen` is the narrower of the two: it covers `api-rest` only, and is what the
+`apps/self-service` `pre*` scripts re-run before each dev-server start.
 
 ---
 

--- a/packages/authz-rpc/README.md
+++ b/packages/authz-rpc/README.md
@@ -1,0 +1,51 @@
+# @lightbridge/authz-rpc
+
+Generated cratestack RPC client for the AuthZ API (accounts / projects / API keys / budget).
+
+The source of truth is `schema/authz.cstack`, copied from the backend repo
+(`lightbridge-authz`). Everything under `generated/` is build output — it is gitignored, and
+`src/` wraps it with the hand-written runtime and hooks glue.
+
+## Codegen
+
+`generated/` is produced by the official `cratestack generate-typescript` CLI, which ships as
+the `@cratestack/cli` npm package (a thin wrapper whose postinstall downloads the matching
+Rust binary from GitHub Releases).
+
+It is a `devDependency` of this package, so the repo-root `postinstall` → `codegen:all` chain
+regenerates `generated/` on every `pnpm install`. No manually installed tooling is required —
+`pnpm install` from the repo root is enough.
+
+To regenerate by hand:
+
+```bash
+pnpm --filter @lightbridge/authz-rpc run codegen
+```
+
+You need that one-liner in exactly one case: when `generated/` is missing or stale but
+`node_modules` is already current. pnpm short-circuits an up-to-date install ("Already up to
+date") without running lifecycle scripts, so `pnpm install` is a no-op there and will *not*
+rebuild it. A fresh clone, a fresh CI checkout, or any install that actually changes
+dependencies does run `postinstall`, and therefore does regenerate it.
+
+## The CLI version pin is a lockstep contract — do not float it
+
+`@cratestack/cli` is pinned to an **exact** version (no `^`), and that version **must match
+`lightbridge-authz`'s `cratestack` / `cratestack-pg` pin** (its root `Cargo.toml`
+`[workspace.dependencies]`) exactly. Nothing enforces this automatically; it is a manual
+convention, and drift is silent and destructive.
+
+That is not hypothetical. It is exactly how
+[lightbridge-authz#282](https://github.com/ADORSYS-GIS/lightbridge-authz/issues/282) happened:
+
+- cratestack 0.7.11 changed `Value`'s wire format from externally-tagged to untagged.
+- This generator stayed on 0.4.16 and kept hand-tagging `Json` fields to the old shape.
+- The untagged-`Value` backend decoded the stale tagged payload **without error** —
+  `deserialize_any` treats any JSON object as `Value::Map` — and stored `{"List": [...]}`
+  literally.
+- That silently defeated the `allowedModels` governance allowlist.
+
+No exception was raised anywhere in the chain. When bumping this pin, bump it in lockstep with
+the backend and re-verify the wire format, rather than taking a green CI run as proof.
+
+See also [converse-frontends#149](https://github.com/ADORSYS-GIS/converse-frontends/issues/149).

--- a/packages/authz-rpc/package.json
+++ b/packages/authz-rpc/package.json
@@ -8,7 +8,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "codegen:cratestack": "cratestack generate-typescript --schema schema/authz.cstack --out generated --package-name @lightbridge/authz-rpc --full-selection",
+    "codegen": "cratestack generate-typescript --schema schema/authz.cstack --out generated --package-name @lightbridge/authz-rpc --full-selection",
     "test": "vitest run"
   },
   "dependencies": {
@@ -21,6 +21,7 @@
     "react": ">=18"
   },
   "devDependencies": {
+    "@cratestack/cli": "0.7.16",
     "vitest": "^3.2.7"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,6 +263,9 @@ importers:
         specifier: 19.2.0
         version: 19.2.0
     devDependencies:
+      '@cratestack/cli':
+        specifier: 0.7.16
+        version: 0.7.16
       vitest:
         specifier: ^3.2.7
         version: 3.2.7(@types/node@25.6.2)(jiti@2.7.0)(jsdom@20.0.3)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.4)
@@ -1005,6 +1008,13 @@ packages:
   '@cratestack/api@0.7.16':
     resolution: {integrity: sha512-aRwALXS5AfBb6shgSOkiUmLWMqJsrCbv5MXt5ZO3yuu0qcWlLa+Ourfx3jKgQGFmP6+ZZvZ7t0eSIHz5mkh7Og==}
     engines: {node: '>=18'}
+
+  '@cratestack/cli@0.7.16':
+    resolution: {integrity: sha512-zvK4vfgtO77QLMPTlg3UNptEoik+0VRCB1T38Vwp3vdAc6s/QEFdeughC9Hfl3I9xVj7Ht2cqQNOjfuYUQ6Q6Q==}
+    engines: {node: '>=18'}
+    cpu: [x64, arm64]
+    os: [darwin, linux, win32]
+    hasBin: true
 
   '@cratestack/link-batch@0.7.16':
     resolution: {integrity: sha512-tE6xmlIFx+st6SUq5KBz7ATSL+DQkAM0Ti39BVl5v/ZsVf22AvFhyAoIcZ781ZxcY1XmoVZs9FO6o9znjLLDWQ==}
@@ -7899,6 +7909,8 @@ snapshots:
       - axios
       - yup
       - zod
+
+  '@cratestack/cli@0.7.16': {}
 
   '@cratestack/link-batch@0.7.16':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,10 @@ packages:
 allowBuilds:
   esbuild: true
   unrs-resolver: false
+  # Its postinstall fetches the pinned cratestack-cli binary from GitHub Releases.
+  # Without this, the binary never lands and the root postinstall's `codegen:all`
+  # fails on @lightbridge/authz-rpc. See packages/authz-rpc/README.md.
+  "@cratestack/cli": true
 
 overrides:
   axios: "^1.18.0" # CVE fix floor raised: GHSA-gcfj-64vw-6mp9 (HIGH) needs >=1.18.0


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Renames `packages/authz-rpc`'s `codegen:cratestack` script to `codegen`, so the root `postinstall` → `codegen:all` chain actually picks it up.
- Adds `@cratestack/cli` as an **exact-pinned** (`0.7.16`, no caret) devDependency of that package, and allowlists its build script in `pnpm-workspace.yaml`.
- Removes the hand-rolled cratestack-cli cache/curl/PATH steps and the explicit codegen step from `test.yml` and `docker-image.yml` — `pnpm install` now covers both.
- Adds `packages/authz-rpc/README.md` to carry the lightbridge-authz#282 lockstep warning that previously lived only in the deleted CI comments.
- Corrects `docs/knowledge/architecture-conventions.md` and `docs/knowledge/development-setup.md`, which documented the old manual-install workflow.

It solves:

- A fresh `pnpm install` left `packages/authz-rpc/generated/` missing, breaking local/dev-onboarding setups silently.
- Source of truth: found while verifying https://github.com/ADORSYS-GIS/converse-frontends/issues/146 (`authz-rpc schema copy predates the budget domain — regenerate the client`). This PR fixes the *mechanism* that lets that client go stale; it does **not** close #146, which remains about the schema copy itself.

---

## 2. Intent

The intent of this PR is:

> To make `pnpm install` genuinely sufficient to build this repo, and to remove a class of silent staleness in a generated client that has already caused a production incident once.

The root `codegen:all` script runs `pnpm -r --if-present run codegen`, which only matches scripts named literally `codegen`. `packages/authz-rpc` defined only `codegen:cratestack`, so `--if-present` skipped it **silently**. Because `generated/` is gitignored, a clean checkout never revealed it, and CI papered over the gap with its own explicit `codegen:cratestack` step — so the failure landed only on local and dev-onboarding setups, with no error message pointing at the cause.

The obvious one-line fix (add a `codegen` alias) would have **broken CI**. `cratestack` was an external Rust binary that both workflows installed by hand *after* `pnpm install`, so wiring codegen into `postinstall` would have invoked a binary that was not yet on PATH — `command not found`, install fails, both workflows red, plus every local install on a machine without the tool.

The premise behind that setup turned out to be stale. `test.yml` asserted `generated/` was *"not something CI's Node/pnpm install can produce"*, but `@cratestack/cli` publishes the exact pinned `0.7.16` to npm — a thin wrapper whose postinstall fetches the very same GitHub Releases asset the workflows were curling. Making it a normal devDependency lets `pnpm install` produce `generated/` on any machine, and collapses the version pin from three places into one.

---

## 3. Scope

### In Scope

- The `codegen` script naming mismatch in `packages/authz-rpc` and the resulting postinstall gap.
- Sourcing the cratestack CLI via npm instead of a bespoke curl-and-cache step in each workflow.
- Preserving the CLI version-lockstep warning, which had no home outside the deleted CI comments.
- Correcting the two knowledge-base docs that described the removed workflow.

### Out of Scope

- **Turbo-caching the codegen task.** This would close the residual gap below, but it caches `generated/` — and lightbridge-authz#282 was *precisely* a silently-stale generated client. That trade-off deserves an explicit decision rather than being folded into a bug fix.
- **The repo-wide Prettier failure.** `pnpm exec prettier -c "**/*.{js,jsx,ts,tsx,json,css,md}"` reports 85 dirty files on `main`, including many this PR never touches (verified against `HEAD`). Reformatting them would bury this diff.
- **Closing #146.** The stale schema copy is a separate concern.
- `packages/api-rest` — already consistent, and its client is committed, so it never had this exposure.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

The decisive test was a **clean-machine simulation**: wipe every `node_modules` *and* `generated/`, then scrub `cratestack` from `PATH` so the ambient Rust binary cannot mask the result, and run exactly what CI runs.

Commands run:

```bash
# 1. Clean-machine simulation — no node_modules, no cratestack on PATH
rm -rf packages/authz-rpc/generated node_modules apps/*/node_modules packages/*/node_modules
env PATH="/usr/bin:/bin:/usr/sbin:/sbin:$(dirname "$(command -v node)"):$(dirname "$(command -v pnpm)")" \
  sh -c 'command -v cratestack >/dev/null && exit 1; pnpm install --frozen-lockfile'

# 2. Acceptance grep from the report
grep -rn "requestBudgetRefill" packages/authz-rpc/generated

# 3. Output equivalence: npm-installed CLI vs the PATH-installed Rust binary
diff -r "$SNAPSHOT/gen-npm" packages/authz-rpc/generated

# 4. Full suite + a real web export
pnpm -r --if-present run test
pnpm build
```

Results:

```text
# 1. cratestack NOT on PATH — simulating a clean machine
. postinstall$ pnpm codegen:all
. postinstall: packages/authz-rpc codegen$ cratestack generate-typescript --schema schema/authz.cstack ...
. postinstall: packages/authz-rpc codegen: generated TypeScript client package: generated
. postinstall: packages/api-rest codegen: ✅ Done!
Done in 11.1s using pnpm v11.5.2

# 2. 5 matches, incl. generated/src/client.ts:419 requestBudgetRefill(...)

# 3. IDENTICAL — npm CLI output matches the Rust binary byte-for-byte (no diff output)

# 4. packages/authz-rpc   Test Files 2 passed (2)  | Tests  14 passed (14)
#    packages/hooks       Test Files 4 passed (4)  | Tests  52 passed (52)
#    apps/self-service    Test Suites 29 passed    | Tests 141 passed (141)
#    workspace test exit: 0
#
#    pnpm build → Tasks: 1 successful, 1 total — Exported: dist (entry 3.8MB, css 17KB)
```

---

## 5. Screenshots / Evidence

No UI surface is touched, so there is nothing to screenshot. The meaningful evidence is textual and is inlined above:

* Clean-machine install log: section 4, result 1 — postinstall runs both codegens with `cratestack` absent from `PATH`.
* Byte-for-byte equivalence between the npm CLI and the Rust binary: section 4, result 3. This is the load-bearing check for swapping the toolchain source.
* Test + build output: section 4, result 4.

Two findings worth recording, both surfaced by this work:

* The local `generated/` in the working tree was not merely missing — it was **stale**, still carrying the pre-#158 `accountMemberships` schema with no budget procedures. Anything verified locally against it was exercising an outdated client. This is #146 observed in the wild.
* `pnpm install --frozen-lockfile` on a *warm* `node_modules` prints `Already up to date` and skips lifecycle scripts entirely — see Risk Assessment.

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [x] Medium
* [ ] High

Potential risks:

* **Residual gap — the fix is not total, and I would rather say so than imply otherwise.** If `generated/` is deleted while `node_modules` is already current, pnpm short-circuits (`Already up to date`) and never runs `postinstall`, so nothing regenerates. This is pnpm behaviour, not the script naming, and it is unchanged by this PR. Fresh clones, fresh CI checkouts, and any install that alters dependencies are all unaffected — those are the cases that were actually breaking.
* **Install now depends on network access to `github.com`** at postinstall time (the CLI wrapper fetches its binary). Previously CI curled the same asset, so the dependency is not new, but it moves into `pnpm install`.
* **CI loses the explicit `actions/cache` entry** for `~/.local/bin/cratestack`.
* **Toolchain source changed** for a generator with a documented history of catastrophic silent drift.

Mitigation:

* The residual gap is documented in `packages/authz-rpc/README.md` alongside the exact one-liner (`pnpm --filter @lightbridge/authz-rpc run codegen`), stating plainly which case needs it and why. Turbo-caching would close it and is called out as Out of Scope for a deliberate decision.
* The pin is **exact**, not a caret range, so the fetched asset is deterministic; the wrapper resolves the same GitHub Releases artifact the workflows already trusted.
* pnpm's side-effects cache is keyed off the pnpm store that `actions/setup-node`'s `cache: 'pnpm'` already restores, so the download is not expected on every warm run.
* Output equivalence was verified by `diff -r` rather than assumed from a matching version string.
* The lockstep warning is now in `packages/authz-rpc/README.md`, adjacent to the package that owns the pin, rather than buried in a workflow comment that only CI maintainers ever read.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Specifically: AI traced the `--if-present` skip to its root cause, identified that the naive alias fix would break CI before it was applied, discovered that `@cratestack/cli` publishes the pinned version to npm, and drafted the README and doc corrections. Every claim in this PR was verified by execution, not inspection — most importantly the byte-for-byte codegen equivalence and the clean-machine install.

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

Note on the unchecked box: this PR adds no tests. The change is to the install/build pipeline, and the meaningful assertion is the clean-machine reproduction in section 4, which no unit test could stand in for.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [ ] Product intent
* [x] Edge cases

Concretely, the three judgement calls worth a second opinion:

1. **Is sourcing the CLI from npm acceptable** for a generator whose version is a lockstep contract with the backend? The pin is exact and the output is byte-identical, but this changes *how* the toolchain arrives.
2. **Was removing the CI cache/curl steps the right call**, versus keeping them and accepting a duplicated pin in three places? I favoured a single source of truth over the cache entry.
3. **Should the Turbo codegen task land here** rather than being deferred? I deliberately left it out — see Scope — because caching `generated/` is the exact shape of the #282 failure.
