### PR TITLE
docs(auth): diagram the auth flows and document the two-layer authorization model

### DIFF
--- a/docs/knowledge/auth-and-identity.md
+++ b/docs/knowledge/auth-and-identity.md
@@ -6,8 +6,12 @@
 > - `packages/hooks/src/auth/auth-types.ts`
 > - `packages/hooks/src/auth/use-keycloak-login.ts`
 > - `packages/hooks/src/auth/use-auth-session.ts`
-> - `packages/authz-rpc/src/transport.ts` (bearer header + refresh wiring)
+> - `apps/self-service/src/app/_layout.tsx` (refresh wiring into the RPC runtime)
+> - `packages/authz-rpc/src/runtime.ts` (bearer header + proactive refresh + 401-retry-once)
 > - `packages/authz-rpc/schema/authz.cstack` (API-key schema)
+>
+> For the authorization model (RBAC, permissions, server-side enforcement), see
+> `authorization-and-permissions.md`.
 
 ---
 
@@ -32,35 +36,40 @@ These are two completely separate credential types with different purposes and l
 ### Flow
 
 Authentication uses the **Authorization Code Flow with PKCE** (Proof Key for Code Exchange), implemented via
-`expo-auth-session`.
+`expo-auth-session`. Driven by `useKeycloakLogin()`, consumed in `apps/self-service/src/screens/login-screen.tsx`.
 
