### PR TITLE
feat(codegen): wire codegen into Turbo, closing the gap left by #159

### DIFF
--- a/docs/knowledge/architecture-conventions.md
+++ b/docs/knowledge/architecture-conventions.md
@@ -44,6 +44,16 @@ tooling. (Its postinstall is allowlisted under `allowBuilds` in `pnpm-workspace.
 does not run dependency build scripts otherwise.) Regenerate it by hand with
 `pnpm --filter @lightbridge/authz-rpc run codegen`.
 
+`codegen` (both this package's and `api-rest`'s) is also a Turbo task (`turbo.json`), and
+`build:web`/`build-storybook` declare it as a `dependsOn`. `pnpm build`/`pnpm build-storybook`
+therefore regenerate both clients from cache whenever their real inputs — schema/OpenAPI spec,
+or the generator's own pinned version via the lockfile — are unchanged, and only pay the
+generation cost again when one of those actually changes. `packages/api-rest/turbo.json`
+overrides that package's `codegen` inputs to add `openapi/usage.backend.yaml`, which lives
+outside the package directory and so isn't covered by Turbo's default per-package file hashing.
+This is a cache for repeated `turbo run` invocations on top of the `postinstall` path above, not
+a replacement for it — `pnpm install` still always regenerates unconditionally.
+
 The CLI is pinned to an **exact** version (`0.7.16`) that must stay in lockstep with
 lightbridge-authz's deployed `cratestack`/`cratestack-pg` version — see
 `packages/authz-rpc/README.md` for the incident that makes this non-negotiable.

--- a/packages/api-rest/turbo.json
+++ b/packages/api-rest/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "codegen": {
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/openapi/**"]
+    }
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -2,11 +2,15 @@
   "$schema": "https://turbo.build/schema.json",
   "ui": "stream",
   "tasks": {
+    "codegen": {
+      "outputs": ["generated/**", "src/client/**"]
+    },
     "build:web": {
-      "dependsOn": ["^build:web"],
+      "dependsOn": ["^build:web", "codegen"],
       "outputs": ["dist/**"]
     },
     "build-storybook": {
+      "dependsOn": ["codegen"],
       "outputs": ["storybook-static/**"]
     }
   }


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds a `codegen` Turbo task for `packages/authz-rpc` and `packages/api-rest`.
- Makes `build:web` and `build-storybook` declare `codegen` as a `dependsOn`, so `pnpm build`/`pnpm build-storybook` pull codegen through Turbo's cache instead of always re-running it.
- Adds `packages/api-rest/turbo.json`, a package-level override that scopes that package's `codegen` inputs to include `openapi/usage.backend.yaml` (which lives outside the package directory, so Turbo's default per-package file hashing doesn't see it).
- Extends `docs/knowledge/architecture-conventions.md` to describe the Turbo wiring alongside the `postinstall` path.

It solves:

- The gap explicitly deferred in https://github.com/ADORSYS-GIS/converse-frontends/pull/159's Scope section: *"Turbo-caching the codegen task... deserves an explicit decision rather than being folded into a bug fix."* #159 fixed `pnpm install` unconditionally regenerating both clients; this adds the caching layer on top, now that it's its own considered change rather than a drive-by addition.

---

## 2. Intent

The intent of this PR is:

> To stop paying the codegen cost on every `turbo run build:web`/`build-storybook` invocation when neither generator's real inputs have changed, without reintroducing the risk #159 called out: a generated client going silently stale relative to the toolchain that produced it.

That risk is not hypothetical — it's [lightbridge-authz#282](https://github.com/ADORSYS-GIS/lightbridge-authz/issues/282), documented in `packages/authz-rpc/README.md`: a generator/backend version drift that decoded silently instead of erroring, defeating a governance allowlist with no exception anywhere in the chain. Caching a codegen task is exactly the kind of change that could reproduce that shape of bug if the cache key doesn't include the generator's own version. So the work here isn't "add a Turbo task" so much as "verify the cache key actually covers what #282 needed covered" — which is why the PR leads with empirical proof of invalidation rather than the task definition itself.

---

## 3. Scope

### In Scope

- A `codegen` Turbo task for the two packages that already define a `codegen` script.
- Wiring `build:web`/`build-storybook` to depend on it.
- The `api-rest`-specific input override for its cross-package OpenAPI spec dependency.

### Out of Scope

- Changing CI (`test.yml`, `docker-image.yml`). Both still run `pnpm install --frozen-lockfile`, which unconditionally regenerates via `postinstall` regardless of Turbo's cache — that's the correctness guarantee #159 established, and this PR doesn't touch it. CI's subsequent `pnpm turbo run build:web` now also runs `codegen` through Turbo, so on the self-hosted runner's persistent cache (see `docs/knowledge/ci-cd.md`) it can skip re-running codegen a second time when its inputs are unchanged — a modest speed win — but that's a side effect of this change, not something I reconfigured CI to exploit.
- The residual `pnpm install` short-circuit gap #159 documented (deleting `generated/` with warm `node_modules` doesn't trigger a rebuild). Unrelated to Turbo — still open.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Every claim below is from actually running it, not inferred from the config. One correction along the way, worth stating plainly: my first three "cold cache" runs were not actually cold — Turbo shares one cache across every git worktree of this repo, rooted at the *primary* worktree (`is_shared_worktree=true` in `--verbosity=2` output), not the one I was working in. Deleting `.turbo` in my worktree was deleting a path Turbo wasn't reading from. I found this by reading the debug log directly rather than trusting the result, then re-ran the decisive test against the actual shared cache path.

Commands run:

```bash
# 1. Independent invalidation per package
echo "// probe" >> packages/authz-rpc/schema/authz.cstack
pnpm turbo run codegen   # expect: authz-rpc miss, api-rest hit
git checkout -- packages/authz-rpc/schema/authz.cstack

echo "# probe" >> openapi/usage.backend.yaml
pnpm turbo run codegen   # expect: api-rest miss, authz-rpc hit
git checkout -- openapi/usage.backend.yaml

# 2. The #282-relevant test: version bump alone, schema untouched
# (bumped @cratestack/cli's pin in package.json, ran, reverted — see note below)
pnpm turbo run codegen   # expect: authz-rpc miss even with schema unchanged

# 3. Fail-fast propagation
echo "garbage" >> packages/authz-rpc/schema/authz.cstack
pnpm build                # expect: codegen fails, build:web does NOT run
git checkout -- packages/authz-rpc/schema/authz.cstack

# 4. Success propagation
echo "// probe" >> packages/authz-rpc/schema/authz.cstack
pnpm build                 # expect: codegen reruns, build:web reruns (not cached)
git checkout -- packages/authz-rpc/schema/authz.cstack

# 5. True cold clean-machine run
rm -rf /Users/selast/dev/gis/converse-frontends/.turbo   # the REAL shared cache path
rm -rf node_modules apps/*/node_modules packages/*/node_modules packages/authz-rpc/generated
env PATH="<no cratestack>" pnpm install --frozen-lockfile
pnpm build

# 6. Full suite
pnpm -r --if-present run test
```

Results:

```text
# 1. authz-rpc: cache miss, executing | api-rest: cache hit, replaying logs — Cached: 1/2
#    (then reversed for the openapi/api-rest edit, confirming BOTH directions are scoped
#    correctly — this required adding packages/api-rest/turbo.json; before that override,
#    touching openapi/usage.backend.yaml wrongly invalidated authz-rpc too, since root-level
#    turbo.json inputs apply to every package running the task)

# 2. @lightbridge/authz-rpc:codegen: cache miss, executing 58dc919260a033ea
#    (api-rest stayed cached — confirms Turbo's lockfile-based dependency-version hashing
#    catches a version bump with zero schema changes, which is the exact shape #282 needed
#    caught)

# 3. @lightbridge/authz-rpc:codegen: Error: unsupported top-level declaration: garbage
#    Tasks: 1 successful, 2 total — self-service:build:web never ran

# 4. Tasks: 3 successful, 3 total / Cached: 1 cached, 3 total
#    (authz-rpc:codegen reran, api-rest:codegen stayed cached, build:web reran — correct
#    propagation in both directions)

# 5. clean machine, cratestack not on PATH, shared turbo cache wiped
#    Tasks: 3 successful, 3 total / Cached: 0 cached, 3 total / Time: 7.976s
#    → real dist/ produced from a genuinely cold state

# 6. packages/authz-rpc   Test Files 2 passed (2)  | Tests  14 passed (14)
#    packages/hooks       Test Files 4 passed (4)  | Tests  52 passed (52)
#    apps/self-service    Test Suites 29 passed    | Tests 141 passed (141)
#    exit: 0
```

A note on test 2's mechanics, since it left a footprint worth disclosing: bumping the pin triggered an environment-level hook that ran a real `pnpm install`, which both updated `pnpm-lock.yaml` and had pnpm auto-append a `minimumReleaseAgeExclude` entry to `pnpm-workspace.yaml` for the bumped version (pnpm's own minimum-release-age supply-chain guard). Once the cache-miss was confirmed, I reverted all three files (`package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`) to `HEAD` and re-ran `pnpm install --frozen-lockfile` to resync `node_modules` — this PR's diff carries none of that scratch state.

---

## 5. Screenshots / Evidence

No UI surface is touched. The evidence is the command output inlined above — most load-bearing is test 2 (version-bump invalidation, the direct #282 analog) and test 5 (genuine cold build).

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* **Turbo's shared-worktree cache** means a stale codegen output cached from one worktree could, in principle, be replayed into another worktree's build if their input hashes collide while their `node_modules`/toolchain don't actually match. In practice the hash includes the resolved dependency versions from the lockfile, so this would need two worktrees with different lockfiles claiming an identical hash — not a realistic collision, but worth naming since it surprised me during verification.
* **`packages/api-rest/turbo.json` is a second place the codegen task can be configured**, alongside root `turbo.json`. Only needed because that package's input lives outside its own directory; `authz-rpc`'s schema is package-local and needed no override.

Mitigation:

* CI's correctness doesn't depend on Turbo's cache at all — `pnpm install --frozen-lockfile` still unconditionally regenerates both clients before Turbo ever runs, exactly as #159 left it. Turbo caching is purely a speed optimization layered on top, never a substitute for that guarantee.
* The override is minimal (one `inputs` key) and its purpose is explained inline in the docs update.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [x] I understand every meaningful change in this PR
* [x] I checked generated code manually
* [ ] I checked generated tests manually
* [x] I removed unsupported AI assumptions
* [x] I accept responsibility for this PR

Note on the unsupported-assumptions box: the initial "cold cache" test results were wrong (see Verification) because of an incorrect assumption about where Turbo's cache lives in a worktree setup. That was caught by reading the debug log rather than trusting the plausible-looking result, and the decisive tests were re-run against the real cache path before this PR was written up.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [ ] Product intent
* [x] Edge cases

Specifically: does the `packages/api-rest/turbo.json` override correctly express "this package's codegen also depends on a file outside its own directory," or would you rather see that expressed differently (e.g. a `globalDependencies` entry in root `turbo.json`, which would be simpler but would invalidate *both* packages' codegen on an OpenAPI spec change — the over-broad behavior this PR specifically moved away from)?
