### PR TITLE
fix(self-service): make every project reachable — shared searchable picker replaces the 10-item cap

### DIFF
--- a/apps/self-service/src/__tests__/api-keys-screen.test.tsx
+++ b/apps/self-service/src/__tests__/api-keys-screen.test.tsx
@@ -49,8 +49,12 @@ jest.mock('@lightbridge/hooks', () => {
   return {
     __esModule: true,
     usePagination: actual.usePagination,
-    useAccounts: () => ({ data: mockAccounts, isLoading: false }),
-    useProjects: (accountId?: string) => ({
+    // The screen now fetches the *complete* account/project list (every page, not the first
+    // `limit: 10`) — see useAllAccounts/useAllProjects in packages/hooks/src/{accounts,projects}.ts.
+    // This test's fixtures are small so "complete" and "first page" look identical here; what
+    // matters for this suite is that the screen calls the hook the picker actually feeds from.
+    useAllAccounts: () => ({ data: mockAccounts, isLoading: false }),
+    useAllProjects: (accountId?: string) => ({
       data: accountId ? (mockProjectsByAccount[accountId] ?? []) : [],
       isLoading: false,
     }),

--- a/apps/self-service/src/__tests__/picker.test.tsx
+++ b/apps/self-service/src/__tests__/picker.test.tsx
@@ -201,4 +201,35 @@ describe('PickerList', () => {
 
     expect(screen.getByText('Project 15')).toBeTruthy();
   });
+
+  // Guards the residual gap from the fetch-all loop's own safety ceiling (MAX_*_PAGES in
+  // packages/hooks/src/{accounts,projects}.ts): if that's ever hit, `options` is a real but
+  // incomplete slice of the server's total. This is the caller's (app-layer) signal that
+  // happened — PickerList itself does no counting, it just renders whatever string it's handed.
+  it('shows the truncation notice when the caller says the loaded set is incomplete', async () => {
+    await render(
+      <PickerList
+        options={manyOptions}
+        onSelect={() => undefined}
+        searchPlaceholder="Search projects"
+        noResultsLabel="No matches"
+        truncationNotice="Not everything could be loaded."
+      />
+    );
+
+    expect(screen.getByText('Not everything could be loaded.')).toBeTruthy();
+  });
+
+  it('shows no truncation notice when the caller omits it (the loaded set is complete)', async () => {
+    await render(
+      <PickerList
+        options={manyOptions}
+        onSelect={() => undefined}
+        searchPlaceholder="Search projects"
+        noResultsLabel="No matches"
+      />
+    );
+
+    expect(screen.queryByText('Not everything could be loaded.')).toBeNull();
+  });
 });

--- a/apps/self-service/src/__tests__/picker.test.tsx
+++ b/apps/self-service/src/__tests__/picker.test.tsx
@@ -1,0 +1,204 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { Picker, PickerList, type PickerOption } from '@lightbridge/ui';
+
+// The regression case this whole feature exists for: an account/project list with more items
+// than a single API page (the old call sites capped requests at `limit: 10`). 15 options here
+// stands in for "more than one page" — what matters is that every one of them, including the
+// last, is reachable through the component, not that the number matches the real backend default.
+const manyOptions: PickerOption[] = Array.from({ length: 15 }, (_, index) => ({
+  id: `proj-${index + 1}`,
+  label: `Project ${index + 1}`,
+}));
+
+const fewOptions: PickerOption[] = [
+  { id: 'acc-1', label: 'acc-1' },
+  { id: 'acc-2', label: 'acc-2' },
+];
+
+describe('Picker', () => {
+  it('renders an inline control (no trigger row) below the sheet threshold', async () => {
+    await render(
+      <Picker
+        options={fewOptions}
+        selectedId="acc-1"
+        onSelect={() => undefined}
+        onOpenPicker={() => undefined}
+        emptyLabel="No accounts"
+        placeholderLabel="Select an account"
+      />
+    );
+
+    // Both options are on screen at once — an inline SegmentedControl, not a tap-to-open row.
+    expect(screen.getByText('acc-1')).toBeTruthy();
+    expect(screen.getByText('acc-2')).toBeTruthy();
+  });
+
+  it('marks the selected option for accessibility when inline', async () => {
+    await render(
+      <Picker
+        options={fewOptions}
+        selectedId="acc-2"
+        onSelect={() => undefined}
+        onOpenPicker={() => undefined}
+        emptyLabel="No accounts"
+        placeholderLabel="Select an account"
+      />
+    );
+
+    expect(screen.getByLabelText('acc-2').props.accessibilityState.selected).toBeTruthy();
+    expect(screen.getByLabelText('acc-1').props.accessibilityState.selected).toBeFalsy();
+  });
+
+  it('calls onSelect directly when choosing inline (no sheet involved)', async () => {
+    const onSelect = jest.fn();
+    await render(
+      <Picker
+        options={fewOptions}
+        selectedId="acc-1"
+        onSelect={onSelect}
+        onOpenPicker={() => undefined}
+        emptyLabel="No accounts"
+        placeholderLabel="Select an account"
+      />
+    );
+
+    await fireEvent.press(screen.getByText('acc-2'));
+
+    expect(onSelect).toHaveBeenCalledWith('acc-2');
+  });
+
+  it('renders a single tap-to-open trigger row — not every option — at/above the sheet threshold', async () => {
+    await render(
+      <Picker
+        options={manyOptions}
+        selectedId="proj-1"
+        onSelect={() => undefined}
+        onOpenPicker={() => undefined}
+        emptyLabel="No projects"
+        placeholderLabel="Select a project"
+      />
+    );
+
+    // Only the selected item's label shows on the trigger — the other 14 are not rendered here at
+    // all (that would defeat the point: an unbounded list dumped inline is the bug being fixed).
+    expect(screen.getByText('Project 1')).toBeTruthy();
+    expect(screen.queryByText('Project 15')).toBeNull();
+  });
+
+  it('hands control back to the caller via onOpenPicker instead of opening anything itself', async () => {
+    const onOpenPicker = jest.fn();
+    await render(
+      <Picker
+        options={manyOptions}
+        selectedId="proj-1"
+        onSelect={() => undefined}
+        onOpenPicker={onOpenPicker}
+        emptyLabel="No projects"
+        placeholderLabel="Select a project"
+        triggerAccessibilityLabel="Select project"
+      />
+    );
+
+    await fireEvent.press(screen.getByLabelText('Select project'));
+
+    expect(onOpenPicker).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the empty label when there are no options', async () => {
+    await render(
+      <Picker
+        options={[]}
+        onSelect={() => undefined}
+        onOpenPicker={() => undefined}
+        emptyLabel="No projects yet"
+        placeholderLabel="Select a project"
+      />
+    );
+
+    expect(screen.getByText('No projects yet')).toBeTruthy();
+  });
+});
+
+describe('PickerList', () => {
+  it('renders the complete option set up front — nothing is pre-truncated', async () => {
+    await render(
+      <PickerList
+        options={manyOptions}
+        onSelect={() => undefined}
+        searchPlaceholder="Search projects"
+        noResultsLabel="No matches"
+      />
+    );
+
+    expect(screen.getByText('Project 1')).toBeTruthy();
+    // The 15th item (past any 10-item page) is reachable without typing anything — the caller is
+    // expected to have already loaded the complete set, and this proves the list doesn't silently
+    // re-truncate it.
+    expect(screen.getByText('Project 15')).toBeTruthy();
+  });
+
+  it('search reaches an item beyond the old 10-item page cap — the actual regression this guards', async () => {
+    await render(
+      <PickerList
+        options={manyOptions}
+        onSelect={() => undefined}
+        searchPlaceholder="Search projects"
+        noResultsLabel="No matches"
+      />
+    );
+
+    await fireEvent.changeText(screen.getByPlaceholderText('Search projects'), 'Project 15');
+
+    expect(screen.getByText('Project 15')).toBeTruthy();
+    expect(screen.queryByText('Project 1')).toBeNull();
+  });
+
+  it('selecting a filtered result calls onSelect with its id', async () => {
+    const onSelect = jest.fn();
+    await render(
+      <PickerList
+        options={manyOptions}
+        onSelect={onSelect}
+        searchPlaceholder="Search projects"
+        noResultsLabel="No matches"
+      />
+    );
+
+    await fireEvent.changeText(screen.getByPlaceholderText('Search projects'), 'Project 15');
+    await fireEvent.press(screen.getByText('Project 15'));
+
+    expect(onSelect).toHaveBeenCalledWith('proj-15');
+  });
+
+  it('shows the no-results label when the search matches nothing', async () => {
+    await render(
+      <PickerList
+        options={manyOptions}
+        onSelect={() => undefined}
+        searchPlaceholder="Search projects"
+        noResultsLabel="No matches"
+      />
+    );
+
+    await fireEvent.changeText(screen.getByPlaceholderText('Search projects'), 'nonexistent-xyz');
+
+    expect(screen.getByText('No matches')).toBeTruthy();
+    expect(screen.queryByText('Project 1')).toBeNull();
+  });
+
+  it('search is case-insensitive and matches mid-label', async () => {
+    await render(
+      <PickerList
+        options={manyOptions}
+        onSelect={() => undefined}
+        searchPlaceholder="Search projects"
+        noResultsLabel="No matches"
+      />
+    );
+
+    await fireEvent.changeText(screen.getByPlaceholderText('Search projects'), 'project 15');
+
+    expect(screen.getByText('Project 15')).toBeTruthy();
+  });
+});

--- a/apps/self-service/src/components/__tests__/entity-picker-field.test.ts
+++ b/apps/self-service/src/components/__tests__/entity-picker-field.test.ts
@@ -1,0 +1,17 @@
+import { pickerTruncationNotice } from '../entity-picker-field';
+
+describe('pickerTruncationNotice', () => {
+  it('returns the notice when the loaded count is less than the server total', () => {
+    expect(pickerTruncationNotice(1000, 1247, 'Not everything could be loaded.')).toBe(
+      'Not everything could be loaded.'
+    );
+  });
+
+  it('returns undefined when the loaded count matches the server total (the normal case)', () => {
+    expect(pickerTruncationNotice(12, 12, 'Not everything could be loaded.')).toBeUndefined();
+  });
+
+  it('returns undefined for an empty, complete list (0 loaded, 0 total)', () => {
+    expect(pickerTruncationNotice(0, 0, 'Not everything could be loaded.')).toBeUndefined();
+  });
+});

--- a/apps/self-service/src/components/entity-picker-field.tsx
+++ b/apps/self-service/src/components/entity-picker-field.tsx
@@ -37,6 +37,23 @@ export function toProjectPickerOptions(
   }));
 }
 