-```
-User clicks Login
-       │
-       ▼
-Frontend generates code_verifier + code_challenge (S256)
-       │
-       ▼
-Redirect to Keycloak /authorize?response_type=code&code_challenge=...
-       │  (user authenticates with Keycloak)
-       ▼
-Keycloak redirects back with authorization code
-       │
-       ▼
-Frontend exchanges code → tokens at Keycloak /token endpoint
-       │  (POST with code_verifier for PKCE validation)
-       ▼
-Frontend fetches user info from Keycloak /userinfo endpoint
-       │
-       ▼
-AuthSession stored (see Token Storage below)
+```mermaid
+sequenceDiagram
+    participant User
+    participant App as LoginScreen (useKeycloakLogin)
+    participant Browser as System browser (expo-web-browser)
+    participant KC as Keycloak
+
+    User->>App: Tap "Log in with SSO"
+    App->>App: generate code_verifier + code_challenge (S256)
+    App->>Browser: promptAsync() opens /authorize<br/>(response_type=code, PKCE, scopes incl. offline_access)
+    Browser->>KC: GET /authorize?...
+    KC->>User: Present login form
+    User->>KC: Submit credentials
+    KC-->>Browser: Redirect with authorization code
+    Browser-->>App: Deep link / redirect callback
+    App->>KC: POST /token (code + code_verifier)
+    KC-->>App: access_token, refresh_token, id_token, expires_in
+    App->>App: validate JWT audience (extractAndValidateAudience)
+    App->>KC: GET /userinfo (Bearer access_token)
+    KC-->>App: sub, name, preferred_username, email
+    App->>App: setAuthSession() + persistAuthSession()
+    App-->>User: Navigate to /home
 ```
 
 ### Key implementation details (from `use-keycloak-login.ts`)
 
 - **PKCE method:** `CodeChallengeMethod.S256`
 - **Response type:** `ResponseType.Code`
-- **Default scopes:** `['openid', 'profile', 'email']`
+- **Default scopes:** `['openid', 'profile', 'email', 'offline_access']`. The `offline_access` scope
+  is what makes the silent, long-lived refresh described below possible — it asks Keycloak for a
+  refresh token that outlives the browser SSO session, per the doc comment directly above the
+  `useAuthRequest()` call.
 - Discovery is performed via `AuthSession.useAutoDiscovery(config.issuer)` — all Keycloak endpoint URLs are resolved
   from the OIDC discovery document, not hardcoded.
 - The `useKeycloakLogin` hook exposes `promptAsync()` to trigger the login redirect and `isLoading` to track exchange
@@ -68,12 +77,92 @@ AuthSession stored (see Token Storage below)
 
 ### Token Refresh
 
-`refreshAccessToken()` in `use-keycloak-login.ts`:
+Refresh is **silent and refresh-token-based** — it is a background `POST /token` with
+`grant_type=refresh_token`, never a re-login redirect through Keycloak's login form. It is not one
+mechanism but two, both living in `AuthzRpcRuntime` (`packages/authz-rpc/src/runtime.ts`), which
+wraps every outgoing RPC `fetch` call:
+
+1. **Proactive refresh, ahead of expiry.** `tryProactiveRefresh()` runs before every RPC call and
+   checks `getExpiresAt()` (wired to `getLatestAuthSession().tokens?.expiresAt` in
+   `apps/self-service/src/app/_layout.tsx`); if the access token expires within
+   `TOKEN_REFRESH_BUFFER_MS` (60 s), it refreshes before the call goes out, so a normal request
+   essentially never hits a 401 for a merely-stale token.
+2. **Reactive retry-once, on an actual 401.** If a request still comes back `401` (proactive
+   refresh missed it, or the token was invalidated some other way), `authenticatedFetch()`
+   refreshes once and retries the *same* request with the new `Authorization` header — not by
+   re-invoking the runtime's `headers` callback (which already ran and built the now-stale
+   request), but by overwriting the header directly on the retried call.
+
+Both paths call the same `performRefresh()`, which de-duplicates concurrent refresh attempts via a
+shared `refreshPromise` and enforces a 60 s cooldown (`REFRESH_COOLDOWN_MS`) after a failed refresh
+so a dead refresh token doesn't trigger a refresh attempt on every single RPC call.
+
+`refreshAuth()` — the closure `AuthzRpcRuntime` calls into — is `handleRefreshAuth()` in
+`_layout.tsx`, which calls `refreshAccessToken()` (`use-keycloak-login.ts`):
 
 - Posts `grant_type=refresh_token` to the Keycloak token endpoint.
 - Re-fetches user info if the new access token is valid.
-- Persists the refreshed session to storage.
-- Returns `null` on any failure (caller is responsible for handling expired sessions).
+- Validates the JWT audience on the new access token the same way login does.
+- Persists the refreshed session to storage (`setAuthSession()` + `persistAuthSession()`).
+- Returns `null` on any failure; `handleRefreshAuth()` turns that into `false` for the runtime.
+
+**Session teardown only happens when the refresh token itself is rejected**, not on every failed
+call: `performRefresh()` invokes `onRefreshFailure()` — wired to `handleRefreshFailure()` in
+`_layout.tsx` — only when `refreshAuth()` itself resolves `false` (or throws). `handleRefreshFailure`
+force-clears the session (`clearPersistedAuthSession()`) and shows a "Session Expired" alert; the
+declarative `Stack.Protected` auth guard in `_layout.tsx` then redirects to `/login` on its own once
+`isAuthenticated` flips false. A single transient `401` that a retry-once resolves never reaches this
+path.
+
+```mermaid
+sequenceDiagram
+    participant Caller as Screen / hook
+    participant Runtime as AuthzRpcRuntime.authenticatedFetch
+    participant App as _layout.tsx (handleRefreshAuth)
+    participant KC as Keycloak /token endpoint
+
+    Caller->>Runtime: RPC call
+    Runtime->>Runtime: tryProactiveRefresh()<br/>expiresAt - now <= 60s?
+    alt token expiring within buffer
+        Runtime->>App: refreshAuth() -> handleRefreshAuth()
+        App->>KC: POST /token (grant_type=refresh_token)
+        KC-->>App: new access/refresh/id tokens
+        App->>App: persistAuthSession() + setAuthSession()
+        App-->>Runtime: true
+        Runtime->>Runtime: resetRefreshCooldown()
+    end
+    Runtime->>Runtime: fetch(Authorization: Bearer token)
+    Runtime-->>Caller: response
+```
+
+```mermaid
+sequenceDiagram
+    participant Runtime as AuthzRpcRuntime.authenticatedFetch
+    participant Backend as LightBridge AuthZ API
+    participant App as _layout.tsx (handleRefreshAuth)
+    participant KC as Keycloak /token endpoint
+
+    Runtime->>Backend: fetch(Authorization: Bearer token)
+    Backend-->>Runtime: 401 Unauthorized
+    alt not in refresh cooldown
+        Runtime->>App: refreshAuth() -> handleRefreshAuth()
+        App->>KC: POST /token (grant_type=refresh_token)
+        alt refresh token accepted
+            KC-->>App: new tokens
+            App-->>Runtime: true
+            Runtime->>Backend: retry original request once<br/>(new Authorization header)
+            Backend-->>Runtime: response
+        else refresh token rejected
+            KC-->>App: error
+            App-->>Runtime: false
+            Runtime->>Runtime: markRefreshFailed()<br/>(60s cooldown)
+            Runtime->>App: onRefreshFailure() -> handleRefreshFailure()
+            App->>App: clearPersistedAuthSession() + Alert("Session Expired")
+        end
+    else in cooldown
+        Runtime-->>Runtime: skip refresh, return the 401 as-is
+    end
+```
 
 ### Non-Dependency: `lightbridge-authz` Token-Exchange (ADR-0011)
 
@@ -103,6 +192,7 @@ Defined in `packages/hooks/src/auth/auth-types.ts`:
 | `expiresAt`    | `number` | No       | Epoch milliseconds at which `accessToken` expires           |
 | `tokenType`    | `string` | No       | Typically `"Bearer"`                                        |
 | `scope`        | `string` | No       | Space-separated OAuth2 scopes granted                       |
+| `audience`     | `string[]` | No     | `aud` claim(s) extracted from the access token, used for the JWT audience validation described below |
 
 ---
 
@@ -174,12 +264,20 @@ Authorization: Bearer <accessToken>
 The AuthZ API's `cratestack::AuthProvider` implementation (`CratestackAuthProvider`, backend-side)
 extracts and validates this same bearer/JWKS token exactly as before the RPC migration — it just
 sits in front of the RPC dispatcher instead of REST handlers now. On the frontend, the header is
-attached by `packages/authz-rpc/src/transport.ts`'s `rpcCall()`, which mirrors the previous REST
-client's proactive-refresh / 401-retry-once behavior:
+attached by the generated `CratestackRpcRuntime`'s `headers` callback, configured in
+`packages/authz-rpc/src/runtime.ts` (`AuthzRpcRuntime`'s constructor) — this is also the class that
+implements the proactive-refresh / 401-retry-once behavior described under "Token Refresh" above:
 
 ```typescript
