### PR TITLE
refactor(self-service): compose api-keys list and home views from design-system primitives

### DIFF
--- a/apps/self-service/src/views/api-keys-list-view.tsx
+++ b/apps/self-service/src/views/api-keys-list-view.tsx
@@ -6,6 +6,7 @@ import {
   Button,
   Callout,
   Card,
+  DataCard,
   designTokens,
   Div,
   Divider,
@@ -259,96 +260,96 @@ export function ApiKeysListView({
                 const isActive = item.status === 'active';
 
                 return (
-                  <Card key={item.id} size="md">
-                    <Stack gap="md">
-                      <ListRow
-                        title={
-                          <Stack direction="row" align="center" gap="sm">
-                            <Text
-                              intent="bodyStrong"
-                              numberOfLines={1}
-                              ellipsizeMode="tail"
-                              style={{ flexShrink: 1 }}>
-                              {item.name}
-                            </Text>
-                            <Badge
-                              tone={isActive ? 'success' : 'error'}
-                              accessibilityLabel={t(`apiKeys.status.${item.status}`)}>
-                              {t(`apiKeys.status.${item.status}`)}
-                            </Badge>
+                  <DataCard
+                    key={item.id}
+                    title={
+                      <Stack direction="row" align="center" gap="sm">
+                        <Text
+                          intent="bodyStrong"
+                          numberOfLines={1}
+                          ellipsizeMode="tail"
+                          style={{ flexShrink: 1 }}>
+                          {item.name}
+                        </Text>
+                        <Badge
+                          tone={isActive ? 'success' : 'error'}
+                          accessibilityLabel={t(`apiKeys.status.${item.status}`)}>
+                          {t(`apiKeys.status.${item.status}`)}
+                        </Badge>
+                      </Stack>
+                    }
+                    subtitle={
+                      <Text intent="caption">
+                        {t('apiKeys.keyPrefixLabel')}{' '}
+                        <Text intent="caption" mono>
+                          {item.keyPrefix}
+                        </Text>
+                      </Text>
+                    }
+                    trailing={
+                      canDelete ? (
+                        <Button
+                          variant="ghost"
+                          onPress={() => onDelete(item.id, item.name)}
+                          accessibilityLabel={t('apiKeys.deleteNamed', { name: item.name })}
+                          style={{ paddingHorizontal: 8, paddingVertical: 4 }}>
+                          <Feather name="trash-2" size={18} color={colors.error} />
+                        </Button>
+                      ) : undefined
+                    }
+                    footer={
+                      <Stack gap="md">
+                        {/* Two discrete actions — a segmented control implies a
+                            persistent selection, which these aren't. Rotate is
+                            neutral; Revoke is destructive (error-tinted label). */}
+                        {canRotate || canRevoke ? (
+                          <Stack direction="row" gap="sm" width="full">
+                            {canRotate ? (
+                              <Button
+                                variant="neutral"
+                                size="sm"
+                                disabled={!isActive}
+                                onPress={() => onRotate(item.id, item.name)}
+                                accessibilityLabel={t('apiKeys.rotateNamed', { name: item.name })}
+                                style={{ flex: 1 }}>
+                                {t('apiKeys.rotate')}
+                              </Button>
+                            ) : null}
+                            {canRevoke ? (
+                              <Button
+                                variant="neutral"
+                                size="sm"
+                                disabled={!isActive}
+                                onPress={() => onRevoke(item.id, item.name)}
+                                accessibilityLabel={t('apiKeys.revokeNamed', { name: item.name })}
+                                textProps={{ style: { color: colors.error } }}
+                                style={{ flex: 1 }}>
+                                {t('apiKeys.revoke')}
+                              </Button>
+                            ) : null}
                           </Stack>
-                        }
-                        subtitle={
-                          <Text intent="caption">
-                            {t('apiKeys.keyPrefixLabel')}{' '}
-                            <Text intent="caption" mono>
-                              {item.keyPrefix}
-                            </Text>
-                          </Text>
-                        }
-                        trailing={
-                          canDelete ? (
-                            <Button
-                              variant="ghost"
-                              onPress={() => onDelete(item.id, item.name)}
-                              accessibilityLabel={t('apiKeys.deleteNamed', { name: item.name })}
-                              style={{ paddingHorizontal: 8, paddingVertical: 4 }}>
-                              <Feather name="trash-2" size={18} color={colors.error} />
-                            </Button>
-                          ) : undefined
-                        }
-                      />
+                        ) : null}
 
-                      {/* Two discrete actions — a segmented control implies a
-                          persistent selection, which these aren't. Rotate is
-                          neutral; Revoke is destructive (error-tinted label). */}
-                      {canRotate || canRevoke ? (
-                        <Stack direction="row" gap="sm" width="full">
-                          {canRotate ? (
-                            <Button
-                              variant="neutral"
-                              size="sm"
-                              disabled={!isActive}
-                              onPress={() => onRotate(item.id, item.name)}
-                              accessibilityLabel={t('apiKeys.rotateNamed', { name: item.name })}
-                              style={{ flex: 1 }}>
-                              {t('apiKeys.rotate')}
-                            </Button>
-                          ) : null}
-                          {canRevoke ? (
-                            <Button
-                              variant="neutral"
-                              size="sm"
-                              disabled={!isActive}
-                              onPress={() => onRevoke(item.id, item.name)}
-                              accessibilityLabel={t('apiKeys.revokeNamed', { name: item.name })}
-                              textProps={{ style: { color: colors.error } }}
-                              style={{ flex: 1 }}>
-                              {t('apiKeys.revoke')}
-                            </Button>
+                        <Stack direction="row" gap="md" wrap="wrap" width="full">
+                          <Text intent="caption">{createdLabel}</Text>
+                          <Text intent="caption">
+                            {item.lastUsedAt
+                              ? t('apiKeys.lastUsed', {
+                                  date: formatNullableDate(item.lastUsedAt, dateLocale),
+                                })
+                              : t('apiKeys.neverUsed')}
+                          </Text>
+                          {item.expiresAt ? (
+                            <Text intent="caption">
+                              {t('apiKeys.expiresOn', {
+                                date: formatNullableDate(item.expiresAt, dateLocale),
+                              })}
+                            </Text>
                           ) : null}
                         </Stack>
-                      ) : null}
-
-                      <Stack direction="row" gap="md" wrap="wrap" width="full">
-                        <Text intent="caption">{createdLabel}</Text>
-                        <Text intent="caption">
-                          {item.lastUsedAt
-                            ? t('apiKeys.lastUsed', {
-                                date: formatNullableDate(item.lastUsedAt, dateLocale),
-                              })
-                            : t('apiKeys.neverUsed')}
-                        </Text>
-                        {item.expiresAt ? (
-                          <Text intent="caption">
-                            {t('apiKeys.expiresOn', {
-                              date: formatNullableDate(item.expiresAt, dateLocale),
-                            })}
-                          </Text>
-                        ) : null}
                       </Stack>
-                    </Stack>
-                  </Card>
+                    }
+                  />
                 );
               })}
           </Stack>

--- a/apps/self-service/src/views/home-view.tsx
+++ b/apps/self-service/src/views/home-view.tsx
@@ -138,32 +138,34 @@ export function HomeView({
           <Stack gap="md">
             <Text intent="eyebrow">{t('home.gettingStarted.title')}</Text>
             <Stack gap="sm">
-              <Stack direction="row" align="center" gap="sm">
-                <Feather name="key" size={designTokens.icon.action} color={colors.primary} />
-                <Text intent="body">{t('home.gettingStarted.createKey')}</Text>
-              </Stack>
-              <Stack direction="row" align="center" gap="sm">
-                <Feather name="settings" size={designTokens.icon.action} color={colors.primary} />
-                <Text intent="body">{t('home.gettingStarted.manageProject')}</Text>
-              </Stack>
-              <Stack direction="row" align="center" gap="sm">
-                <Feather name="user" size={designTokens.icon.action} color={colors.primary} />
-                <Text intent="body">{t('home.gettingStarted.reviewSettings')}</Text>
-              </Stack>
+              <ListRow
+                leading={<Feather name="key" size={designTokens.icon.action} color={colors.primary} />}
+                title={<Text intent="body">{t('home.gettingStarted.createKey')}</Text>}
+              />
+              <ListRow
+                leading={
+                  <Feather name="settings" size={designTokens.icon.action} color={colors.primary} />
+                }
+                title={<Text intent="body">{t('home.gettingStarted.manageProject')}</Text>}
+              />
+              <ListRow
+                leading={<Feather name="user" size={designTokens.icon.action} color={colors.primary} />}
+                title={<Text intent="body">{t('home.gettingStarted.reviewSettings')}</Text>}
+              />
             </Stack>
           </Stack>
         </Card>
 
         <Card size="sm" accessibilityRole="button" onPress={onSupport}>
-          <Stack direction="row" align="center" gap="sm">
-            <Div tone="successSoft" rounded="xl" size="iconMd" align="center" justify="center">
-              <Feather name="help-circle" size={designTokens.icon.action} color={colors.success} />
-            </Div>
-            <Text intent="bodyStrong" style={{ flex: 1 }}>
-              {t('home.quickActions.support')}
-            </Text>
-            <Feather name="chevron-right" size={18} color={colors.subtle} />
-          </Stack>
+          <ListRow
+            leading={
+              <Div tone="successSoft" rounded="xl" size="iconMd" align="center" justify="center">
+                <Feather name="help-circle" size={designTokens.icon.action} color={colors.success} />
+              </Div>
+            }
+            title={t('home.quickActions.support')}
+            trailing={<Feather name="chevron-right" size={18} color={colors.subtle} />}
+          />
         </Card>
       </Stack>
     </Scroll>


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `api-keys-list-view.tsx` — the per-item `Card size="md"` + `Stack` + `ListRow` composition becomes `DataCard` (added in #157).
- `home-view.tsx` — the hand-built icon+text rows in "Getting started" (3) and the Support card row become `ListRow`.
- Two files, +108/−105. No other files, no i18n, no `packages/ui` changes.

It solves:

- A slice of https://github.com/ADORSYS-GIS/converse-frontends/issues/79 — the "refactor views to compose them" half.

---

## 2. Intent

The intent of this PR is:

> Compose these views from the design-system primitives instead of hand-rolling layout.
>
> **The epic's headline metric was stale and is corrected here.** #79 claims `api-keys-list-view.tsx` inlines "~9" patterns, targeting 0. That number predates commit `ad7816d` (#81, "add 6 foundational components and compose api-keys view"), which already did most of the work months ago — the view already used `PageHeader`, `Badge`, `Divider`, `EmptyState`, `Callout` and `ListRow`, and `Pagination` correctly lives in `api-keys-screen.tsx` (#155), not the view. **Actual remaining hand-rolled patterns: 3 before, 2 after.** The two that remain have no matching primitive and are listed below as follow-up work, not as failures.

---

## 3. Scope

### In Scope

- The two view files. Composition only — no behaviour change, no prop-contract change, so both screens keep working untouched.

### Out of Scope — deliberately left inline, each for a stated reason

These are the epic's next tickets, not oversights:

1. **Filter card** (`api-keys-list-view`): one `Card size="sm"` holding two titled subsections split by a `Divider`. `SectionCard` doesn't fit — its own card chrome would either double-wrap into two cards or change the `size="sm"` padding. No primitive supports "one card, multiple titled subsections".
2. **Loading skeleton card** (`api-keys-list-view`): hand-built `Skeleton` layout mirroring the `DataCard` shape. No skeleton variant of `DataCard` exists.
3. **Active-project summary card** (`home-view`): close to `DataCard`, but `DataCard`'s header is hardcoded `align="start"` where this uses `align="center"`, and the plan "pill" (`Div tone="muted" rounded="full" pad="sm"`, 8px) matches neither `Badge` (`px-2 py-0.5`) nor `Chip` (`px-2 py-1` + border). Forcing either is a visible appearance change.
4. **Logout button** (`home-view`): a circular icon action, not an identity affordance — correctly not an `Avatar`.

No `StatCard` was used: nothing on the home view is a metric, and the brief was not to force a KPI tile onto content that isn't one.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
pnpm -r --if-present run test
pnpm lint
pnpm build
npx tsc --noEmit   # in apps/self-service
```

Results:

```text
tests:      hooks 52/52, self-service 29 suites / 141 tests — ZERO test files modified.
            api-keys-list-view.lifecycle.test.tsx and .formatDate.test.ts pass unchanged
            (they query by accessibilityLabel, preserved exactly).
tsc:        clean
pnpm build: turbo run build:web -> 1/1 successful
lint:       6 pre-existing errors / 131 warnings, none in the two touched files
```

`pnpm build` was re-run independently on this branch by the orchestrator.

---

## 5. Screenshots / Evidence

**No before/after screenshots, and for this PR that is a genuine evidence gap worth stating plainly** — the entire claim is "it looks the same," and these screens are Keycloak-gated so a live capture needs a running auth stack.

What was done instead: visual parity was established by reading each primitive's `cva.tsx` and comparing class-for-class against the markup it replaced. Specifically, `DataCard`'s default tone resolves to `bg-surface p-6 shadow-sm rounded-2xl`, identical to `Card size="md"`; `ListRow`'s default `pad="none" tone="transparent"` renders identically to the `Stack` rows it replaces. That is a sound argument, but it is not the same as having looked at it.

A reviewer wanting visual confirmation should use the temporary ungated `/preview` route pattern — it renders the pure `*View` components with mock props and needs no auth stack.

* Epic: https://github.com/ADORSYS-GIS/converse-frontends/issues/79
* Primitives being adopted: https://github.com/ADORSYS-GIS/converse-frontends/pull/157

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* A primitive swap that is class-equivalent in theory but shifts spacing or alignment in practice.
* Losing an accessibility label and silently breaking a test's query or a screen reader.

Mitigation:

* `accessibilityLabel` values were preserved exactly, which is why the existing tests pass without a single edited assertion — that is the main guard here.
* Where a primitive would have changed position or padding, it was **not** used and the reason recorded (see Out of Scope). In particular `DataCard`'s `status` slot was avoided because it renders at the row's far end, moving the badge away from the name.
* No prop contracts changed, so the screens rendering these views are untouched.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [ ] Generating code
* [x] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Refactored by Claude Code (Sonnet subagent under an Opus 5 orchestrator) on behalf of @stephane-segning. The agent was asked to re-measure the epic's metric rather than repeat it, and to treat "no primitive fits" as a valid answer — both of which produced the corrections above. The absence of visual evidence is stated by the agent, not discovered in review.

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

**Human attestation pending @stephane-segning's review** — an agent must not tick the accountable human's boxes on their behalf.

---

## 8. Reviewer Focus

Please focus your review on:

* [ ] Correctness
* [x] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [x] Product intent
* [ ] Edge cases

Specifically:

1. **The four patterns left inline.** Each is a candidate follow-up ticket — particularly the "one card, multiple titled subsections" gap and a skeleton variant of `DataCard`, both of which would recur across other views.
2. **Whether the epic's success metric should be rewritten.** "~9 → 0" was never accurate for this view's current state; "3 → 2, with 2 blocked on missing primitives" is the real picture, and leaving the old number in place will keep misleading whoever reads the epic next.
