### PR TITLE
feat(self-service): surface ApiKeySecret.oauth2Url on the one-time secret card

### DIFF
--- a/apps/self-service/src/__tests__/one-time-secret-card.test.tsx
+++ b/apps/self-service/src/__tests__/one-time-secret-card.test.tsx
@@ -27,4 +27,43 @@ describe('OneTimeSecretCard', () => {
     expect(onCopy).toHaveBeenCalledWith('TEST-FIXTURE-SECRET-VALUE');
     expect(screen.getByText('Copied!')).toBeTruthy();
   });
+
+  it('renders no oauth2Url section when the prop is absent (baseline unchanged)', async () => {
+    await render(
+      <OneTimeSecretCard secret="TEST-FIXTURE-SECRET-VALUE" onCopy={jest.fn()} />
+    );
+
+    expect(screen.queryByText('OAuth2 token endpoint:')).toBeNull();
+  });
+
+  it('renders no oauth2Url section when the prop is an empty string', async () => {
+    await render(
+      <OneTimeSecretCard secret="TEST-FIXTURE-SECRET-VALUE" onCopy={jest.fn()} oauth2Url="" />
+    );
+    expect(screen.queryByText('OAuth2 token endpoint:')).toBeNull();
+  });
+
+  it('renders no oauth2Url section when the prop is a malformed URL', async () => {
+    await render(
+      <OneTimeSecretCard
+        secret="TEST-FIXTURE-SECRET-VALUE"
+        onCopy={jest.fn()}
+        oauth2Url="not-a-url"
+      />
+    );
+    expect(screen.queryByText('OAuth2 token endpoint:')).toBeNull();
+  });
+
+  it('renders the oauth2Url, labeled and selectable, when the backend returns one', async () => {
+    await render(
+      <OneTimeSecretCard
+        secret="TEST-FIXTURE-SECRET-VALUE"
+        onCopy={jest.fn()}
+        oauth2Url="https://auth.example.com/oauth2/token"
+      />
+    );
+
+    expect(screen.getByText('OAuth2 token endpoint:')).toBeTruthy();
+    expect(screen.getByText('https://auth.example.com/oauth2/token')).toBeTruthy();
+  });
 });

--- a/apps/self-service/src/components/one-time-secret-card.tsx
+++ b/apps/self-service/src/components/one-time-secret-card.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useCopyToClipboard } from '@uidotdev/usehooks';
 import { useTranslation } from '@lightbridge/i18n';
 import { Button, Card, Div, Icon as Feather, Stack, Text } from '@lightbridge/ui';
@@ -7,13 +7,48 @@ import { useThemeColors } from '../hooks/use-theme-colors';
 type OneTimeSecretCardProps = {
   secret: string;
   onCopy: (value: string) => void;
+  /**
+   * OAuth2 token endpoint the backend returns alongside the secret (see
+   * `ApiKeySecret.oauth2Url` in `packages/authz-rpc/schema/authz.cstack`), so an
+   * external API-key consumer can find `/oauth2/token` at the moment they have
+   * their new key in hand. Optional and additive — omit it (or pass an empty/
+   * malformed value) and the card renders exactly as it did before this field
+   * existed; only a non-empty, well-formed http(s) URL is ever shown.
+   */
+  oauth2Url?: string | null;
 };
 