-// packages/authz-rpc/src/transport.ts (abridged)
-headers.authorization = `Bearer ${token}`;
+// packages/authz-rpc/src/runtime.ts (abridged)
+headers: async () => {
+  const token = await this.authOptions.auth();
+  const headers: Record<string, string> = {};
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+},
 ```
 
 The Usage API is unaffected — it still authenticates the same way over plain REST, via
@@ -215,25 +313,38 @@ Note: the schema also declares a `keyHash` column, but it's marked `@server_only
 emitted on the wire and does not appear in the generated `ApiKey` TypeScript type at all.
 
 The secret is only returned **once**, at creation (`procedure.createApiKey`) or rotation
-(`procedure.rotateApiKey`), as an `ApiKeySecret` object. Unlike the pre-migration REST response,
-this is **flat** — the `ApiKey` fields and `secret` sit side by side, not nested under an `api_key`
-key (the schema's own comment explains why: `cratestack-pg` 0.4.9 can't reference a model type by
-name inside a `type` block, so `ApiKeySecret` inlines every `ApiKey` field as a scalar instead of
-nesting the model):
+(`procedure.rotateApiKey`), as an `ApiKeySecret` object. As of `cratestack-pg` 0.4.13
+(cratestack/cratestack#147), this is **nested** — `apiKey` carries the full `ApiKey` model as its
+own object, with `secret` and `oauth2Url` as sibling scalars:
 
 ```json
 {
-  "id": "key_ghi789",
-  "projectId": "proj_def456",
-  "name": "My App Key",
-  "keyPrefix": "lb_ghi789...",
-  "status": "active",
-  "billingPlan": "standard",
-  "createdAt": "2025-03-30T10:00:00Z",
-  "updatedAt": "2025-03-30T10:00:00Z",
+  "apiKey": {
+    "id": "key_ghi789",
+    "projectId": "proj_def456",
+    "name": "My App Key",
+    "keyPrefix": "lb_ghi789...",
+    "status": "active",
+    "billingPlan": "standard",
+    "createdAt": "2025-03-30T10:00:00Z",
+    "updatedAt": "2025-03-30T10:00:00Z"
+  },
   "secret": "lb_ghi789fullsecretstringshownonce",
   "oauth2Url": null
 }
 ```
 
-The frontend displays this secret to the user at that moment; it is not stored by the frontend.
+This was flat on an earlier `cratestack-pg` (0.4.9–0.4.12): that version's `type`-block codegen
+couldn't reference a model type by name, so `ApiKeySecret` inlined every `ApiKey` field as a scalar
+instead of nesting the model (a real compiler limitation, not a design choice — see the schema
+comment directly above `type ApiKeySecret` in `packages/authz-rpc/schema/authz.cstack` for the
+`include_server_schema!` failure that motivated the workaround). It was un-flattened back to the
+nested shape once 0.4.13 lifted that limitation, which is what the schema — and therefore the wire
+format — currently declares. The two call sites that consume this response in the app,
+`apps/self-service/src/screens/api-key-create-screen.tsx` and
+`apps/self-service/src/screens/rotate-api-key-sheet.tsx`, only ever read the top-level `secret` and
+`oauth2Url` scalars, so neither needed a code change across that shape flip — but any future code
+reading `id`/`keyPrefix`/etc. from an `ApiKeySecret` result must go through `.apiKey`, not the
+top level.
+
+The frontend displays the secret to the user at that moment; it is not stored by the frontend.

--- a/docs/knowledge/authorization-and-permissions.md
+++ b/docs/knowledge/authorization-and-permissions.md
@@ -1,0 +1,239 @@
+# Authorization and Permissions
+
+> Sources:
+>
+> - `packages/hooks/src/rbac.ts` (client-side RBAC mirror)
+> - `packages/hooks/src/use-permissions.ts` (`usePermissions()` hook)
+> - `packages/hooks/src/auth/jwt-utils.ts` (`getJwtRoles()`)
+> - `packages/authz-rpc/schema/authz.cstack` (server-side `@@allow` policies and procedure comments —
+>   the closest thing to backend source available from this repo)
+> - `apps/self-service/src/screens/api-key-create-screen.tsx`,
+>   `apps/self-service/src/screens/project-settings-screen.tsx` (concrete client/server gap examples)
+>
+> For authentication (login, tokens, refresh), see `auth-and-identity.md`.
+
+---
+
+## Two layers, one source of truth
+
+This app makes an authorization decision twice for most actions: once in the UI, to decide whether
+to show a control at all, and once — always — on the server, when the RPC call actually lands. The
+two layers are **not symmetric**:
+
+- **Client-side RBAC mirror** (`packages/hooks/src/rbac.ts`) is a pure, dependency-free re-encoding
+  of the backend's coarse role → permission mapping. It exists purely so the UI can hide/disable
+  controls the caller almost certainly can't use. It is **never consulted by the server** and
+  **cannot grant anything** — it can only get a show/hide decision wrong.
+- **Server-side enforcement** is the actual authorization boundary: a coarse RBAC permission gate
+  first, then, depending on the RPC verb, either a per-row `@@allow` policy (generic model CRUD) or
+  a hand-written SQL check inside a procedure (everything else).
+
+The client mirror only ever implements the first half of the server's decision. The gap between
+"the coarse permission says yes" and "the server's row-level/procedure-level check says yes" is
+real, currently unclosed, and documented below with a concrete example already called out in the
+app's own code comments.
+
+---
+
+## Layer 1: Client-side RBAC mirror (UI convenience, not a security boundary)
+
+`packages/hooks/src/rbac.ts` opens with this doc comment, worth quoting verbatim because it is the
+authoritative statement of what this layer is for:
+
+> Client-side mirror of `lightbridge-authz-core::authz`... This is a *UI convenience*, not a
+> security boundary — the backend is the source of truth and still enforces every permission
+> server-side. Getting this out of sync only shows/hides the wrong control; it can never grant
+> access the server wouldn't otherwise allow.
+
+### `ALL_PERMISSIONS`
+
+A flat, ordered array of 28 permission strings, grouped by resource:
+
+| Resource | Count | Permissions |
+| -------- | ----- | ----------- |
+| `account` | 5 | `create`, `read`, `update`, `delete`, `disable` |
+| `project` | 6 | `create`, `read`, `update`, `delete`, `disable`, `member` |
+| `apikey`  | 7 | `create`, `read`, `update`, `delete`, `revoke`, `rotate`, `validate` |
+| `budget`  | 10 | `read`, `self-refill`, `review`, `grant`, `revoke`, `audit-read`, `policy-read`, `policy-write`, `policy-simulate`, `policy-activate` |
+
+The `Permission` TypeScript type is `(typeof ALL_PERMISSIONS)[number]` — derived from the array, not
+declared independently, so the two can't drift apart inside this file. The **order** matters too:
+the doc comment states this array mirrors the backend's `Permission::ALL` in the same declaration
+order specifically so wildcard expansion (below) produces the same set on both sides.
+
+### `DEFAULT_ROLE_PERMISSIONS`
+
+The built-in role → grant mapping, used whenever the backend has no
+`oauth2.rbac.role_permissions` override configured:
+
+```typescript
+export const DEFAULT_ROLE_PERMISSIONS: Record<string, string[]> = {
+  'lightbridge-admin': ['*'],
+  'lightbridge-editor': ['account:read', 'project:*', 'apikey:*'],
+  'lightbridge-viewer': ['account:read', 'project:read', 'apikey:read'],
+};
+```
+
+### Wildcard expansion (`expandGrant`)
+
+- `'*'` expands to **every** entry in `ALL_PERMISSIONS`.
+- `'resource:*'` expands to every entry whose resource prefix matches.
+- A literal grant (`'account:read'`) expands to itself if it's a real permission, otherwise to
+  nothing — unknown grants never widen access.
+
+### `usePermissions()`
+
+```typescript
+// packages/hooks/src/use-permissions.ts
+const roles = getJwtRoles(accessToken); // 'lightbridge_api_roles' claim, JSON array or space-delimited string
+return permissionsForRoles(roles); // -> Set<Permission>, memoized on accessToken
+```
+
+Screens call `has('resource:verb')` off this hook to decide whether to render a control at all —
+for example `apps/self-service/src/screens/home-screen.tsx` (`canCreateKey={has('apikey:create')}`),
+`account-settings-screen.tsx` (`canUpdate`/`canDelete`/`canDisable`), and
+`project-settings-screen.tsx` (`canCreate`/`canUpdate`/`canDelete`/`canDisable`/`canManageMembers`).
+
+```mermaid
+flowchart TD
+    A[Access token] --> B["getJwtRoles(token)<br/>reads 'lightbridge_api_roles' claim"]
+    B --> C["permissionsForRoles(roles, DEFAULT_ROLE_PERMISSIONS)"]
+    C --> D["expandGrant() per role's grants:<br/>'*' / 'resource:*' / literal"]
+    D --> E["Set&lt;Permission&gt;"]
+    E --> F["has('resource:verb') via usePermissions()"]
+    F --> G[Screen shows or hides a control]
+    G -.this is where the client mirror stops.-> H([Server decides independently, see Layer 2])
+```
+
+---
+
+## Layer 2: Server-side enforcement (the actual boundary)
+
+Everything below is read from procedure and `@@allow` comments in
+`packages/authz-rpc/schema/authz.cstack` — the schema this frontend's RPC client is generated
+from, and the closest artifact to backend source available in this repo. The backend crate itself
+(`lightbridge-authz-rest`'s `rpc_authorize.rs`) is out of this repo's scope; where the schema
+comments cite it by name, this doc does too, without claiming to have read it directly.
+
+Every RPC call passes a **coarse RBAC permission gate** first (the same role → permission shape as
+Layer 1, but authoritative). What happens after that gate depends on the kind of verb:
+
+- **Generic model CRUD verbs** (`model.Account.*`, `model.Project.*`, `model.ApiKey.*`,
+  `model.ProjectMember.*`) additionally get a **per-row `@@allow` policy**, declared directly in the
+  schema. For example:
+  - `Project`: `@@allow("delete", isDefault != true && account.id == auth().id)` — you can only
+    delete a project you own, and never the account's default project.
+  - `ApiKey`: `@@allow("read", project.account.id == auth().id || project.members.some.accountId == auth().id)`
+    — readable by the owning account or any project member.
+  - `Account.create`/`Account.delete` and `ApiKey.create` have **no** `@@allow` at all — they're
+    unconditionally denied at the RBAC layer and only reachable through dedicated procedures below.
+- **Hand-written procedures** (`createApiKey`, `rotateApiKey`, `addProjectMember`,
+  `removeProjectMember`, `setProjectMemberRole`, `disableAccount`, `activateBudgetPolicy`, ...) only
+  declare `@allow(auth() != null)` at the schema level — "authenticated caller", nothing more. Real
+  authorization is either:
+  - hand-written SQL inside the procedure (e.g. `createApiKey` and the roster mutations require the
+    caller to own the project's account or hold a `project_members` row with `role == "lead"` — a
+    compound condition the schema's `@@allow` predicate language cannot express, per the comments on
+    the `Project`/`ProjectMember` models), or
+  - the coarse RBAC gate alone, with no per-row check at all (e.g. every budget procedure:
+    `activateBudgetPolicy`'s comment states plainly "there is no per-tenant ownership check here...
+    the real authorization is entirely the coarse `budget:policy-activate` RBAC gate", because
+    budget policy is a single platform-wide singleton, not owned by any account).
+
+```mermaid
+flowchart TD
+    A[RPC call arrives] --> B{"Coarse RBAC permission gate<br/>(role-to-permission, authoritative)"}
+    B -- caller lacks permission --> Z[403 Forbidden]
+    B -- caller has permission --> C{Verb kind}
+    C -- "generic model verb<br/>(Account / Project / ApiKey / ProjectMember)" --> D["@@allow row policy<br/>(authz.cstack)"]
+    D -- predicate false --> Z
+    D -- predicate true --> E[Allowed]
+    C -- "hand-written procedure<br/>(createApiKey, addProjectMember, ...)" --> F["@allow(auth() != null)<br/>authenticated only"]
+    F --> G["hand-written SQL check<br/>(e.g. lead-only) OR none<br/>(budget procedures rely on the gate alone)"]
+    G -- check fails --> Z
+    G -- check passes / no extra check --> E
+```
+
+---
+
+## Where the client mirror stops: the per-row gap
+
+`usePermissions()` only ever evaluates the coarse role → permission mapping, client-side, from the
+JWT `lightbridge_api_roles` claim. It has no way to evaluate a per-row `@@allow` predicate or a hand-written SQL
+check — both require data the client either doesn't have (the full `project_members` roster) or
+would need an extra round-trip to fetch (`listProjectRoster`) before it could even attempt the
+check itself. So the client mirror necessarily stops one layer short of what the server actually
+decides.
+
+The clearest illustration of this gap is already called out in the app's own code, not something
+this doc is inferring — `apps/self-service/src/screens/api-key-create-screen.tsx`:
+
+```typescript
+const { has } = usePermissions();
+// Only project leads may mint keys on a non-free plan; everyone else is pinned to `free`.
+// Note this is the coarse capability only — the server additionally requires the caller to own
+// the project's account or hold `role: 'lead'` on it, so a `403` is still possible here.
+const canChoosePlan = has('project:member');
+```
+
+`project:member` is granted to `lightbridge-editor` via the `project:*` wildcard in
+`DEFAULT_ROLE_PERMISSIONS`. So **any** editor — lead or plain member — sees the non-free plan picker
+in this screen; only the ones who are actually project leads (or the account owner) will have
+`createApiKey`'s hand-written SQL check accept the mutation.
+
+```mermaid
+sequenceDiagram
+    participant UI as ApiKeyCreateScreen
+    participant Client as usePermissions()
+    participant RPC as createApiKey procedure
+    participant SQL as hand-written lead check
+
+    UI->>Client: has('project:member')
+    Client-->>UI: true (editor role, project:* wildcard)
+    UI->>UI: show non-free plan picker
+    Note over UI: caller is a plain project member, not lead
+    UI->>RPC: createApiKey({ projectId, billingPlan: "paid" })
+    RPC->>SQL: caller owns project's account OR role == "lead"?
+    SQL-->>RPC: false
+    RPC-->>UI: 403 Forbidden
+```
+
+The same class of gap applies to `project-settings-screen.tsx`'s
+`canManageMembers={has('project:member')}` — inferred here from combining the same
+`DEFAULT_ROLE_PERMISSIONS` wildcard with the `Project`/`ProjectMember` schema comments describing
+`addProjectMember`/`removeProjectMember`/`setProjectMemberRole` as lead-only, since that call site
+carries no explicit comment of its own (unlike the `api-key-create-screen.tsx` case above): an
+editor sees the "manage members" control regardless of whether they hold `role: "lead"` on that
+specific project, and a non-lead editor's roster mutation will be rejected server-side the same way.
+
+---
+
+## Gotcha: a bare `'*'` grant silently widens with every new resource
+
+`DEFAULT_ROLE_PERMISSIONS['lightbridge-admin']` is `['*']`, which `expandGrant()` resolves to
+**the entire current contents of `ALL_PERMISSIONS`** — not a fixed snapshot. Any permission added to
+that array is automatically included in every existing `'*'` grant, whether or not anyone reviewed
+that specific role for that specific new capability.
+
+This already happened once, and `rbac.ts`'s own comment records it happening:
+
+> NOTE ON `budget:*`: `lightbridge-admin`'s bare `'*'` grant now also expands to the ten `budget:*`
+> permissions added alongside `ALL_PERMISSIONS` above, including `budget:policy-activate`. That is
+> unreviewed here on purpose — which role(s) should carry `budget:self-refill` and the other budget
+> permissions is still open in ADORSYS-GIS/lightbridge-authz#294, so `editor`/`viewer` deliberately
+> do NOT get any `budget:*` grant yet.
+
+`budget:policy-activate` gates `activateBudgetPolicy` — a platform-wide operation that overwrites
+which budget policy revision is live for every tenant at once (see the procedure comment in
+`authz.cstack`). Nothing in this app's UI calls it or surfaces a control for it (confirmed by
+grepping the app and `packages/hooks`/`packages/authz-rpc` for `policy-activate`/`policyActivate` —
+the only hits are the schema comments and `rbac.ts` itself); the product deliberately does not
+expose it here. Any `lightbridge-admin`-permissioned caller of this frontend's RPC client can still
+invoke it directly, though, since the *server-side* RBAC gate — not this app's UI — is what actually
+grants or denies the call.
+
+**Lesson for future permission additions:** extending `ALL_PERMISSIONS` for an unrelated feature is
+not additive-only from a review standpoint. Every bare `'*'` grantee gains the new permissions for
+free; if a role shouldn't get a new resource's permissions, both this file and the backend's
+`Permission::ALL` mirror have to switch that role from a wildcard to an explicit permission list —
+there is no way to carve out an exception while keeping the wildcard.


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Rewrites the inaccurate parts of `docs/knowledge/auth-and-identity.md` and adds three mermaid sequence diagrams (login, proactive refresh, reactive 401-retry with its failure branch).
- Adds `docs/knowledge/authorization-and-permissions.md` with three diagrams covering the client RBAC mirror, server-side enforcement, and the structural gap between them.
- **Documentation only.** No code, test or config file touched.

It solves:

- Continues the auth-documentation work from #144 (delivered in #152), which added the ADR-0011 token-exchange non-dependency section that this PR preserves and builds around.
- Source of truth for the token-exchange material: [lightbridge-authz ADR-0011](https://github.com/ADORSYS-GIS/lightbridge-authz/blob/main/docs/adr/0011-authz-issues-a-full-oidc-token-object.md).
- The repo had 13 knowledge docs and **zero diagrams**, and the auth doc carried five claims that no longer match the code.

---

## 2. Intent

The intent of this PR is:

> Make the auth and authorization model legible, and correct what had drifted.
>
> The authorization half was previously undocumented entirely. That matters more than the diagrams: the client-side RBAC mirror is **a UI convenience, never a security boundary**, and it mirrors only the server's *coarse* permission gate. It structurally cannot evaluate per-row checks like "am I lead on *this* project," which is why some controls appear for callers the server will reject. That gap is now written down instead of being rediscovered.

---

## 3. Scope

### In Scope

- `docs/knowledge/auth-and-identity.md`, `docs/knowledge/authorization-and-permissions.md`.

### Out of Scope

- CI/deploy, architecture layering, and the RPC/codegen pipeline — three sibling PRs cover those.
- Any code change, including the client/server permission gap this documents.

The RBAC material went into a new file rather than the existing one: it would have pushed `auth-and-identity.md` past 500 lines and mixed authorization into a document about authentication.

---

## 4. Verification

I verified this change by:

- [ ] Running automated tests
- [x] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Every claim was traced to source rather than carried over from the existing prose:

```
login flow      packages/hooks/src/auth/use-keycloak-login.ts, screens/login-screen.tsx
refresh         packages/authz-rpc/src/runtime.ts (tryProactiveRefresh, performRefresh,
                authenticatedFetch, cooldown/dedup)
                -> apps/self-service/src/app/_layout.tsx (handleRefreshAuth, handleRefreshFailure)
                -> packages/hooks/src/auth/use-keycloak-login.ts (refreshAccessToken)
RBAC mirror     packages/hooks/src/rbac.ts (28 permissions, 10 budget:*), use-permissions.ts
server gates    packages/authz-rpc/schema/authz.cstack — @@allow row policies on generic
                model verbs vs. hand-written SQL on procedures
```

**All 6 mermaid blocks were extracted and rendered with `mmdc`** to confirm they parse — a syntax error renders as a raw error block on GitHub, which is worse than plain text.

### Five stale claims corrected

1. Default Keycloak scopes were listed as `['openid','profile','email']`; the code also requests `offline_access`, which is what enables the long-lived silent refresh.
2. The request-flow section cited `packages/authz-rpc/src/transport.ts` — **that file no longer exists**; the logic lives in `runtime.ts`'s `AuthzRpcRuntime`.
3. The `AuthTokens` table omitted the `audience` field present in `auth-types.ts`.
4. `ApiKeySecret` was documented as a **flat** response with a matching JSON example. It is nested — `{ apiKey, secret, oauth2Url }` — since cratestack-pg 0.4.13 un-flattened it.
5. Token refresh was described as a bare `refreshAccessToken()` call, omitting the actual proactive-refresh-ahead-of-expiry, reactive-401-retry-once, and cooldown behaviour.

---

## 5. Screenshots / Evidence

Not applicable — the diagrams are the evidence, and GitHub renders mermaid natively in the diff.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* A diagram that encodes a stale claim is **worse** than no diagram, because it reads as authoritative.
* Documentation drifts again.

Mitigation:

* Every statement was verified against source before being drawn; the five corrections above are the result. Claims verified in code are distinguished from claims carried over.
* Each diagram cites the files it was derived from, so the next reader can re-check rather than trust.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [ ] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Written by Claude Code (Sonnet subagent under an Opus 5 orchestrator) on behalf of @stephane-segning. The agent was instructed to assume the existing prose was wrong and verify before drawing — that instruction is what produced the five corrections.

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

**Human attestation pending @stephane-segning's review** — an agent must not tick the accountable human's boxes on their behalf.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [x] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [ ] Product intent
* [ ] Edge cases

Specifically: the **refresh sequence diagrams**, since correcting claim 5 means they describe behaviour nobody had written down before — worth one careful read against `runtime.ts`.

The same two stale claims (`transport.ts`, flat `ApiKeySecret`) are duplicated in `docs/knowledge/api-reference.md`. That file is owned by a sibling docs PR and the corrections have been routed there rather than fixed here, to avoid two branches editing one file.
