### PR TITLE
fix(ui): make Skeleton visible on web — NativeWind drops className on Animated wrappers

### DIFF
--- a/packages/ui/src/components/skeleton/component.stories.tsx
+++ b/packages/ui/src/components/skeleton/component.stories.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { Div } from '../div';
+import { Stack } from '../stack';
+import { Skeleton } from './component';
+
+// Skeleton widths default to "100%", and the Storybook canvas root has no intrinsic
+// width — without a sized parent every percentage-width story would collapse to 0px
+// and look identical to the NativeWind-drops-the-className bug this story guards.
+const meta: Meta<typeof Skeleton> = {
+  title: 'UI/Skeleton',
+  component: Skeleton,
+  decorators: [
+    (Story) => (
+      <Div style={{ width: 320 }}>
+        <Story />
+      </Div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Skeleton>;
+
+export const Default: Story = {};
+
+export const Rounded: Story = {
+  render: () => (
+    <Stack gap="md">
+      <Skeleton rounded="sm" height={20} />
+      <Skeleton rounded="md" height={20} />
+      <Skeleton rounded="xl" height={20} />
+      <Skeleton rounded="full" height={20} />
+    </Stack>
+  ),
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <Stack gap="sm">
+      <Skeleton width={160} height={12} />
+      <Skeleton width="60%" height={14} />
+      <Skeleton height={14} />
+      <Skeleton rounded="full" width={40} height={40} />
+    </Stack>
+  ),
+};
+
+/** How the four shipped loading states compose it: a stack of text-shaped lines. */
+export const TextBlock: Story = {
+  render: () => (
+    <Stack gap="sm">
+      <Skeleton width={120} height={12} />
+      <Skeleton width="100%" height={14} />
+      <Skeleton width="80%" height={14} />
+    </Stack>
+  ),
+};

--- a/packages/ui/src/components/skeleton/component.tsx
+++ b/packages/ui/src/components/skeleton/component.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useRef } from 'react';
-import { Animated, View } from 'react-native';
+import React from 'react';
+import { View } from 'react-native';
 import type { ViewProps } from 'react-native';
 
 import { cn } from '../../cn';
@@ -7,13 +7,16 @@ import { skeletonVariants } from './cva';
 import type { SkeletonProps } from './types';
 
 const ViewBase = View as React.ComponentType<ViewProps & { className?: string }>;
-const AnimatedView = Animated.createAnimatedComponent(ViewBase);
-
-const PULSE_DURATION_MS = 900;
 
 /**
  * Shimmer placeholder for content that's still loading. Pulses opacity rather than sweeping a
  * gradient — cheaper, no extra dependency, and reads fine at the sizes this app uses it at.
+ *
+ * The pulse comes from NativeWind's `animate-pulse` (a CSS animation on web, translated to
+ * Reanimated on native), not a hand-wired RN `Animated.Value`. Same precedent as Spinner, and
+ * for the same reason: `Animated.createAnimatedComponent()` produces a component NativeWind
+ * doesn't know about, so every `className` on it is dropped and the element renders with no
+ * background, no rounding, and no pulse.
  */
 export function Skeleton({
   rounded,
@@ -22,33 +25,12 @@ export function Skeleton({
   style,
   ...props
 }: Readonly<SkeletonProps>) {
-  const opacity = useRef(new Animated.Value(0.4)).current;
-
-  useEffect(() => {
-    const loop = Animated.loop(
-      Animated.sequence([
-        Animated.timing(opacity, {
-          toValue: 1,
-          duration: PULSE_DURATION_MS,
-          useNativeDriver: true,
-        }),
-        Animated.timing(opacity, {
-          toValue: 0.4,
-          duration: PULSE_DURATION_MS,
-          useNativeDriver: true,
-        }),
-      ])
-    );
-    loop.start();
-    return () => loop.stop();
-  }, [opacity]);
-
   return (
-    <AnimatedView
+    <ViewBase
       accessibilityElementsHidden
       importantForAccessibility="no-hide-descendants"
-      className={cn(skeletonVariants({ rounded }))}
-      style={[{ width, height, opacity }, style]}
+      className={cn('animate-pulse', skeletonVariants({ rounded }))}
+      style={[{ width, height }, style]}
       {...props}
     />
   );


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Fixes `Skeleton` rendering **fully invisible on web**. It wrapped `View` in `Animated.createAnimatedComponent()` and passed `className` to the result; NativeWind's transform only rewrites `className` for components it recognises, and the component `createAnimatedComponent` returns at runtime is not one of them — so the class was passed through as an inert prop and never applied.
- Replaces the hand-wired `Animated.loop` with NativeWind's `animate-pulse` (a CSS animation on web, translated to Reanimated on native), following the `Spinner` precedent. Net −29/+70 lines across 2 files, all inside `packages/ui/src/components/skeleton/`.
- Adds the missing `component.stories.tsx` so this cannot silently regress.

It solves:

- A defect in the `Skeleton` primitive from https://github.com/ADORSYS-GIS/converse-frontends/issues/79, found incidentally while building the Phase 2 primitives in #157.

---

## 2. Intent

The intent of this PR is:

> `Skeleton` had never once been visible on web, in any of the four screens that ship it as their primary loading state.
>
> **The symptom was total, not partial.** I confirmed it in the browser before changing anything, because the inline `style` prop (carrying `width`/`height`) *is* applied normally and I expected the box to be correctly sized but unstyled. The rendered element:
>
> ```
> class:            "css-view-g5y9jx"      ← react-native-web base class only; zero utilities
> background-color: rgba(0, 0, 0, 0)       ← no bg-border
> border-radius:    0px                    ← no rounded-lg
> opacity:          0.4, frozen            ← pulse never ticked
> ```
>
> Correct 160×12 box, zero pixels of it visible. Everything you'd check to diagnose it reports healthy: the `.bg-border` rule **is** in the compiled stylesheet, `--color-border` **is** defined, the sibling `Stack` in the same tree **does** get its classes (`flex flex-col gap-2 …`). Only the join between class and element was missing.
>
> A second defect sat underneath the first: the hand-wired `Animated.loop` with `useNativeDriver: true` never advanced either — opacity stayed pinned at its `0.4` seed across 1.6s of sampling. So even had the background applied, it would have been a static box, not a pulse.
>
> It went unnoticed for a mundane reason worth recording: `skeleton` was the **only** component directory in `packages/ui` with no Storybook story. The one surface where a human looks at components in isolation had a hole exactly where the broken component was.

---

## 3. Scope

### In Scope

- `packages/ui/src/components/skeleton/component.tsx` — the fix.
- `packages/ui/src/components/skeleton/component.stories.tsx` — new; 4 stories (Default, Rounded, Sizes, TextBlock).

### Out of Scope

- **Auditing the rest of the package for the same pattern.** Already done and clean: `grep` confirms `skeleton` was the only component using `createAnimatedComponent`, and `cssInterop`/`remapProps` appear nowhere in `packages/ui/src` or `apps/self-service/src`, so no other component was relying on an unregistered wrapper.
- **The four consuming views.** Verified unchanged and correct (below); they needed no edits — all four pass only `width`/`height`/`rounded`/`style`, and none depended on the animated opacity.
- Any change to the `bg-border` token or the visual design of the placeholder.

### Design note — why `animate-pulse` over `cssInterop`

Both fix it. I took the utility route because `cssInterop` keeps a broken-by-default pattern alive: the registration has to be remembered by whoever next reaches for `createAnimatedComponent`, and it would make `skeleton` the only component in the package needing a registration step. The utility route deletes the machinery instead, needs no wrapper, and leaves **one** animation pattern in the package rather than two divergent ones. `Spinner` already established it with `animate-spin`.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
pnpm -r --if-present run test
pnpm build
pnpm build-storybook
pnpm lint
```

Results:

```text
test            29 suites, 141 tests passed
build           passed — web bundle exported
build-storybook passed — ui-skeleton--{default,rounded,sizes,text-block} all in index.json
lint            FAILS — pre-existing, see below
```

**On `pnpm lint`:** it fails on this branch and fails identically on the branch point — **137 problems / 6 errors, byte-identical count with my changes stashed**. The 6 errors are all `react-hooks/rules-of-hooks` in the pagination / segmented-control / select stories, untouched by this PR. My two files contribute zero problems.

**Post-fix DOM**, same element as the "before" above:

```
class:            "css-view-g5y9jx animate-pulse bg-border rounded-lg"
background-color: rgb(230, 232, 236)   ← --color-border
border-radius:    8px
animation:        pulse 2s
```

The production CSS bundle carries all three rules, so this survives the real bundler and not just the dev server:

```
.animate-pulse{animation:2s cubic-bezier(.4,0,.6,1) infinite pulse}
@keyframes pulse{50%{opacity:.5}}
.bg-border{--tw-bg-opacity:1;background-color:rgb(var(--color-border) / var(--tw-bg-opacity,1))}
```

---

## 5. Screenshots / Evidence

**Storybook, before → after.** Before: a blank canvas. After: all four rounding variants distinct (`sm`/`md`/`xl`/`full`), verified in both light and dark.

**The four consuming views**, each rendering its loading state correctly on web. These screens are Keycloak-gated, so I verified through a temporary `/preview` route rendering each `*View` with mock props — **reverted before commit**; the diff is only the component and its story.

| View | Loading state |
|---|---|
| `api-keys-list-view.tsx` | two full skeleton cards |
| `project-settings-view.tsx` | field-shaped stack + button |
| `account-settings-view.tsx` | two pill buttons |
| `home-view.tsx` | account-label line under the greeting |

Browser console: clean, no errors.

### Reproducing the animation check — read this before re-verifying

In a headless browser the animation's `currentTime` sits pinned at `0` and computed opacity never moves, **which looks exactly like the bug is still present.** It isn't — that environment doesn't advance animation timelines at all. The control: `Spinner`, which is known-good and shipped, freezes identically under the same measurement.

To actually prove the keyframes are live, seek the timeline by hand:

```js
const a = el.getAnimations()[0];
for (const t of [0, 500, 1000, 1500]) { a.currentTime = t; console.log(t, getComputedStyle(el).opacity); }
// 0 → "1"   500 → "0.75"   1000 → "0.5"   1500 → "0.75"
```

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* **Native (iOS/Android) is unverified.** `animate-pulse` depends on NativeWind translating the CSS animation to Reanimated on device. I had no device available, so this rests on precedent, not proof — it is the identical mechanism `Spinner` already ships with `animate-spin`. This is the one thing I'd want a reviewer with a device to confirm.
* The pulse timing changes slightly: was a hand-rolled 900ms `0.4 ↔ 1` linear loop, now Tailwind's standard 2s `1 → 0.5 → 1` cubic-bezier. Intentional — it's the platform default and matches `Spinner`'s posture — but it is a visible difference from the code's stated intent, even though that intent never actually reached a screen.

Mitigation:

* Blast radius is one leaf component with no state, no callbacks, and no consumers passing anything beyond size/rounding/style — so a regression is visual only and immediately obvious.
* The new story is the durable guard: the gap that hid this for its whole lifetime was the absent story, and that gap is now closed.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Claude Code investigated the report, confirmed the defect in a live browser before editing, implemented the fix and the story, and drafted this description.

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually — *n/a, no tests added; the guard here is a Storybook story, checked manually in the browser*
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

On "removed unsupported AI assumptions": the originating report hedged that the symptom *might* be partial (correct size, missing background). That was not assumed either way — it was checked in the DOM first, and found to be total invisibility. The frozen-`currentTime` reading was likewise not accepted at face value; it was disproved with a control against a known-working component before concluding the fix worked.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [ ] Product intent
* [x] Edge cases

Specifically:

1. **Native rendering** — the one gap in my verification. Does `animate-pulse` pulse on a real device?
2. **`animate-pulse` vs `cssInterop`** — is the "one pattern in the package" argument in §3 the call you'd make?
3. **The story's fixed-width decorator** is load-bearing, not cosmetic: without a sized parent, the percentage-width stories collapse to 0px and would render identically to the bug they exist to catch. Worth not "simplifying" away later — there's a comment on it.