+/**
+ * Decides whether the sheet's truncation notice should be shown, given what actually loaded vs
+ * what the server says exists in total. `useAllAccounts`/`useAllProjects` page until
+ * `pageInfo.hasNextPage` is false, but bail out at their own `MAX_*_PAGES` safety ceiling — this
+ * is how the picker finds out that happened instead of silently presenting a partial list as
+ * complete. Returns the caller's own already-translated `notice` verbatim, or `undefined` when
+ * `loadedCount` already accounts for everything (the normal case — no notice, no count is shown
+ * here either, that's `resultCountLabel`'s job).
+ */
+export function pickerTruncationNotice(
+  loadedCount: number,
+  totalCount: number,
+  notice: string
+): string | undefined {
+  return loadedCount < totalCount ? notice : undefined;
+}
+
 export type EntityPickerFieldProps = {
   /** Field heading, e.g. "Account" / "Project" (rendered above the control). */
   label: string;

--- a/apps/self-service/src/components/entity-picker-field.tsx
+++ b/apps/self-service/src/components/entity-picker-field.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { Icon as Feather, Picker, Stack, Text } from '@lightbridge/ui';
+import type { PickerOption } from '@lightbridge/ui';
+import type { Account, Project } from '@lightbridge/hooks';
+import type { useThemeColors } from '../hooks/use-theme-colors';
+
+/** Maps the account list to `PickerOption`s. An account has no display name beyond its id — same
+ *  label the old per-screen `Button` loops rendered. */
+export function toAccountPickerOptions(accounts: Account[]): PickerOption[] {
+  return accounts.map((account) => ({ id: account.id, label: account.id }));
+}
+
+/**
+ * Maps the project list to `PickerOption`s, preserving the star-for-default-project marker the
+ * old per-screen `Button` loop rendered (project-settings only — the API-keys screen's own
+ * loop never had this marker, so it simply won't show one there either, matching prior behavior).
+ * `colors` is a plain value, not a hook call, so this stays callable from both a view (which
+ * already holds `useThemeColors()`'s result for its own rendering) and a screen (see
+ * `usePickerSheet` in ../hooks/use-picker-sheet, which needs the identical mapping to build the
+ * sheet's option list).
+ */
+export function toProjectPickerOptions(
+  projects: Project[],
+  selectedProjectId: string | undefined,
+  colors: ReturnType<typeof useThemeColors>
+): PickerOption[] {
+  return projects.map((project) => ({
+    id: project.id,
+    label: project.name,
+    icon: project.isDefault ? (
+      <Feather
+        name="star"
+        size={12}
+        color={project.id === selectedProjectId ? colors.surface : colors.subtle}
+      />
+    ) : undefined,
+  }));
+}
+
+export type EntityPickerFieldProps = {
+  /** Field heading, e.g. "Account" / "Project" (rendered above the control). */
+  label: string;
+  options: PickerOption[];
+  selectedId?: string;
+  onSelect: (id: string) => void;
+  /**
+   * Called instead of selecting inline once `options.length` reaches the sheet threshold. This
+   * component has no Sheet/reanimated dependency on purpose — it is used directly by *view*
+   * modules, which are unit-tested standalone without a SheetProvider/GestureHandlerRootView
+   * ancestor (see `@lightbridge/ui/sheet`'s own doc comment on why Sheet stays out of the main
+   * barrel). The owning *screen* wires this to `usePickerSheet()` — see
+   * ../hooks/use-picker-sheet.tsx — exactly like it already wires `onDeleteProject`/
+   * `onCreateProject` to `useSheet().present(...)` for the create/delete/rotate/revoke flows.
+   */
+  onOpenPicker: () => void;
+  /** Shown in place of the control when `options` is empty. */
+  emptyLabel: string;
+  /** Trigger-row label when nothing is selected yet (sheet mode only). */
+  placeholderLabel: string;
+  triggerAccessibilityLabel?: string;
+  optionAccessibilityLabel?: (option: PickerOption) => string;
+  /** Threshold at/above which selection opens a searchable sheet instead of an inline control. */
+  sheetThreshold?: number;
+  isLoading?: boolean;
+};
+
+/**
+ * Shared account/project selector used on the API-keys, project-settings, and account-settings
+ * screens — replaces what used to be an unbounded, wrapped row of `Button` pills duplicated
+ * (with minor variations) across all three. Thin wrapper around `@lightbridge/ui`'s presentational
+ * `Picker` that adds only the field heading; every string and the `onOpenPicker` callback come
+ * from the caller.
+ */
+export function EntityPickerField({
+  label,
+  options,
+  selectedId,
+  onSelect,
+  onOpenPicker,
+  emptyLabel,
+  placeholderLabel,
+  triggerAccessibilityLabel,
+  optionAccessibilityLabel,
+  sheetThreshold,
+  isLoading = false,
+}: Readonly<EntityPickerFieldProps>) {
+  return (
+    <Stack gap="xs">
+      <Text intent="bodyStrong">{label}</Text>
+      <Picker
+        options={options}
+        selectedId={selectedId}
+        onSelect={onSelect}
+        onOpenPicker={onOpenPicker}
+        sheetThreshold={sheetThreshold}
+        emptyLabel={emptyLabel}
+        placeholderLabel={placeholderLabel}
+        triggerAccessibilityLabel={triggerAccessibilityLabel}
+        optionAccessibilityLabel={optionAccessibilityLabel}
+        isLoading={isLoading}
+      />
+    </Stack>
+  );
+}

--- a/apps/self-service/src/hooks/use-picker-sheet.tsx
+++ b/apps/self-service/src/hooks/use-picker-sheet.tsx
@@ -13,6 +13,13 @@ export type PickerSheetParams = {
   /** Already-formatted, i18n-pluralized count caption (e.g. "12 projects"). */
   resultCountLabel?: string;
   optionAccessibilityLabel?: (option: PickerOption) => string;
+  /**
+   * Already-formatted notice shown when `options` is a known-incomplete slice of a larger set
+   * (the fetch-everything loop in useAllAccounts/useAllProjects hit its page ceiling). The caller
+   * decides this — it already has `totalCount` vs `options.length` — and passes copy verbatim.
+   * Omit when the set is complete.
+   */
+  truncationNotice?: string;
 };
 
 /**
@@ -47,6 +54,7 @@ export function usePickerSheet() {
             title={params.title}
             resultCountLabel={params.resultCountLabel}
             optionAccessibilityLabel={params.optionAccessibilityLabel}
+            truncationNotice={params.truncationNotice}
           />
         ),
         { accessibilityLabel: params.title }

--- a/apps/self-service/src/hooks/use-picker-sheet.tsx
+++ b/apps/self-service/src/hooks/use-picker-sheet.tsx
@@ -1,0 +1,57 @@
+import React, { useCallback } from 'react';
+import { PickerList } from '@lightbridge/ui';
+import type { PickerOption } from '@lightbridge/ui';
+import { useSheet } from '@lightbridge/ui/sheet';
+
+export type PickerSheetParams = {
+  options: PickerOption[];
+  selectedId?: string;
+  onSelect: (id: string) => void;
+  searchPlaceholder: string;
+  noResultsLabel: string;
+  title: string;
+  /** Already-formatted, i18n-pluralized count caption (e.g. "12 projects"). */
+  resultCountLabel?: string;
+  optionAccessibilityLabel?: (option: PickerOption) => string;
+};
+
+/**
+ * Presents `PickerList` (the searchable sheet body `Picker` opens once its trigger row is
+ * pressed) through this app's existing imperative sheet API.
+ *
+ * Screen-only, deliberately: `useSheet` comes from the `@lightbridge/ui/sheet` subpath, which
+ * pulls in `@gorhom/bottom-sheet` → `react-native-reanimated` → worklets — real native modules
+ * that crash under Jest unless a real app runtime initialized them first (see that subpath's own
+ * doc comment: "Sheet is intentionally NOT re-exported from the barrel"). Views are unit-tested by
+ * rendering them standalone, with no `SheetProvider`/`GestureHandlerRootView` ancestor, so this
+ * hook — like every other sheet.present(...) call in this app (create/delete/rotate/revoke) —
+ * stays in the screen. `EntityPickerField` (the view-facing half of this feature) only ever
+ * receives a plain `onOpenPicker: () => void` callback; it has no idea a sheet exists.
+ */
+export function usePickerSheet() {
+  const sheet = useSheet();
+
+  return useCallback(
+    (params: PickerSheetParams) => {
+      sheet.present(
+        ({ dismiss }) => (
+          <PickerList
+            options={params.options}
+            selectedId={params.selectedId}
+            onSelect={(id) => {
+              params.onSelect(id);
+              dismiss();
+            }}
+            searchPlaceholder={params.searchPlaceholder}
+            noResultsLabel={params.noResultsLabel}
+            title={params.title}
+            resultCountLabel={params.resultCountLabel}
+            optionAccessibilityLabel={params.optionAccessibilityLabel}
+          />
+        ),
+        { accessibilityLabel: params.title }
+      );
+    },
+    [sheet]
+  );
+}