-export function OneTimeSecretCard({ secret, onCopy }: Readonly<OneTimeSecretCardProps>) {
+/**
+ * Returns `url` trimmed when it is a well-formed absolute http(s) URL,
+ * otherwise `null`. Anything else (missing, empty, unparsable, non-http(s)
+ * scheme) degrades to "not shown" rather than risking a broken link.
+ */
+function normalizeOauth2Url(url: string | null | undefined): string | null {
+  const trimmed = url?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return null;
+    }
+    return trimmed;
+  } catch {
+    return null;
+  }
+}
+
+export function OneTimeSecretCard({
+  secret,
+  onCopy,
+  oauth2Url,
+}: Readonly<OneTimeSecretCardProps>) {
   const { t } = useTranslation();
   const colors = useThemeColors();
   const [, copyToClipboard] = useCopyToClipboard();
   const [copied, setCopied] = useState(false);
+  const resolvedOauth2Url = useMemo(() => normalizeOauth2Url(oauth2Url), [oauth2Url]);
 
   // Flip the button back from "Copied" to "Copy" after a moment, with automatic
   // cleanup — replaces the previous useRef + setTimeout bookkeeping.
@@ -47,6 +82,20 @@ export function OneTimeSecretCard({ secret, onCopy }: Readonly<OneTimeSecretCard
             {secret}
           </Text>
         </Div>
+        {resolvedOauth2Url ? (
+          <Stack gap="xs">
+            <Text intent="caption">{t('apiKeys.oauth2UrlLabel')}</Text>
+            <Div
+              tone="muted"
+              pad="md"
+              rounded="xl"
+              style={{ borderWidth: 1, borderColor: colors.border }}>
+              <Text intent="body" selectable>
+                {resolvedOauth2Url}
+              </Text>
+            </Div>
+          </Stack>
+        ) : null}
         <Button variant="neutral" onPress={handleCopy} width="full">
           <Stack direction="row" align="center" gap="xs">
             <Feather name={copied ? 'check' : 'copy'} size={18} color={colors.primary} />

--- a/apps/self-service/src/screens/api-key-create-screen.tsx
+++ b/apps/self-service/src/screens/api-key-create-screen.tsx
@@ -13,6 +13,7 @@ export function ApiKeyCreateScreen() {
   const router = useRouter();
   const params = useLocalSearchParams<{ projectId?: string }>();
   const [generatedSecret, setGeneratedSecret] = useState<string | null>(null);
+  const [generatedOauth2Url, setGeneratedOauth2Url] = useState<string | null>(null);
   const { mutate: ensureAccount, isPending: isAccountEnsuring } = useEnsureDefaultAccount();
   const { mutate: ensureProject, isPending: isProjectEnsuring } = useEnsureDefaultProject();
   const { mutate: createKey, isPending: isKeyCreating } = useCreateApiKey();
@@ -50,6 +51,7 @@ export function ApiKeyCreateScreen() {
           onSuccess: (data) => {
             if (data?.secret) {
               setGeneratedSecret(data.secret);
+              setGeneratedOauth2Url(data.oauth2Url ?? null);
             }
           },
         }
@@ -69,6 +71,7 @@ export function ApiKeyCreateScreen() {
       isCreating={isPending}
       canChoosePlan={canChoosePlan}
       generatedSecret={generatedSecret}
+      generatedOauth2Url={generatedOauth2Url}
     />
   );
 }

--- a/apps/self-service/src/screens/rotate-api-key-sheet.tsx
+++ b/apps/self-service/src/screens/rotate-api-key-sheet.tsx
@@ -27,6 +27,7 @@ export function RotateApiKeySheet({
   const { data: currentProject } = useCurrentProject();
   const effectiveProjectId = projectId ?? currentProject?.id;
   const [generatedSecret, setGeneratedSecret] = useState<string | null>(null);
+  const [generatedOauth2Url, setGeneratedOauth2Url] = useState<string | null>(null);
   const rotateKey = useRotateApiKey();
 
   const handleConfirm = async () => {
@@ -40,6 +41,7 @@ export function RotateApiKeySheet({
       const result = await rotateKey.mutateAsync({ id, projectId: effectiveProjectId });
       if (result?.secret) {
         setGeneratedSecret(result.secret);
+        setGeneratedOauth2Url(result.oauth2Url ?? null);
       }
     } catch (error) {
       console.error('Failed to rotate API key:', error);
@@ -54,6 +56,7 @@ export function RotateApiKeySheet({
       onCopy={copyToClipboard}
       isRotating={rotateKey.isPending}
       generatedSecret={generatedSecret}
+      generatedOauth2Url={generatedOauth2Url}
     />
   );
 }

--- a/apps/self-service/src/views/api-key-create-view.tsx
+++ b/apps/self-service/src/views/api-key-create-view.tsx
@@ -31,6 +31,8 @@ type ApiKeyCreateViewProps = {
   /** When true, the user may pick a billing plan; otherwise keys are pinned to `free`. */
   canChoosePlan?: boolean;
   generatedSecret?: string | null;
+  /** `ApiKeySecret.oauth2Url` from the create response, if the backend returned one. */
+  generatedOauth2Url?: string | null;
 };
 
 export function ApiKeyCreateView({
@@ -40,6 +42,7 @@ export function ApiKeyCreateView({
   isCreating = false,
   canChoosePlan = false,
   generatedSecret = null,
+  generatedOauth2Url = null,
 }: Readonly<ApiKeyCreateViewProps>) {
   const { t } = useTranslation();
   const colors = useThemeColors();
@@ -101,7 +104,11 @@ export function ApiKeyCreateView({
                   </Stack>
                 </Callout>
 
-                <OneTimeSecretCard secret={generatedSecret} onCopy={onCopy} />
+                <OneTimeSecretCard
+                  secret={generatedSecret}
+                  onCopy={onCopy}
+                  oauth2Url={generatedOauth2Url}
+                />
 
                 <Button variant="ghost" onPress={onBack} width="full">
                   {t('apiKeys.backToKeys')}

--- a/apps/self-service/src/views/rotate-api-key-view.tsx
+++ b/apps/self-service/src/views/rotate-api-key-view.tsx
@@ -21,6 +21,8 @@ type RotateApiKeyViewProps = {
   onCopy: (value: string) => void;
   isRotating?: boolean;
   generatedSecret?: string | null;
+  /** `ApiKeySecret.oauth2Url` from the rotate response, if the backend returned one. */
+  generatedOauth2Url?: string | null;
 };
 
 export function RotateApiKeyView({
@@ -30,6 +32,7 @@ export function RotateApiKeyView({
   onCopy,
   isRotating = false,
   generatedSecret = null,
+  generatedOauth2Url = null,
 }: Readonly<RotateApiKeyViewProps>) {
   const { t } = useTranslation();
   const colors = useThemeColors();
@@ -88,7 +91,11 @@ export function RotateApiKeyView({
                   </Stack>
                 </Div>
 
-                <OneTimeSecretCard secret={generatedSecret} onCopy={onCopy} />
+                <OneTimeSecretCard
+                  secret={generatedSecret}
+                  onCopy={onCopy}
+                  oauth2Url={generatedOauth2Url}
+                />
 
                 <Button variant="ghost" onPress={onBack} width="full">
                   {t('apiKeys.backToKeys')}

--- a/packages/i18n/src/i18n-config.ts
+++ b/packages/i18n/src/i18n-config.ts
@@ -88,6 +88,7 @@ const resources = {
         createdOn: 'Created on {{date}}',
         createdSuccessfully: 'Key Created Successfully',
         yourNewKey: 'Your new API key:',
+        oauth2UrlLabel: 'OAuth2 token endpoint:',
         backToKeys: 'Back to API Keys',
         securityNote:
           'Keep your API keys secure. Never share them in publicly accessible areas such as GitHub or client-side code.',


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `OneTimeSecretCard` accepts an optional `oauth2Url`, rendering it as a labeled, selectable block below the secret when the value is a valid absolute `http(s)` URL.
- Both call sites (`api-key-create-view.tsx`, `rotate-api-key-view.tsx`) pass it through, and the two screens holding the create/rotate response capture the field.
- One new i18n key inside the existing `apiKeys:` namespace.

It solves:

- https://github.com/ADORSYS-GIS/converse-frontends/issues/145

---

## 2. Intent

The intent of this PR is:

> `ApiKeySecret.oauth2Url` is generated by the backend and typed end-to-end, but nothing rendered it — dead data. `lightbridge-authz` v3.0.0 made the endpoint it points at meaningfully harder to use correctly (a registered `client_id` is now mandatory; confidential clients must use `private_key_jwt`), so showing it at the one moment a consumer holds their new key is worth the small cost. This is discoverability only.

---

## 3. Scope

### In Scope

- The optional prop, its rendering, both call sites, the two screens that hold the response, and tests.

### Out of Scope

- Any backend change — the field is already returned.
- A new integration-docs page for `/oauth2/token`. Checked `docs/knowledge/auth-and-identity.md` and `api-reference.md`: both are internal-only with nothing suitable to link out to, so the URL renders as plain selectable text rather than a hyperlink.
- The confidential-client `private_key_jwt` exchange flow — explicitly out of scope per the ticket.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
pnpm -r --if-present run test
pnpm lint
pnpm build
npx tsc --noEmit   # in apps/self-service
```

Results:

```text
tests:      authz-rpc 14/14, hooks 52/52, self-service 29 suites / 145 tests
            one-time-secret-card.test.tsx covers 5 cases: existing copy behaviour,
            no-prop baseline, empty string, malformed URL, valid URL rendered
tsc:        clean
pnpm build: turbo run build:web -> exported cleanly
lint:       6 errors / 131 warnings identical before and after (verified via git stash);
            all pre-existing in gitignored packages/authz-rpc/generated/** and
            packages/ui/**/*.stories.tsx. Zero new issues in touched files.
```

Field presence was confirmed against the generated client (`packages/authz-rpc/generated/src/models.ts:295` — `oauth2Url?: string | null`) rather than assumed from the schema. `pnpm build` was re-run independently on this branch by the orchestrator.

---

## 5. Screenshots / Evidence

**No screenshots** — this renders on the post-creation/rotation secret screen, which is Keycloak-gated and needs a running auth stack plus a real key-creation round trip. Covered by the five component tests above instead. Stated rather than left blank.

* Source of truth: https://github.com/ADORSYS-GIS/converse-frontends/issues/145
* Endpoint change that raised the value of surfacing this: https://github.com/ADORSYS-GIS/lightbridge-authz/pull/288

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* A malformed or absent URL could render an empty section or a broken link on a screen the user sees exactly once and cannot return to.
* Regression on the existing no-`oauth2Url` path, which is every flow that predates this change.

Mitigation:

* `normalizeOauth2Url()` trims, parses via `new URL(...)`, and requires an `http:`/`https:` scheme; anything else returns `null` and the block is not rendered at all. There is no clickable navigation, so a bad value cannot produce a broken link.
* The no-URL path is asserted against the existing baseline by test, and the prop is optional so both call sites keep their previous behaviour when the backend returns nothing.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [x] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Implemented by Claude Code (Sonnet subagent under an Opus 5 orchestrator) on behalf of @stephane-segning. The field's existence was verified against the generated client before wiring, not inferred from the ticket.

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

**Human attestation pending @stephane-segning's review** — an agent must not tick the accountable human's boxes on their behalf.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [ ] Product intent
* [x] Edge cases

Specifically: whether a plain selectable URL is the right treatment, or whether this warrants a copy button like the secret itself has — the audience is an external integrator who will paste this into a config file.

Note this PR also touches `apps/self-service/src/screens/api-key-create-screen.tsx` and `rotate-api-key-sheet.tsx`, beyond the two views the ticket names. The views are prop-driven and do not own the mutation, so the response field had to be captured where the state lives. Verified as not overlapping any concurrent work.