--- a/apps/self-service/src/screens/account-settings-screen.tsx
+++ b/apps/self-service/src/screens/account-settings-screen.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'expo-router';
 import { useTranslation } from '@lightbridge/i18n';
 import {
   getApiErrorMessage,
-  useAccounts,
+  useAllAccounts,
   useAuthSession,
   useDisableAccount,
   useEnableAccount,
@@ -13,6 +13,8 @@ import {
 } from '@lightbridge/hooks';
 import type { Account } from '@lightbridge/hooks';
 import { useSheet } from '@lightbridge/ui/sheet';
+import { toAccountPickerOptions } from '../components/entity-picker-field';
+import { usePickerSheet } from '../hooks/use-picker-sheet';
 import { AccountSettingsView } from '../views/settings/account-settings-view';
 import { DeleteAccountSheet } from './delete-account-sheet';
 import { useRuntimeConfig } from '../configs/runtime-config';
@@ -36,15 +38,35 @@ export function AccountSettingsScreen({ embedded = false }: Readonly<{ embedded?
   const { t } = useTranslation();
   const router = useRouter();
   const sheet = useSheet();
+  const openPicker = usePickerSheet();
   const config = useRuntimeConfig();
   const { session } = useAuthSession();
   const { has } = usePermissions();
   const [accountParam, setAccountParam] = useQueryState('accountId');
 
-  const { data: accounts = [], isLoading: isAccountsLoading } = useAccounts();
+  // Full list (every page) — see the identical comment in api-keys-screen.tsx. In practice this
+  // is 0 or 1 rows under ADR-0006 (one account is one person), but routed through the same
+  // fetch-all hook as the project picker for consistency, not because accounts can grow.
+  const { data: accounts = [], isLoading: isAccountsLoading } = useAllAccounts();
   const accountParamInList = accounts.some((account) => account.id === accountParam);
   const accountId = (accountParamInList ? accountParam : undefined) ?? accounts[0]?.id;
   const selectedAccount: Account | undefined = accounts.find((account) => account.id === accountId);
+
+  const accountOptions = toAccountPickerOptions(accounts);
+
+  const handleOpenAccountPicker = () => {
+    openPicker({
+      options: accountOptions,
+      selectedId: accountId,
+      onSelect: setAccountParam,
+      searchPlaceholder: t('picker.searchAccounts'),
+      noResultsLabel: t('picker.noResults'),
+      title: t('picker.selectAccount'),
+      resultCountLabel: t('picker.accountCount', { count: accountOptions.length }),
+      optionAccessibilityLabel: (option) =>
+        t('settings.account.selectAccount', { account: option.label }),
+    });
+  };
 
   const updateAccount = useUpdateAccount();
   const disableAccount = useDisableAccount();
@@ -94,6 +116,7 @@ export function AccountSettingsScreen({ embedded = false }: Readonly<{ embedded?
       selectedAccountId={accountId}
       isLoading={isAccountsLoading}
       onSelectAccount={setAccountParam}
+      onOpenAccountPicker={handleOpenAccountPicker}
       defaultQuota={selectedAccount?.defaultQuota ?? ''}
       onSaveDefaultQuota={handleSaveDefaultQuota}
       isSavingDefaultQuota={updateAccount.isPending}

--- a/apps/self-service/src/screens/account-settings-screen.tsx
+++ b/apps/self-service/src/screens/account-settings-screen.tsx
@@ -13,7 +13,7 @@ import {
 } from '@lightbridge/hooks';
 import type { Account } from '@lightbridge/hooks';
 import { useSheet } from '@lightbridge/ui/sheet';
-import { toAccountPickerOptions } from '../components/entity-picker-field';
+import { pickerTruncationNotice, toAccountPickerOptions } from '../components/entity-picker-field';
 import { usePickerSheet } from '../hooks/use-picker-sheet';
 import { AccountSettingsView } from '../views/settings/account-settings-view';
 import { DeleteAccountSheet } from './delete-account-sheet';
@@ -47,7 +47,11 @@ export function AccountSettingsScreen({ embedded = false }: Readonly<{ embedded?
   // Full list (every page) — see the identical comment in api-keys-screen.tsx. In practice this
   // is 0 or 1 rows under ADR-0006 (one account is one person), but routed through the same
   // fetch-all hook as the project picker for consistency, not because accounts can grow.
-  const { data: accounts = [], isLoading: isAccountsLoading } = useAllAccounts();
+  const {
+    data: accounts = [],
+    isLoading: isAccountsLoading,
+    totalCount: accountsTotalCount,
+  } = useAllAccounts();
   const accountParamInList = accounts.some((account) => account.id === accountParam);
   const accountId = (accountParamInList ? accountParam : undefined) ?? accounts[0]?.id;
   const selectedAccount: Account | undefined = accounts.find((account) => account.id === accountId);
@@ -65,6 +69,11 @@ export function AccountSettingsScreen({ embedded = false }: Readonly<{ embedded?
       resultCountLabel: t('picker.accountCount', { count: accountOptions.length }),
       optionAccessibilityLabel: (option) =>
         t('settings.account.selectAccount', { account: option.label }),
+      truncationNotice: pickerTruncationNotice(
+        accountOptions.length,
+        accountsTotalCount,
+        t('settings.picker.truncationNotice')
+      ),
     });
   };
 

--- a/apps/self-service/src/screens/api-keys-screen.tsx
+++ b/apps/self-service/src/screens/api-keys-screen.tsx
@@ -2,16 +2,19 @@ import React, { useEffect } from 'react';
 import { useRouter } from 'expo-router';
 import { useTranslation } from '@lightbridge/i18n';
 import {
-  useAccounts,
+  useAllAccounts,
+  useAllProjects,
   useApiKeys,
   usePagination,
   usePermissions,
-  useProjects,
   useQueryState,
 } from '@lightbridge/hooks';
 import type { Account, Project } from '@lightbridge/hooks';
 import { Pagination } from '@lightbridge/ui';
 import { useSheet } from '@lightbridge/ui/sheet';
+import { toAccountPickerOptions, toProjectPickerOptions } from '../components/entity-picker-field';
+import { usePickerSheet } from '../hooks/use-picker-sheet';
+import { useThemeColors } from '../hooks/use-theme-colors';
 import { ApiKeysListView } from '../views/api-keys-list-view';
 import { DeleteApiKeySheet } from './delete-api-key-sheet';
 import { RevokeApiKeySheet } from './revoke-api-key-sheet';
@@ -22,6 +25,8 @@ const PAGE_SIZE = 10;
 export function ApiKeysScreen() {
   const { t } = useTranslation();
   const sheet = useSheet();
+  const openPicker = usePickerSheet();
+  const colors = useThemeColors();
   const { has } = usePermissions();
   // Account/project selection lives in the URL (?accountId=…&projectId=…) so it
   // survives refresh and deep-links, read straight through useQueryState — no
@@ -29,12 +34,16 @@ export function ApiKeysScreen() {
   const [accountParam, setAccountParam] = useQueryState('accountId');
   const [projectParam, setProjectParam] = useQueryState('projectId');
   const router = useRouter();
-  const { data: accountsData = [], isLoading: isAccountsLoading } = useAccounts();
+  // Full lists (every page, not the first `limit: 10`) — these feed the account/project picker,
+  // which needs the complete set to search/select over. See useAllAccounts/useAllProjects in
+  // @lightbridge/hooks for why the plain `useAccounts`/`useProjects` (capped at one page) are the
+  // wrong fit here.
+  const { data: accountsData = [], isLoading: isAccountsLoading } = useAllAccounts();
   const accounts: Account[] = accountsData;
 
   // Effective account: the URL param when set, otherwise the first account.
   const accountId = accountParam ?? accounts[0]?.id;
-  const { data: projectsData = [], isLoading: isProjectsLoading } = useProjects(accountId);
+  const { data: projectsData = [], isLoading: isProjectsLoading } = useAllProjects(accountId);
   const projects: Project[] = projectsData;
 
   // Effective project: the URL param when it belongs to the current account's
@@ -70,6 +79,35 @@ export function ApiKeysScreen() {
 
   const handleSelectProject = (id: string) => {
     setProjectParam(id);
+  };
+
+  const accountOptions = toAccountPickerOptions(accounts);
+  const projectOptions = toProjectPickerOptions(projects, projectId, colors);
+
+  const handleOpenAccountPicker = () => {
+    openPicker({
+      options: accountOptions,
+      selectedId: accountId,
+      onSelect: handleSelectAccount,
+      searchPlaceholder: t('picker.searchAccounts'),
+      noResultsLabel: t('picker.noResults'),
+      title: t('picker.selectAccount'),
+      resultCountLabel: t('picker.accountCount', { count: accountOptions.length }),
+      optionAccessibilityLabel: (option) => t('apiKeys.selectAccount', { account: option.label }),
+    });
+  };
+
+  const handleOpenProjectPicker = () => {
+    openPicker({
+      options: projectOptions,
+      selectedId: projectId,
+      onSelect: handleSelectProject,
+      searchPlaceholder: t('picker.searchProjects'),
+      noResultsLabel: t('picker.noResults'),
+      title: t('picker.selectProject'),
+      resultCountLabel: t('picker.projectCount', { count: projectOptions.length }),
+      optionAccessibilityLabel: (option) => t('apiKeys.selectProject', { project: option.label }),
+    });
   };
 
   const handleCreate = () => {
@@ -124,6 +162,8 @@ export function ApiKeysScreen() {
         onRotate={handleRotate}
         onSelectAccount={handleSelectAccount}
         onSelectProject={handleSelectProject}
+        onOpenAccountPicker={handleOpenAccountPicker}
+        onOpenProjectPicker={handleOpenProjectPicker}
         canCreate={has('apikey:create')}
         canDelete={has('apikey:delete')}
         canRevoke={has('apikey:revoke')}

--- a/apps/self-service/src/screens/api-keys-screen.tsx
+++ b/apps/self-service/src/screens/api-keys-screen.tsx
@@ -12,7 +12,11 @@ import {
 import type { Account, Project } from '@lightbridge/hooks';
 import { Pagination } from '@lightbridge/ui';
 import { useSheet } from '@lightbridge/ui/sheet';
-import { toAccountPickerOptions, toProjectPickerOptions } from '../components/entity-picker-field';
+import {
+  pickerTruncationNotice,
+  toAccountPickerOptions,
+  toProjectPickerOptions,
+} from '../components/entity-picker-field';
 import { usePickerSheet } from '../hooks/use-picker-sheet';
 import { useThemeColors } from '../hooks/use-theme-colors';
 import { ApiKeysListView } from '../views/api-keys-list-view';
@@ -38,12 +42,20 @@ export function ApiKeysScreen() {
   // which needs the complete set to search/select over. See useAllAccounts/useAllProjects in
   // @lightbridge/hooks for why the plain `useAccounts`/`useProjects` (capped at one page) are the
   // wrong fit here.
-  const { data: accountsData = [], isLoading: isAccountsLoading } = useAllAccounts();
+  const {
+    data: accountsData = [],
+    isLoading: isAccountsLoading,
+    totalCount: accountsTotalCount,
+  } = useAllAccounts();
   const accounts: Account[] = accountsData;
 
   // Effective account: the URL param when set, otherwise the first account.
   const accountId = accountParam ?? accounts[0]?.id;
-  const { data: projectsData = [], isLoading: isProjectsLoading } = useAllProjects(accountId);
+  const {
+    data: projectsData = [],
+    isLoading: isProjectsLoading,
+    totalCount: projectsTotalCount,
+  } = useAllProjects(accountId);
   const projects: Project[] = projectsData;
 
   // Effective project: the URL param when it belongs to the current account's
@@ -94,6 +106,11 @@ export function ApiKeysScreen() {
       title: t('picker.selectAccount'),
       resultCountLabel: t('picker.accountCount', { count: accountOptions.length }),
       optionAccessibilityLabel: (option) => t('apiKeys.selectAccount', { account: option.label }),
+      truncationNotice: pickerTruncationNotice(
+        accountOptions.length,
+        accountsTotalCount,
+        t('settings.picker.truncationNotice')
+      ),
     });
   };
 
@@ -107,6 +124,11 @@ export function ApiKeysScreen() {
       title: t('picker.selectProject'),
       resultCountLabel: t('picker.projectCount', { count: projectOptions.length }),
       optionAccessibilityLabel: (option) => t('apiKeys.selectProject', { project: option.label }),
+      truncationNotice: pickerTruncationNotice(
+        projectOptions.length,
+        projectsTotalCount,
+        t('settings.picker.truncationNotice')
+      ),
     });
   };
 

--- a/apps/self-service/src/screens/project-settings-screen.tsx
+++ b/apps/self-service/src/screens/project-settings-screen.tsx
@@ -19,7 +19,11 @@ import {
 } from '@lightbridge/hooks';
 import type { Account, Project } from '@lightbridge/hooks';
 import { useSheet } from '@lightbridge/ui/sheet';
-import { toAccountPickerOptions, toProjectPickerOptions } from '../components/entity-picker-field';
+import {
+  pickerTruncationNotice,
+  toAccountPickerOptions,
+  toProjectPickerOptions,
+} from '../components/entity-picker-field';
 import { usePickerSheet } from '../hooks/use-picker-sheet';
 import { useThemeColors } from '../hooks/use-theme-colors';
 import { ProjectSettingsView } from '../views/settings/project-settings-view';
@@ -45,11 +49,19 @@ export function ProjectSettingsScreen({ embedded = false }: Readonly<{ embedded?
   // Full lists (every page) — see the identical comment in api-keys-screen.tsx. The old
   // `useAccounts()`/`useProjects(accountId)` calls here (capped at `limit: 10`) were the actual
   // truncation bug: an account's 11th project was unreachable and nothing on screen said so.
-  const { data: accountsData = [], isLoading: isAccountsLoading } = useAllAccounts();
+  const {
+    data: accountsData = [],
+    isLoading: isAccountsLoading,
+    totalCount: accountsTotalCount,
+  } = useAllAccounts();
   const accounts: Account[] = accountsData;
   const accountId = accountParam ?? accounts[0]?.id;
 
-  const { data: projectsData = [], isLoading: isProjectsLoading } = useAllProjects(accountId);
+  const {
+    data: projectsData = [],
+    isLoading: isProjectsLoading,
+    totalCount: projectsTotalCount,
+  } = useAllProjects(accountId);
   const projects: Project[] = projectsData;
 
   const projectParamInList = projects.some((project) => project.id === projectParam);
@@ -119,6 +131,11 @@ export function ProjectSettingsScreen({ embedded = false }: Readonly<{ embedded?
       resultCountLabel: t('picker.accountCount', { count: accountOptions.length }),
       optionAccessibilityLabel: (option) =>
         t('settings.project.selectAccount', { account: option.label }),
+      truncationNotice: pickerTruncationNotice(
+        accountOptions.length,
+        accountsTotalCount,
+        t('settings.picker.truncationNotice')
+      ),
     });
   };
 
@@ -133,6 +150,11 @@ export function ProjectSettingsScreen({ embedded = false }: Readonly<{ embedded?
       resultCountLabel: t('picker.projectCount', { count: projectOptions.length }),
       optionAccessibilityLabel: (option) =>
         t('settings.project.selectProject', { project: option.label }),
+      truncationNotice: pickerTruncationNotice(
+        projectOptions.length,
+        projectsTotalCount,
+        t('settings.picker.truncationNotice')
+      ),
     });
   };
 

--- a/apps/self-service/src/screens/project-settings-screen.tsx
+++ b/apps/self-service/src/screens/project-settings-screen.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import { useRouter } from 'expo-router';
+import { useTranslation } from '@lightbridge/i18n';
 import {
   getApiErrorMessage,
-  useAccounts,
+  useAllAccounts,
+  useAllProjects,
   useDisableProject,
   useEnableProject,
   usePermissions,
   useAddProjectMember,
   useProjectMembers,
-  useProjects,
   useQueryState,
   useRemoveProjectMember,
   useSetDefaultProject,
@@ -18,6 +19,9 @@ import {
 } from '@lightbridge/hooks';
 import type { Account, Project } from '@lightbridge/hooks';
 import { useSheet } from '@lightbridge/ui/sheet';
+import { toAccountPickerOptions, toProjectPickerOptions } from '../components/entity-picker-field';
+import { usePickerSheet } from '../hooks/use-picker-sheet';
+import { useThemeColors } from '../hooks/use-theme-colors';
 import { ProjectSettingsView } from '../views/settings/project-settings-view';
 import type {
   ProjectDefaultLimits,
@@ -28,18 +32,24 @@ import { DeleteProjectSheet } from './delete-project-sheet';
 
 export function ProjectSettingsScreen({ embedded = false }: Readonly<{ embedded?: boolean }>) {
   const router = useRouter();
+  const { t } = useTranslation();
   const sheet = useSheet();
+  const openPicker = usePickerSheet();
+  const colors = useThemeColors();
   const { has } = usePermissions();
   // Account/project selection lives in the URL (?accountId=…&projectId=…) so it
   // survives refresh and deep-links — same pattern as the API-keys screen.
   const [accountParam, setAccountParam] = useQueryState('accountId');
   const [projectParam, setProjectParam] = useQueryState('projectId');
 
-  const { data: accountsData = [], isLoading: isAccountsLoading } = useAccounts();
+  // Full lists (every page) — see the identical comment in api-keys-screen.tsx. The old
+  // `useAccounts()`/`useProjects(accountId)` calls here (capped at `limit: 10`) were the actual
+  // truncation bug: an account's 11th project was unreachable and nothing on screen said so.
+  const { data: accountsData = [], isLoading: isAccountsLoading } = useAllAccounts();
   const accounts: Account[] = accountsData;
   const accountId = accountParam ?? accounts[0]?.id;
 
-  const { data: projectsData = [], isLoading: isProjectsLoading } = useProjects(accountId);
+  const { data: projectsData = [], isLoading: isProjectsLoading } = useAllProjects(accountId);
   const projects: Project[] = projectsData;
 
   const projectParamInList = projects.some((project) => project.id === projectParam);
@@ -93,6 +103,37 @@ export function ProjectSettingsScreen({ embedded = false }: Readonly<{ embedded?
   const handleSelectAccount = (id: string) => {
     setAccountParam(id);
     setProjectParam(null);
+  };
+
+  const accountOptions = toAccountPickerOptions(accounts);
+  const projectOptions = toProjectPickerOptions(projects, projectId, colors);
+
+  const handleOpenAccountPicker = () => {
+    openPicker({
+      options: accountOptions,
+      selectedId: accountId,
+      onSelect: handleSelectAccount,
+      searchPlaceholder: t('picker.searchAccounts'),
+      noResultsLabel: t('picker.noResults'),
+      title: t('picker.selectAccount'),
+      resultCountLabel: t('picker.accountCount', { count: accountOptions.length }),
+      optionAccessibilityLabel: (option) =>
+        t('settings.project.selectAccount', { account: option.label }),
+    });
+  };
+
+  const handleOpenProjectPicker = () => {
+    openPicker({
+      options: projectOptions,
+      selectedId: projectId,
+      onSelect: setProjectParam,
+      searchPlaceholder: t('picker.searchProjects'),
+      noResultsLabel: t('picker.noResults'),
+      title: t('picker.selectProject'),
+      resultCountLabel: t('picker.projectCount', { count: projectOptions.length }),
+      optionAccessibilityLabel: (option) =>
+        t('settings.project.selectProject', { project: option.label }),
+    });
   };
 
   const handleSaveDetails = ({ name, billingPlan }: ProjectDetailsInput) => {
@@ -210,6 +251,8 @@ export function ProjectSettingsScreen({ embedded = false }: Readonly<{ embedded?
       isLoading={isAccountsLoading || isProjectsLoading}
       onSelectAccount={handleSelectAccount}
       onSelectProject={setProjectParam}
+      onOpenAccountPicker={handleOpenAccountPicker}
+      onOpenProjectPicker={handleOpenProjectPicker}
       onCreateProject={handleCreateProject}
       onSaveDetails={handleSaveDetails}
       isSavingDetails={updateProject.isPending}

--- a/apps/self-service/src/views/__tests__/api-keys-list-view.lifecycle.test.tsx
+++ b/apps/self-service/src/views/__tests__/api-keys-list-view.lifecycle.test.tsx
@@ -33,6 +33,8 @@ function renderList(item: ApiKey, overrides: Partial<Record<string, unknown>> = 
       onRotate={overrides.onRotate as (id: string, name: string) => void}
       onSelectAccount={noop}
       onSelectProject={noop}
+      onOpenAccountPicker={noop}
+      onOpenProjectPicker={noop}
     />
   );
 }

--- a/apps/self-service/src/views/api-keys-list-view.tsx
+++ b/apps/self-service/src/views/api-keys-list-view.tsx
@@ -20,6 +20,11 @@ import {
   Text,
 } from '@lightbridge/ui';
 import type { Account, ApiKey, Project } from '@lightbridge/hooks';
+import {
+  EntityPickerField,
+  toAccountPickerOptions,
+  toProjectPickerOptions,
+} from '../components/entity-picker-field';
 import { useThemeColors } from '../hooks/use-theme-colors';
 
 const i18nLocaleMap: Record<string, string> = {
@@ -45,6 +50,9 @@ type ApiKeysListViewProps = {
   onRotate: (id: string, name: string) => void;
   onSelectAccount: (id: string) => void;
   onSelectProject: (id: string) => void;
+  /** Opens the searchable account/project picker sheet — owned by the screen (`usePickerSheet`). */
+  onOpenAccountPicker: () => void;
+  onOpenProjectPicker: () => void;
   canCreate?: boolean;
   canDelete?: boolean;
   canRevoke?: boolean;
@@ -85,6 +93,8 @@ export function ApiKeysListView({
   onRotate,
   onSelectAccount,
   onSelectProject,
+  onOpenAccountPicker,
+  onOpenProjectPicker,
   canCreate = true,
   canDelete = true,
   canRevoke = true,
@@ -96,6 +106,9 @@ export function ApiKeysListView({
 
   const displayItems = items;
   const selectedProject = projects.find((project) => project.id === selectedProjectId);
+
+  const accountOptions = toAccountPickerOptions(accounts);
+  const projectOptions = toProjectPickerOptions(projects, selectedProjectId, colors);
 
   return (
     <Div tone="muted" width="full" style={{ flex: 1 }}>
@@ -129,59 +142,37 @@ export function ApiKeysListView({
         <Stack gap="lg">
           <Card size="sm">
             <Stack gap="md">
-              <Stack gap="xs">
-                <Text intent="bodyStrong">{t('apiKeys.accountsLabel')}</Text>
-                <Stack direction="row" wrap="wrap" gap="sm">
-                  {accounts.length === 0 ? (
-                    <Text intent="caption">{t('apiKeys.noAccounts')}</Text>
-                  ) : (
-                    accounts.map((account) => {
-                      const isSelected = account.id === selectedAccountId;
-
-                      return (
-                        <Button
-                          key={account.id}
-                          variant={isSelected ? 'primary' : 'neutral'}
-                          size="sm"
-                          onPress={() => onSelectAccount(account.id)}
-                          accessibilityLabel={t('apiKeys.selectAccount', {
-                            account: account.id,
-                          })}>
-                          {account.id}
-                        </Button>
-                      );
-                    })
-                  )}
-                </Stack>
-              </Stack>
+              <EntityPickerField
+                label={t('apiKeys.accountsLabel')}
+                options={accountOptions}
+                selectedId={selectedAccountId}
+                onSelect={onSelectAccount}
+                onOpenPicker={onOpenAccountPicker}
+                emptyLabel={t('apiKeys.noAccounts')}
+                placeholderLabel={t('picker.selectAccount')}
+                triggerAccessibilityLabel={t('picker.selectAccount')}
+                optionAccessibilityLabel={(option) =>
+                  t('apiKeys.selectAccount', { account: option.label })
+                }
+                isLoading={isLoading}
+              />
 
               <Divider tone="muted" />
 
-              <Stack gap="xs">
-                <Text intent="bodyStrong">{t('apiKeys.projectsLabel')}</Text>
-                <Stack direction="row" wrap="wrap" gap="sm">
-                  {projects.length === 0 ? (
-                    <Text intent="caption">{t('apiKeys.noProjects')}</Text>
-                  ) : (
-                    projects.map((project) => {
-                      const isSelected = project.id === selectedProjectId;
-
-                      return (
-                        <Button
-                          key={project.id}
-                          variant={isSelected ? 'primary' : 'neutral'}
-                          size="sm"
-                          onPress={() => onSelectProject(project.id)}
-                          accessibilityLabel={t('apiKeys.selectProject', {
-                            project: project.name,
-                          })}>
-                          {project.name}
-                        </Button>
-                      );
-                    })
-                  )}
-                </Stack>
-              </Stack>
+              <EntityPickerField
+                label={t('apiKeys.projectsLabel')}
+                options={projectOptions}
+                selectedId={selectedProjectId}
+                onSelect={onSelectProject}
+                onOpenPicker={onOpenProjectPicker}
+                emptyLabel={t('apiKeys.noProjects')}
+                placeholderLabel={t('picker.selectProject')}
+                triggerAccessibilityLabel={t('picker.selectProject')}
+                optionAccessibilityLabel={(option) =>
+                  t('apiKeys.selectProject', { project: option.label })
+                }
+                isLoading={isLoading}
+              />
             </Stack>
           </Card>
 

--- a/apps/self-service/src/views/settings/__tests__/account-settings-view.test.tsx
+++ b/apps/self-service/src/views/settings/__tests__/account-settings-view.test.tsx
@@ -22,6 +22,7 @@ function renderView(overrides: Partial<React.ComponentProps<typeof AccountSettin
     <AccountSettingsView
       onBack={noop}
       onSelectAccount={noop}
+      onOpenAccountPicker={noop}
       defaultQuota="t-m"
       onSaveDefaultQuota={noop}
       authIssuer="https://issuer.example.com/realms/lightbridge"

--- a/apps/self-service/src/views/settings/__tests__/project-settings-view.test.tsx
+++ b/apps/self-service/src/views/settings/__tests__/project-settings-view.test.tsx
@@ -49,6 +49,8 @@ function renderView(overrides: Partial<React.ComponentProps<typeof ProjectSettin
       project={project}
       onSelectAccount={noop}
       onSelectProject={noop}
+      onOpenAccountPicker={noop}
+      onOpenProjectPicker={noop}
       onCreateProject={noop}
       onSaveDetails={noop}
       onAddModel={noop}

--- a/apps/self-service/src/views/settings/account-settings-view.tsx
+++ b/apps/self-service/src/views/settings/account-settings-view.tsx
@@ -13,12 +13,12 @@ import {
   PageHeader,
   Scroll,
   SectionCard,
-  Skeleton,
   Stack,
   Text,
   TextField,
 } from '@lightbridge/ui';
 import type { Account } from '@lightbridge/hooks';
+import { EntityPickerField, toAccountPickerOptions } from '../../components/entity-picker-field';
 import { useThemeColors } from '../../hooks/use-theme-colors';
 
 type AccountSettingsViewProps = {
@@ -28,6 +28,8 @@ type AccountSettingsViewProps = {
   selectedAccountId?: string;
   isLoading?: boolean;
   onSelectAccount: (id: string) => void;
+  /** Opens the searchable account picker sheet — owned by the screen (see `usePickerSheet`). */
+  onOpenAccountPicker: () => void;
   defaultQuota: string;
   onSaveDefaultQuota: (value: string) => void;
   isSavingDefaultQuota?: boolean;
@@ -51,6 +53,7 @@ export function AccountSettingsView({
   selectedAccountId,
   isLoading = false,
   onSelectAccount,
+  onOpenAccountPicker,
   defaultQuota,
   onSaveDefaultQuota,
   isSavingDefaultQuota = false,
@@ -77,6 +80,8 @@ export function AccountSettingsView({
   const trimmedDraft = defaultQuotaDraft.trim();
   const hasDefaultQuotaChanged = trimmedDraft !== defaultQuota.trim();
   const canSaveDefaultQuota = hasDefaultQuotaChanged && !isSavingDefaultQuota;
+
+  const accountOptions = toAccountPickerOptions(accounts);
 
   return (
     <Div tone="muted" width="full" style={{ flex: 1 }}>
@@ -121,32 +126,20 @@ export function AccountSettingsView({
           )}
 
           <Card size="sm">
-            <Stack gap="xs">
-              <Text intent="bodyStrong">{t('settings.account.accountsLabel')}</Text>
-              {isLoading && accounts.length === 0 ? (
-                <Stack direction="row" gap="sm">
-                  <Skeleton width={96} height={36} rounded="xl" />
-                  <Skeleton width={96} height={36} rounded="xl" />
-                </Stack>
-              ) : accounts.length === 0 ? (
-                <Text intent="caption">{t('settings.account.noAccounts')}</Text>
-              ) : (
-                <Stack direction="row" wrap="wrap" gap="sm">
-                  {accounts.map((account) => (
-                    <Button
-                      key={account.id}
-                      variant={account.id === selectedAccountId ? 'primary' : 'neutral'}
-                      size="sm"
-                      onPress={() => onSelectAccount(account.id)}
-                      accessibilityLabel={t('settings.account.selectAccount', {
-                        account: account.id,
-                      })}>
-                      {account.id}
-                    </Button>
-                  ))}
-                </Stack>
-              )}
-            </Stack>
+            <EntityPickerField
+              label={t('settings.account.accountsLabel')}
+              options={accountOptions}
+              selectedId={selectedAccountId}
+              onSelect={onSelectAccount}
+              onOpenPicker={onOpenAccountPicker}
+              emptyLabel={t('settings.account.noAccounts')}
+              placeholderLabel={t('picker.selectAccount')}
+              triggerAccessibilityLabel={t('picker.selectAccount')}
+              optionAccessibilityLabel={(option) =>
+                t('settings.account.selectAccount', { account: option.label })
+              }
+              isLoading={isLoading}
+            />
           </Card>
 
           {canUpdate ? (

--- a/apps/self-service/src/views/settings/project-settings-view.tsx
+++ b/apps/self-service/src/views/settings/project-settings-view.tsx
@@ -21,6 +21,11 @@ import {
 } from '@lightbridge/ui';
 import type { Account, Project, ProjectMember } from '@lightbridge/hooks';
 import { AllowlistEnforcementNotice } from '../../components/allowlist-enforcement-notice';
+import {
+  EntityPickerField,
+  toAccountPickerOptions,
+  toProjectPickerOptions,
+} from '../../components/entity-picker-field';
 import { useThemeColors } from '../../hooks/use-theme-colors';
 import { formatDate } from '../api-keys-list-view';
 
@@ -61,6 +66,9 @@ type ProjectSettingsViewProps = {
   isLoading?: boolean;
   onSelectAccount: (id: string) => void;
   onSelectProject: (id: string) => void;
+  /** Opens the searchable account/project picker sheet — owned by the screen (`usePickerSheet`). */
+  onOpenAccountPicker: () => void;
+  onOpenProjectPicker: () => void;
   onCreateProject: () => void;
   onSaveDetails: (input: ProjectDetailsInput) => void;
   isSavingDetails?: boolean;
@@ -123,6 +131,8 @@ export function ProjectSettingsView({
   isLoading = false,
   onSelectAccount,
   onSelectProject,
+  onOpenAccountPicker,
+  onOpenProjectPicker,
   onCreateProject,
   onSaveDetails,
   isSavingDetails = false,
@@ -156,6 +166,9 @@ export function ProjectSettingsView({
   const { t, i18n } = useTranslation();
   const colors = useThemeColors();
   const dateLocale = i18n.language;
+
+  const accountOptions = toAccountPickerOptions(accounts);
+  const projectOptions = toProjectPickerOptions(projects, selectedProjectId, colors);
 
   const projectLimits = asDefaultLimits(project?.defaultLimits);
 
@@ -296,60 +309,37 @@ export function ProjectSettingsView({
 
           <Card size="sm">
             <Stack gap="md">
-              <Stack gap="xs">
-                <Text intent="bodyStrong">{t('settings.project.accountsLabel')}</Text>
-                <Stack direction="row" wrap="wrap" gap="sm">
-                  {accounts.length === 0 ? (
-                    <Text intent="caption">{t('settings.project.noAccounts')}</Text>
-                  ) : (
-                    accounts.map((account) => (
-                      <Button
-                        key={account.id}
-                        variant={account.id === selectedAccountId ? 'primary' : 'neutral'}
-                        size="sm"
-                        onPress={() => onSelectAccount(account.id)}
-                        accessibilityLabel={t('settings.project.selectAccount', {
-                          account: account.id,
-                        })}>
-                        {account.id}
-                      </Button>
-                    ))
-                  )}
-                </Stack>
-              </Stack>
+              <EntityPickerField
+                label={t('settings.project.accountsLabel')}
+                options={accountOptions}
+                selectedId={selectedAccountId}
+                onSelect={onSelectAccount}
+                onOpenPicker={onOpenAccountPicker}
+                emptyLabel={t('settings.project.noAccounts')}
+                placeholderLabel={t('picker.selectAccount')}
+                triggerAccessibilityLabel={t('picker.selectAccount')}
+                optionAccessibilityLabel={(option) =>
+                  t('settings.project.selectAccount', { account: option.label })
+                }
+                isLoading={isLoading}
+              />
 
               <Divider tone="muted" />
 
-              <Stack gap="xs">
-                <Text intent="bodyStrong">{t('settings.project.projectsLabel')}</Text>
-                <Stack direction="row" wrap="wrap" gap="sm">
-                  {projects.length === 0 ? (
-                    <Text intent="caption">{t('settings.project.noProjects')}</Text>
-                  ) : (
-                    projects.map((item) => (
-                      <Button
-                        key={item.id}
-                        variant={item.id === selectedProjectId ? 'primary' : 'neutral'}
-                        size="sm"
-                        leadingIcon={
-                          item.isDefault ? (
-                            <Feather
-                              name="star"
-                              size={12}
-                              color={item.id === selectedProjectId ? colors.surface : colors.subtle}
-                            />
-                          ) : undefined
-                        }
-                        onPress={() => onSelectProject(item.id)}
-                        accessibilityLabel={t('settings.project.selectProject', {
-                          project: item.name,
-                        })}>
-                        {item.name}
-                      </Button>
-                    ))
-                  )}
-                </Stack>
-              </Stack>
+              <EntityPickerField
+                label={t('settings.project.projectsLabel')}
+                options={projectOptions}
+                selectedId={selectedProjectId}
+                onSelect={onSelectProject}
+                onOpenPicker={onOpenProjectPicker}
+                emptyLabel={t('settings.project.noProjects')}
+                placeholderLabel={t('picker.selectProject')}
+                triggerAccessibilityLabel={t('picker.selectProject')}
+                optionAccessibilityLabel={(option) =>
+                  t('settings.project.selectProject', { project: option.label })
+                }
+                isLoading={isLoading}
+              />
             </Stack>
           </Card>
 

--- a/packages/hooks/src/accounts.test.ts
+++ b/packages/hooks/src/accounts.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // accounts.ts pulls in `./auth-session` → `@tanstack/react-db`/native-storage modules and
 // `@lightbridge/authz-rpc` → the generated cratestack client — both drag in React Native's
@@ -6,10 +6,22 @@ import { describe, expect, it, vi } from 'vitest';
 // syntax). Mock both so this file only ever exercises the pure query-key/defaulting helpers
 // under test, same spirit as the "import from the dedicated subpath" workaround documented in
 // apps/self-service/src/__tests__/use-pagination.test.tsx for the Jest side.
+//
+// `listMock` is declared via `vi.hoisted` because `vi.mock` factories are hoisted above regular
+// module-level `const`s by Vitest's transform — a plain `const listMock = vi.fn()` referenced
+// inside the factory below would be a temporal-dead-zone read at hoist time.
+const { listMock } = vi.hoisted(() => ({ listMock: vi.fn() }));
 vi.mock('./auth-session', () => ({ useAuthSession: () => ({ isAuthenticated: true }) }));
-vi.mock('@lightbridge/authz-rpc', () => ({ getAuthzRpcClient: () => ({}) }));
+vi.mock('@lightbridge/authz-rpc', () => ({
+  getAuthzRpcClient: () => ({ accounts: { list: listMock } }),
+}));
 
-import { accountsListQueryKey, accountsQueryKey, resolveAccountsOptions } from './accounts';
+import {
+  accountsListQueryKey,
+  accountsQueryKey,
+  fetchAllAccounts,
+  resolveAccountsOptions,
+} from './accounts';
 
 describe('resolveAccountsOptions', () => {
   it('defaults to offset 0, limit 10 when nothing is passed (unchanged existing behavior)', () => {
@@ -45,5 +57,52 @@ describe('accountsListQueryKey', () => {
   it('every per-page key still starts with the bare invalidation prefix', () => {
     const key = accountsListQueryKey({ offset: 40, limit: 10 });
     expect(key.slice(0, accountsQueryKey.length)).toEqual(accountsQueryKey);
+  });
+});
+
+describe('fetchAllAccounts', () => {
+  beforeEach(() => {
+    listMock.mockReset();
+  });
+
+  it('pages past the first response and returns every item — the actual truncation bug fix: the old call sites capped at one page (limit 10) with nothing on screen saying so', async () => {
+    const page1Items = Array.from({ length: 50 }, (_, i) => ({ id: `acc-${i + 1}` }));
+    const page2Items = [{ id: 'acc-51' }, { id: 'acc-52' }];
+
+    listMock
+      .mockResolvedValueOnce({
+        items: page1Items,
+        totalCount: 52,
+        pageInfo: { limit: 50, offset: 0, hasNextPage: true, hasPreviousPage: false },
+      })
+      .mockResolvedValueOnce({
+        items: page2Items,
+        totalCount: 52,
+        pageInfo: { limit: 50, offset: 50, hasNextPage: false, hasPreviousPage: true },
+      });
+
+    const result = await fetchAllAccounts();
+
+    expect(result.items).toHaveLength(52);
+    // The item past the first page — unreachable before this fix — is present.
+    expect(result.items.map((account) => account.id)).toContain('acc-52');
+    expect(result.totalCount).toBe(52);
+    expect(listMock).toHaveBeenCalledTimes(2);
+    expect(listMock).toHaveBeenNthCalledWith(1, { limit: 50, offset: 0 });
+    expect(listMock).toHaveBeenNthCalledWith(2, { limit: 50, offset: 50 });
+  });
+
+  it('stops after a single page when the server reports no more', async () => {
+    listMock.mockResolvedValueOnce({
+      items: [{ id: 'acc-1' }],
+      totalCount: 1,
+      pageInfo: { limit: 50, offset: 0, hasNextPage: false, hasPreviousPage: false },
+    });
+
+    const result = await fetchAllAccounts();
+
+    expect(result.items).toEqual([{ id: 'acc-1' }]);
+    expect(result.totalCount).toBe(1);
+    expect(listMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/hooks/src/accounts.ts
+++ b/packages/hooks/src/accounts.ts
@@ -48,6 +48,73 @@ export function useAccounts(enabled = true, options: UseAccountsOptions = {}) {
   return { ...query, data: items };
 }
 
+/** Rows per request while paging through the complete account list — see {@link fetchAllAccounts}. */
+const ALL_ACCOUNTS_PAGE_SIZE = 50;
+/**
+ * Safety ceiling on {@link fetchAllAccounts}'s "keep paging" loop: large enough that no real
+ * account list should ever hit it (ADR-0006: one account is one person — ergo the account list
+ * response the caller sees is realistically always 0 or 1 rows), small enough that a server bug
+ * returning `hasNextPage: true` forever cannot turn this into an unbounded fetch loop.
+ */
+const MAX_ACCOUNTS_PAGES = 20;
+
+/**
+ * Pages through `accounts.list` until the server reports no more (`pageInfo.hasNextPage: false`),
+ * accumulating every item. Backs `useAllAccounts` below — the account picker needs the *complete*
+ * list to search over, not a first page capped at `resolveAccountsOptions`'s default `limit: 10`
+ * (the truncation this whole hook exists to avoid; see `useAllProjects` in ./projects for the
+ * same pattern applied to the list that actually grows past one page in practice).
+ */
+export async function fetchAllAccounts(): Promise<{ items: Account[]; totalCount: number }> {
+  let items: Account[] = [];
+  let offset = 0;
+  let totalCount = 0;
+
+  for (let pageIndex = 0; pageIndex < MAX_ACCOUNTS_PAGES; pageIndex += 1) {
+    const page = await getAuthzRpcClient().accounts.list({
+      limit: ALL_ACCOUNTS_PAGE_SIZE,
+      offset,
+    });
+    items = items.concat(page.items);
+    totalCount = page.totalCount ?? items.length;
+
+    if (!page.pageInfo.hasNextPage) {
+      return { items, totalCount };
+    }
+    offset += ALL_ACCOUNTS_PAGE_SIZE;
+  }
+
+  return { items, totalCount };
+}
+
+/** Query key for the complete-list fetch — nested under `accountsQueryKey` so invalidating that
+ *  bare prefix (every mutation below already does) clears this cache too. */
+export function allAccountsQueryKey() {
+  return [...accountsQueryKey, 'all'] as const;
+}
+
+/**
+ * The complete account list — every page, not just the first. Feeds the account picker
+ * (`EntityPickerField` in apps/self-service), which needs to search/select over every account the
+ * caller has, not just the first `limit: 10` of them. Prefer `useAccounts` for anything that
+ * intentionally wants one page (e.g. an existence check).
+ */
+export function useAllAccounts(enabled = true) {
+  const { isAuthenticated } = useAuthSession();
+
+  const query = useQuery({
+    queryKey: allAccountsQueryKey(),
+    queryFn: fetchAllAccounts,
+    enabled: enabled && isAuthenticated,
+    staleTime: 5 * 60_000,
+  });
+
+  const items = useMemo<Account[]>(() => query.data?.items ?? [], [query.data]);
+  const totalCount = query.data?.totalCount ?? items.length;
+
+  return { ...query, data: items, totalCount };
+}
+
 export function useCurrentAccount(enabled = true) {
   const { isAuthenticated } = useAuthSession();
   const { data, ...query } = useAccounts(enabled);

--- a/packages/hooks/src/projects.test.ts
+++ b/packages/hooks/src/projects.test.ts
@@ -1,19 +1,29 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // projects.ts pulls in `./accounts` → `./auth-session` and `@lightbridge/authz-rpc` — both drag
 // in React Native's entry point transitively, which Vitest's plain Rollup/esbuild pipeline can't
 // parse (Flow syntax). Mock both so this file only ever exercises the pure query-key/defaulting
 // helpers under test, same spirit as the "import from the dedicated subpath" workaround
 // documented in apps/self-service/src/__tests__/use-pagination.test.tsx for the Jest side.
+//
+// `listMock` is declared via `vi.hoisted` because `vi.mock` factories are hoisted above regular
+// module-level `const`s by Vitest's transform — a plain `const listMock = vi.fn()` referenced
+// inside the factory below would be a temporal-dead-zone read at hoist time.
+const { listMock } = vi.hoisted(() => ({ listMock: vi.fn() }));
 vi.mock('./auth-session', () => ({ useAuthSession: () => ({ isAuthenticated: true }) }));
 vi.mock('./accounts', () => ({ useCurrentAccount: () => ({ data: undefined }) }));
 vi.mock('@lightbridge/authz-rpc', () => ({
-  getAuthzRpcClient: () => ({}),
+  getAuthzRpcClient: () => ({ projects: { list: listMock } }),
   createId: () => 'test-id',
 }));
 vi.mock('@lightbridge/i18n', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 
-import { projectsListQueryKey, projectsQueryKey, resolveProjectsOptions } from './projects';
+import {
+  fetchAllProjectsForAccount,
+  projectsListQueryKey,
+  projectsQueryKey,
+  resolveProjectsOptions,
+} from './projects';
 
 describe('resolveProjectsOptions', () => {
   it('defaults to offset 0, limit 10 when nothing is passed (unchanged existing behavior)', () => {
@@ -58,5 +68,65 @@ describe('projectsListQueryKey', () => {
 
   it('falls back to a stable placeholder key with no account, matching the enabled: !!accountId gate', () => {
     expect(projectsListQueryKey(undefined)).toEqual(['projects', 'unknown']);
+  });
+});
+
+describe('fetchAllProjectsForAccount', () => {
+  const accountId = 'acc-1';
+
+  beforeEach(() => {
+    listMock.mockReset();
+  });
+
+  it('pages past the first response and returns every project — the actual bug this hook fixes: an account with 11+ projects had its 11th+ unreachable under the old `useProjects(accountId)` call (capped at limit 10), with nothing on screen saying so', async () => {
+    const page1Items = Array.from({ length: 10 }, (_, i) => ({
+      id: `proj-${i + 1}`,
+      name: `Project ${i + 1}`,
+    }));
+    const page2Items = [{ id: 'proj-11', name: 'Project 11' }];
+
+    listMock
+      .mockResolvedValueOnce({
+        items: page1Items,
+        totalCount: 11,
+        pageInfo: { limit: 50, offset: 0, hasNextPage: true, hasPreviousPage: false },
+      })
+      .mockResolvedValueOnce({
+        items: page2Items,
+        totalCount: 11,
+        pageInfo: { limit: 50, offset: 50, hasNextPage: false, hasPreviousPage: true },
+      });
+
+    const result = await fetchAllProjectsForAccount(accountId);
+
+    expect(result.items).toHaveLength(11);
+    // Project 11 — unreachable through the old capped-at-10 picker — is present.
+    expect(result.items.map((project) => project.id)).toContain('proj-11');
+    expect(result.totalCount).toBe(11);
+    expect(listMock).toHaveBeenCalledTimes(2);
+    expect(listMock).toHaveBeenNthCalledWith(1, {
+      limit: 50,
+      offset: 0,
+      filters: [{ key: 'accountId', value: accountId }],
+    });
+    expect(listMock).toHaveBeenNthCalledWith(2, {
+      limit: 50,
+      offset: 50,
+      filters: [{ key: 'accountId', value: accountId }],
+    });
+  });
+
+  it('stops after a single page when the server reports no more', async () => {
+    listMock.mockResolvedValueOnce({
+      items: [{ id: 'proj-1', name: 'Project 1' }],
+      totalCount: 1,
+      pageInfo: { limit: 50, offset: 0, hasNextPage: false, hasPreviousPage: false },
+    });
+
+    const result = await fetchAllProjectsForAccount(accountId);
+
+    expect(result.items).toEqual([{ id: 'proj-1', name: 'Project 1' }]);
+    expect(result.totalCount).toBe(1);
+    expect(listMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/hooks/src/projects.ts
+++ b/packages/hooks/src/projects.ts
@@ -124,6 +124,82 @@ export function useProjects(accountId?: string, options: UseProjectsOptions = {}
   return { ...query, data: items };
 }
 
+/** Rows per request while paging through an account's complete project list — see
+ *  {@link fetchAllProjectsForAccount}. */
+const ALL_PROJECTS_PAGE_SIZE = 50;
+/**
+ * Safety ceiling on {@link fetchAllProjectsForAccount}'s "keep paging" loop: large enough that no
+ * real project list should ever hit it, small enough that a server bug returning
+ * `hasNextPage: true` forever cannot turn this into an unbounded fetch loop.
+ */
+const MAX_PROJECTS_PAGES = 20;
+
+/**
+ * Pages through `projects.list` (scoped to one account) until the server reports no more
+ * (`pageInfo.hasNextPage: false`), accumulating every item. This is the actual fix for the
+ * project-picker truncation bug: the old call sites read `useProjects(accountId)` with no
+ * options, which defaults to `resolveProjectsOptions`'s `limit: 10` — an account's 11th project
+ * was unreachable and nothing on screen said so. `useAllProjects` below feeds the picker from
+ * this instead, so it always has the complete list to select/search over.
+ */
+export async function fetchAllProjectsForAccount(
+  accountId: string
+): Promise<{ items: Project[]; totalCount: number }> {
+  let items: Project[] = [];
+  let offset = 0;
+  let totalCount = 0;
+
+  for (let pageIndex = 0; pageIndex < MAX_PROJECTS_PAGES; pageIndex += 1) {
+    const page = await getAuthzRpcClient().projects.list({
+      limit: ALL_PROJECTS_PAGE_SIZE,
+      offset,
+      filters: [{ key: 'accountId', value: accountId }],
+    });
+    items = items.concat(page.items.map(toProject));
+    totalCount = page.totalCount ?? items.length;
+
+    if (!page.pageInfo.hasNextPage) {
+      return { items, totalCount };
+    }
+    offset += ALL_PROJECTS_PAGE_SIZE;
+  }
+
+  return { items, totalCount };
+}
+
+/** Query key for the complete-list fetch — nested under `projectsQueryKey(accountId)` so
+ *  invalidating that bare prefix (every mutation below already does) clears this cache too. */
+export function allProjectsQueryKey(accountId: string | undefined) {
+  return accountId
+    ? ([...projectsQueryKey(accountId), 'all'] as const)
+    : (['projects', 'unknown', 'all'] as const);
+}
+
+/**
+ * The complete project list for one account — every page, not just the first. Feeds the project
+ * picker (`EntityPickerField` in apps/self-service), which needs to search/select over every
+ * project the account has. Prefer `useProjects` for anything that intentionally wants one page
+ * (e.g. an existence check).
+ */
+export function useAllProjects(accountId?: string) {
+  const { isAuthenticated } = useAuthSession();
+
+  const query = useQuery({
+    queryKey: allProjectsQueryKey(accountId),
+    queryFn: async () => {
+      if (!accountId) throw new Error('Account ID is required');
+      return fetchAllProjectsForAccount(accountId);
+    },
+    enabled: !!accountId && isAuthenticated,
+    staleTime: 5 * 60_000,
+  });
+
+  const items = useMemo<Project[]>(() => query.data?.items ?? [], [query.data]);
+  const totalCount = query.data?.totalCount ?? items.length;
+
+  return { ...query, data: items, totalCount };
+}
+
 export function useCurrentProject(enabled = true) {
   const { isAuthenticated } = useAuthSession();
   const { data: currentAccount, isLoading: isAccountLoading } = useCurrentAccount(enabled);

--- a/packages/i18n/src/i18n-config.ts
+++ b/packages/i18n/src/i18n-config.ts
@@ -15,6 +15,23 @@ const resources = {
         previous: 'Previous',
         next: 'Next',
       },
+      // Shared strings for the account/project picker (`EntityPickerField` in
+      // apps/self-service/src/components/entity-picker-field.tsx, wrapping `@lightbridge/ui`'s
+      // `Picker`/`PickerList`). Generic on purpose — the entity-specific label, empty-state, and
+      // per-option accessibility copy stay on each screen's own namespace (apiKeys.*,
+      // settings.account.*, settings.project.*) since those already existed and read naturally
+      // in context ("No accounts available.", not "No items available.").
+      picker: {
+        searchAccounts: 'Search accounts',
+        searchProjects: 'Search projects',
+        noResults: 'No matches',
+        selectAccount: 'Select account',
+        selectProject: 'Select project',
+        accountCount_one: '{{count}} account',
+        accountCount_other: '{{count}} accounts',
+        projectCount_one: '{{count}} project',
+        projectCount_other: '{{count}} projects',
+      },
       project: {
         defaultName: 'Default Project',
       },

--- a/packages/i18n/src/i18n-config.ts
+++ b/packages/i18n/src/i18n-config.ts
@@ -172,6 +172,15 @@ const resources = {
           budget: 'Budget',
           budgetReview: 'Budget Review',
         },
+        // Shown inside the account/project picker sheet (EntityPickerField, wired through
+        // usePickerSheet) only when the fetch-everything loop in useAllAccounts/useAllProjects
+        // hit its page ceiling and the list it loaded is provably shorter than the server's own
+        // totalCount. Deliberately not "showing X of Y" — search only covers what actually
+        // loaded, so the copy says that plainly rather than implying the search is complete.
+        picker: {
+          truncationNotice:
+            "Not everything could be loaded, so search only covers what's shown here. Contact support if you can't find what you're looking for.",
+        },
         account: {
           title: 'Account settings',
           accountsLabel: 'Accounts',

--- a/packages/ui/src/components/picker/component.stories.tsx
+++ b/packages/ui/src/components/picker/component.stories.tsx
@@ -1,0 +1,112 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { Picker, PickerList } from './component';
+import type { PickerOption } from './types';
+
+const fewOptions: PickerOption[] = [
+  { id: 'acc-1', label: 'acc-1' },
+  { id: 'acc-2', label: 'acc-2' },
+];
+
+const manyOptions: PickerOption[] = Array.from({ length: 24 }, (_, index) => ({
+  id: `proj-${index + 1}`,
+  label: `Project ${index + 1}`,
+}));
+
+const meta: Meta<typeof Picker> = {
+  title: 'UI/Picker',
+  component: Picker,
+  decorators: [
+    (Story) => (
+      <div style={{ width: 420 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Picker>;
+
+// `render:` needs a real (capitalized) component function, not an inline arrow, so the
+// `useState` inside satisfies react-hooks/rules-of-hooks.
+function InlineBelowThresholdStory() {
+  const [selectedId, setSelectedId] = useState(fewOptions[0]?.id);
+  return (
+    <Picker
+      options={fewOptions}
+      selectedId={selectedId}
+      onSelect={setSelectedId}
+      onOpenPicker={() => {}}
+      emptyLabel="No accounts"
+      placeholderLabel="Select an account"
+    />
+  );
+}
+
+export const InlineBelowThreshold: Story = {
+  render: () => <InlineBelowThresholdStory />,
+};
+
+function TriggerAtThresholdStory() {
+  const [selectedId, setSelectedId] = useState(manyOptions[0]?.id);
+  return (
+    <Picker
+      options={manyOptions}
+      selectedId={selectedId}
+      onSelect={setSelectedId}
+      onOpenPicker={() => alert('Present the sheet — the app owns this call.')}
+      emptyLabel="No projects"
+      placeholderLabel="Select a project"
+      triggerAccessibilityLabel="Select project"
+    />
+  );
+}
+
+export const TriggerAtThreshold: Story = {
+  render: () => <TriggerAtThresholdStory />,
+};
+
+export const Empty: Story = {
+  args: {
+    options: [],
+    onSelect: () => {},
+    onOpenPicker: () => {},
+    emptyLabel: 'No projects yet',
+    placeholderLabel: 'Select a project',
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    options: [],
+    onSelect: () => {},
+    onOpenPicker: () => {},
+    emptyLabel: 'No projects yet',
+    placeholderLabel: 'Select a project',
+    isLoading: true,
+  },
+};
+
+// PickerList is the sheet-mode counterpart the app presents via `sheet.present(...)` once
+// `Picker` calls `onOpenPicker` — demoed here inline (not as a real sheet) since Storybook has no
+// SheetProvider host.
+function SheetContentStory() {
+  const [selectedId, setSelectedId] = useState(manyOptions[0]?.id);
+  return (
+    <PickerList
+      options={manyOptions}
+      selectedId={selectedId}
+      onSelect={setSelectedId}
+      searchPlaceholder="Search projects"
+      noResultsLabel="No matching projects"
+      title="Select project"
+      resultCountLabel={`${manyOptions.length} projects`}
+    />
+  );
+}
+
+export const SheetContent: Story = {
+  render: () => <SheetContentStory />,
+};

--- a/packages/ui/src/components/picker/component.tsx
+++ b/packages/ui/src/components/picker/component.tsx
@@ -91,6 +91,7 @@ export function PickerList({
   title,
   resultCountLabel,
   optionAccessibilityLabel,
+  truncationNotice,
 }: Readonly<PickerListProps>) {
   const [query, setQuery] = useState('');
 
@@ -115,6 +116,7 @@ export function PickerList({
         autoCorrect={false}
         accessibilityLabel={searchPlaceholder}
       />
+      {truncationNotice ? <Text intent="warning">{truncationNotice}</Text> : null}
       {resultCountLabel ? <Text intent="caption">{resultCountLabel}</Text> : null}
       <Scroll style={{ maxHeight: 360 }}>
         <Stack gap="xs" width="full">

--- a/packages/ui/src/components/picker/component.tsx
+++ b/packages/ui/src/components/picker/component.tsx
@@ -1,0 +1,147 @@
+import React, { useMemo, useState } from 'react';
+
+import { ListRow } from '../list-row';
+import { Scroll } from '../scroll';
+import { SegmentedControl } from '../segmented-control';
+import { Skeleton } from '../skeleton';
+import { Stack } from '../stack';
+import { Text } from '../text';
+import { TextField } from '../text-field';
+import type { PickerListProps, PickerProps } from './types';
+
+/**
+ * Selection control for a list of `PickerOption`s. Renders one of two shapes depending on
+ * `options.length` vs `sheetThreshold`:
+ *
+ * - Below the threshold: an inline `SegmentedControl` — correct group accessibility semantics
+ *   for free, no extra tap to open anything.
+ * - At/above the threshold: a tap-to-open trigger row. This component never opens anything
+ *   itself (no Sheet/modal/route dependency) — `onOpenPicker` hands control back to the caller,
+ *   which is expected to present {@link PickerList} (e.g. via the app's imperative sheet API).
+ *
+ * Fetches no data and owns no i18n: every string is a prop.
+ */
+export function Picker({
+  options,
+  selectedId,
+  onSelect,
+  onOpenPicker,
+  sheetThreshold = 5,
+  emptyLabel,
+  placeholderLabel,
+  triggerAccessibilityLabel,
+  optionAccessibilityLabel,
+  isLoading = false,
+}: Readonly<PickerProps>) {
+  if (options.length === 0) {
+    if (isLoading) {
+      return <Skeleton width={140} height={36} rounded="xl" />;
+    }
+    return <Text intent="caption">{emptyLabel}</Text>;
+  }
+
+  if (options.length < sheetThreshold) {
+    return (
+      <SegmentedControl
+        width="full"
+        value={selectedId ?? ''}
+        onChange={onSelect}
+        options={options.map((option) => ({
+          key: option.id,
+          label: option.label,
+          icon: option.icon,
+          accessibilityLabel: optionAccessibilityLabel?.(option) ?? option.label,
+        }))}
+      />
+    );
+  }
+
+  const selected = options.find((option) => option.id === selectedId);
+
+  return (
+    <ListRow
+      tone="muted"
+      pad="sm"
+      rounded="md"
+      onPress={onOpenPicker}
+      accessibilityLabel={triggerAccessibilityLabel}
+      title={selected?.label ?? placeholderLabel}
+      leading={selected?.icon}
+      trailing={<Text intent="caption">⌄</Text>}
+    />
+  );
+}
+
+/**
+ * Searchable list — the sheet-mode counterpart to `Picker`'s trigger row. The caller presents
+ * this itself (e.g. `sheet.present(({ dismiss }) => <PickerList onSelect={(id) => { onSelect(id);
+ * dismiss(); }} .../>)`), so this component has no Sheet dependency and stays in the plain
+ * `@lightbridge/ui` barrel.
+ *
+ * Filters over exactly the `options` it's given — it is the caller's responsibility to pass the
+ * *complete* set (not one page of it), otherwise search would silently hide items that were never
+ * fetched. This component performs no fetching itself, so it cannot detect that on its own.
+ */
+export function PickerList({
+  options,
+  selectedId,
+  onSelect,
+  searchPlaceholder,
+  noResultsLabel,
+  title,
+  resultCountLabel,
+  optionAccessibilityLabel,
+}: Readonly<PickerListProps>) {
+  const [query, setQuery] = useState('');
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return options;
+    return options.filter(
+      (option) =>
+        option.label.toLowerCase().includes(needle) ||
+        (option.description?.toLowerCase().includes(needle) ?? false)
+    );
+  }, [options, query]);
+
+  return (
+    <Stack gap="md" width="full">
+      {title ? <Text intent="bodyStrong">{title}</Text> : null}
+      <TextField
+        value={query}
+        onChangeText={setQuery}
+        placeholder={searchPlaceholder}
+        autoCapitalize="none"
+        autoCorrect={false}
+        accessibilityLabel={searchPlaceholder}
+      />
+      {resultCountLabel ? <Text intent="caption">{resultCountLabel}</Text> : null}
+      <Scroll style={{ maxHeight: 360 }}>
+        <Stack gap="xs" width="full">
+          {filtered.length === 0 ? (
+            <Text intent="caption">{noResultsLabel}</Text>
+          ) : (
+            filtered.map((option) => {
+              const isSelected = option.id === selectedId;
+              return (
+                <ListRow
+                  key={option.id}
+                  tone={isSelected ? 'muted' : 'transparent'}
+                  pad="sm"
+                  rounded="md"
+                  onPress={() => onSelect(option.id)}
+                  accessibilityLabel={optionAccessibilityLabel?.(option) ?? option.label}
+                  accessibilityState={{ selected: isSelected }}
+                  title={option.label}
+                  subtitle={option.description}
+                  leading={option.icon}
+                  trailing={isSelected ? <Text intent="bodyStrong">✓</Text> : undefined}
+                />
+              );
+            })
+          )}
+        </Stack>
+      </Scroll>
+    </Stack>
+  );
+}

--- a/packages/ui/src/components/picker/index.tsx
+++ b/packages/ui/src/components/picker/index.tsx
@@ -1,0 +1,2 @@
+export { Picker, PickerList } from './component';
+export type { PickerListProps, PickerOption, PickerProps } from './types';

--- a/packages/ui/src/components/picker/types.tsx
+++ b/packages/ui/src/components/picker/types.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from 'react';
+
+/** A single selectable row. `id` is the value handed back through `onSelect`. */
+export type PickerOption = {
+  id: string;
+  label: string;
+  description?: string;
+  /** Rendered in the leading slot both inline (SegmentedControl icon) and in the sheet list. */
+  icon?: ReactNode;
+};
+
+export type PickerProps = {
+  options: PickerOption[];
+  selectedId?: string;
+  onSelect: (id: string) => void;
+  /**
+   * Called instead of selecting inline once `options.length >= sheetThreshold`. The caller
+   * decides how to present the picker (this component has no opinion on sheets/modals/routes) —
+   * typically `sheet.present(() => <PickerList ... />)` via the app's existing imperative sheet
+   * API. Ignored below the threshold, where selection happens inline.
+   */
+  onOpenPicker: () => void;
+  /**
+   * Item-count threshold at/above which this renders a tap-to-open trigger row instead of an
+   * inline `SegmentedControl`. Defaults to 5 — below that, opening a sheet to choose between a
+   * couple of options is more friction than it saves.
+   */
+  sheetThreshold?: number;
+  /** Shown in place of the control when `options` is empty. */
+  emptyLabel: string;
+  /** Trigger-row label when nothing is selected yet (sheet mode only). */
+  placeholderLabel: string;
+  /** Accessibility label for the trigger row (sheet mode only). */
+  triggerAccessibilityLabel?: string;
+  /** Per-option accessibility label override; defaults to the option's own label. */
+  optionAccessibilityLabel?: (option: PickerOption) => string;
+  /** Shows a placeholder skeleton instead of the empty state while the first page is in flight. */
+  isLoading?: boolean;
+};
+
+export type PickerListProps = {
+  options: PickerOption[];
+  selectedId?: string;
+  onSelect: (id: string) => void;
+  searchPlaceholder: string;
+  noResultsLabel: string;
+  /** Optional heading rendered above the search field (e.g. "Select project"). */
+  title?: string;
+  /**
+   * Optional, already-formatted result-count caption (e.g. "12 projects"). Pass the caller's own
+   * i18n-pluralized string — this component does no counting or i18n of its own. Omit when the
+   * count would not add information (e.g. a list too short to ever reach the sheet).
+   */
+  resultCountLabel?: string;
+  optionAccessibilityLabel?: (option: PickerOption) => string;
+};

--- a/packages/ui/src/components/picker/types.tsx
+++ b/packages/ui/src/components/picker/types.tsx
@@ -53,4 +53,12 @@ export type PickerListProps = {
    */
   resultCountLabel?: string;
   optionAccessibilityLabel?: (option: PickerOption) => string;
+  /**
+   * Already-formatted notice shown near the search field when `options` is known to be an
+   * incomplete slice of a larger set (e.g. a fetch-everything loop hit its page ceiling). This
+   * component does no counting of its own — the caller decides when the set is incomplete (it
+   * already holds the server's total count) and passes the copy verbatim. Omit when the set is
+   * complete.
+   */
+  truncationNotice?: string;
 };

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -64,6 +64,8 @@ export { KeyValue, keyValueVariants } from './components/key-value';
 export type { KeyValueProps } from './components/key-value';
 export { ListRow, listRowVariants } from './components/list-row';
 export type { ListRowProps } from './components/list-row';
+export { Picker, PickerList } from './components/picker';
+export type { PickerListProps, PickerOption, PickerProps } from './components/picker';
 export { PageHeader, pageHeaderVariants } from './components/page-header';
 export type { PageHeaderProps } from './components/page-header';
 export { Pagination, paginationVariants } from './components/pagination';


### PR DESCRIPTION
## 1. Summary

This PR changes:

- **Fixes a correctness bug**: account/project selectors silently capped at 10 items, so an account's 11th project was unreachable with nothing on screen saying so.
- Adds `Picker`/`PickerList` to `packages/ui` and an app-level `EntityPickerField` + `usePickerSheet`, replacing three copy-pasted ~25-line `Button`-loop selectors.
- Adds `useAllAccounts`/`useAllProjects`, which page through the list endpoints to completion instead of taking only the first page.

It solves:

- The truncation finding from the friction audit on https://github.com/ADORSYS-GIS/converse-frontends/issues/79

---

## 2. Intent

The intent of this PR is:

> Make every project reachable, and stop maintaining the same selector three times.
>
> All five screen call sites used `useAccounts()` / `useProjects(accountId)` with no options, and both hooks default to `limit: 10` (`packages/hooks/src/accounts.ts:19`, `packages/hooks/src/projects.ts:76`). The selectors rendered a wrapped row of `Button` pills with no load-more, no count and no search. Item 11 was not a scroll away — it did not exist as far as the UI was concerned.
>
> Accounts were never really at risk (`accounts.ts:155` notes that under ADR-0006 one account is one person), but they share the same component now for consistency.

---

## 3. Scope

### In Scope

- `Picker` / `PickerList` in `packages/ui` — presentational only.
- `EntityPickerField` + `usePickerSheet` + option mappers in the app.
- `useAllAccounts` / `useAllProjects` and their `fetchAll*` helpers.
- Replacing the three duplicated selectors; i18n for search and the truncation notice.

### Out of Scope

- **`packages/hooks/src/pagination.ts` — deliberately untouched.** See the finding below; it needs its own change.
- The API-keys **list** pagination (`usePagination` + `<Pagination>`, #155) on the same screen. That mechanism is correct; this PR changes the account/project *selectors* above it, not the list.
- `api-key-settings-screen.tsx`, which still uses the old capped hooks.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
pnpm -r --if-present run test
pnpm lint
pnpm build
cd apps/self-service && npx tsc --noEmit ; echo "exit: $?"
cd packages/ui     && npx tsc --noEmit ; echo "exit: $?"
```

Results:

```text
tests:       252 passing — authz-rpc 14, hooks 56, self-service 182 across 33 suites
tsc:         exit 0 / 0 errors in BOTH apps/self-service and packages/ui
pnpm build:  turbo run build:web succeeded
lint:        137 problems, identical to the origin/main baseline (6 pre-existing
             rules-of-hooks errors in packages/ui/**/*.stories.tsx)
```

**The regression test is the point of this PR:** `picker.test.tsx` renders 15 options and proves item 15 — past any 10-item page — is reachable via search; `accounts.test.ts`/`projects.test.ts` prove `fetchAllAccounts`/`fetchAllProjectsForAccount` page past a 10- and 50-item first response and return every item. Without those, this bug comes back the moment someone touches the hooks.

Rebased onto `b60b554` (post-Batch-A) and re-verified by the orchestrator: both typecheckers and the build were re-run independently. `tsc` is included deliberately — it is the only gate that caught the type regression in #166, since Metro does not typecheck.

---

## 5. Screenshots / Evidence

**No screenshots** — Keycloak-gated, no auth stack. Behaviour is covered by the tests above. Stated rather than left blank.

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [x] Medium
* [ ] High

This replaces the primary navigation control on three screens and changes how the underlying data is fetched.

Potential risks:

* **Replacing one silent truncation with another** — a search box filtering only the first page would leave the bug intact behind a nicer control.
* **An unbounded fetch loop** if the server ever reports `hasNextPage: true` forever.
* Coupling views to the sheet system, which drags reanimated/gorhom into a layer that never had them.

Mitigation:

* `fetchAll*` pages until `pageInfo.hasNextPage` is false, so the picker filters a **complete** set — there is nothing left to truncate at realistic sizes.
* The loop is bounded: 50 rows per request, `MAX_*_PAGES = 20` (1000 items), with a comment explaining that the ceiling exists so a server bug cannot turn this into an unbounded fetch. **And when that ceiling is hit, the UI says so** — `pickerTruncationNotice(loaded, total, copy)` compares against the server's real `totalCount` and renders a warning in the picker. That path is tested in both directions. The one unacceptable outcome — quietly showing a partial list — does not occur at any size.
* `useSheet()` lives in a screen-only hook. An earlier revision put it in the view-facing component and broke five **pre-existing** view tests with `WorkletsError`, because `@lightbridge/ui/sheet` pulls in reanimated/gorhom and views were never coupled to that — only screens were. Caught by running the full suite rather than only the new tests.
* Under 5 options the picker renders inline via `SegmentedControl` rather than a sheet — no modal to choose between two projects — and that primitive brings correct group accessibility semantics (`accessibilityRole` + `accessibilityState={{selected}}`) that the hand-rolled `Button` loop lacked.
* `packages/ui`'s contract is preserved: `Picker`/`PickerList` fetch no data, import no i18n, and take every string as a prop. The truncation notice is a single optional string.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Refactoring
* [x] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Implemented by Claude Code (Sonnet subagent under an Opus 5 orchestrator) on behalf of @stephane-segning. The agent was told that silently filtering a truncated list was the one unacceptable outcome; the ceiling notice exists because a review pass found `totalCount` was being returned by the hook but never read by the UI.

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

**Human attestation pending @stephane-segning's review** — an agent must not tick the accountable human's boxes on their behalf.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [x] Product intent
* [ ] Edge cases

### Finding: #69's `hasMore` heuristic is obsolete

Investigating this bug established that **`@@paged` is live, not aspirational**. `packages/authz-rpc/generated/src/models.ts` defines a real `Page<T> { items, totalCount, pageInfo: { hasNextPage, ... } }`, and `packages/hooks/src/{accounts,projects}.ts` already consume `page.items` — while **discarding `totalCount` and `pageInfo` entirely**.

That contradicts the premise of #69, whose doc comment in `packages/hooks/src/pagination.ts` still reads that the backend "returns a bare array with no total-count," justifying a length-vs-limit heuristic and a documented edge case where the final Next lands on an empty page. None of that is necessary any more.

Deliberately **not** fixed here — `pagination.ts` has its own tests and a live consumer in the API-keys list, so it deserves a focused change rather than a drive-by. Worth its own ticket, which can also delete #69's "known limitation" note.

Also confirmed: these `list` procedures expose **no server-side text search** (equality `filters` and a `key=value` `where`/`or` DSL only, no `contains`), which is why search filters client-side over the fully-loaded set rather than querying.

Two things worth a second opinion: the **5-option inline/sheet threshold**, and the **truncation copy** — *"Not everything could be loaded, so search only covers what's shown here. Contact support if you can't find what you're looking for."* It avoids implying a load-more affordance or a search that reaches beyond what is loaded, since neither exists — but "contact support" may not be the right escape hatch for your users.
