### PR TITLE
docs(architecture): diagram the monorepo and correct the layering rules

### DIFF
--- a/docs/knowledge/architecture-conventions.md
+++ b/docs/knowledge/architecture-conventions.md
@@ -18,7 +18,8 @@ converse-frontends/
 ├── packages/         # Shared libraries consumed by apps
 │   ├── authz-rpc/    # Generated cratestack RPC client for accounts/projects/api-keys
 │   │                 # (do not hand-edit packages/authz-rpc/generated/ — codegen output)
-│   ├── api-rest/     # Generated REST client for the Usage API only (do not hand-edit)
+│   ├── api-rest/     # Generated REST client for the Usage API only (do not hand-edit).
+│   │                 # Currently unused — nothing imports it; see architecture.md.
 │   ├── api-native/   # Native API client utilities
 │   ├── hooks/        # Shared React hooks (auth, usage, projects, etc.)
 │   ├── i18n/         # Internationalisation resources
@@ -62,12 +63,14 @@ Since `cratestack-cli` 0.4.14 (issue #182), the generated runtime accepts a comp
 `links?: RpcLink[]` interceptor chain, threaded through as `AuthzRpcRuntimeOptions.links`
 (`packages/authz-rpc/src/runtime.ts`). `@cratestack/api`'s `createBatchLink()` plugs into it —
 an automatic scheduler that collapses concurrent unary calls into one `POST /rpc/batch` request —
-and is exercised in `packages/authz-rpc/src/runtime.test.ts`, but **is not wired into the app
-root** (`apps/self-service/src/app/_layout.tsx`'s `useAuthzRpcClient(config)` call omits `links`).
-Activating it end-to-end is tracked separately
-([converse-frontends#120](https://github.com/ADORSYS-GIS/converse-frontends/issues/120)); the
-backend RBAC gate for `POST /rpc/batch` was fixed to authorize per-frame in
-[lightbridge-authz#157](https://github.com/ADORSYS-GIS/lightbridge-authz/issues/157).
+and is exercised in `packages/authz-rpc/src/runtime.test.ts`. **Corrected from an earlier version
+of this doc, which said this was not wired into the app root:** it now is —
+`apps/self-service/src/app/_layout.tsx` constructs `authzBatchLink = createBatchLink()` at module
+scope (not per-render — the file's own comment explains this avoids constructing a fresh batcher on
+every render) and passes `links: [authzBatchLink]` into `useAuthzRpcClient(...)`. The tracking
+issues ([converse-frontends#120](https://github.com/ADORSYS-GIS/converse-frontends/issues/120),
+[lightbridge-authz#157](https://github.com/ADORSYS-GIS/lightbridge-authz/issues/157)) describe the
+work that made this possible; the code now reflects it landed.
 
 **Rule:** Never place application-specific business logic in `packages/`. Packages export reusable, app-agnostic code only.
 
@@ -75,37 +78,198 @@ backend RBAC gate for `POST /rpc/batch` was fixed to authorize per-frame in
 
 ## Application Layering
 
-Within `apps/self-service/src/`, follow this strict layering:
+Within `apps/self-service/src/`, follow this strict layering. **Corrected from an earlier version
+of this table:** views do not call hooks for data. Screens do. This was verified by reading every
+current `views/*.tsx` file's imports — see the note under the table.
 
 | Layer          | Directory                                                                        | Responsibility                                                                                                                    |
 | -------------- | -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | **Routes**     | `src/app/`                                                                       | Expo Router file-based routes. Thin — only renders the corresponding Screen.                                                      |
-| **Screens**    | `src/screens/`                                                                   | Assembles Views. May select which View to show but contains no business logic.                                                    |
-| **Views**      | `src/views/`                                                                     | Presentational components. Calls hooks for data; renders UI. Contains layout logic.                                               |
+| **Screens**    | `src/screens/`                                                                   | Owns data fetching (calls `packages/hooks`) and, where relevant, imperative sheet presentation (`useSheet`). Passes data and callbacks down to Views as props. Sheet-content components (`*-sheet.tsx`) live here too — they're screen-owned, not view-owned. |
+| **Views**      | `src/views/`                                                                     | Pure presentational components. Render UI from props only. May import **types** from `@lightbridge/hooks` (or its dependency-free subpaths, e.g. `@lightbridge/hooks/budget-tiers`) but never call a data-fetching hook. Must not import `@lightbridge/ui/sheet`. |
 | **Hooks**      | `packages/hooks/`                                                                | All data fetching, state management, and business logic. No JSX.                                                                  |
-| **API Client** | `packages/authz-rpc/` (accounts/projects/api-keys), `packages/api-rest/` (usage) | Auto-generated. Never edit by hand — `packages/authz-rpc/generated/` and `packages/api-rest/src/client/` are both codegen output. |
+| **API Client** | `packages/authz-rpc/` (accounts/projects/api-keys), `packages/api-rest/` (usage — currently unused, see `architecture.md`) | Auto-generated. Never edit by hand — `packages/authz-rpc/generated/` and `packages/api-rest/src/client/` are both codegen output. |
 
-**Dependency direction:** Routes → Screens → Views → Hooks → API Client
+**Dependency direction:** Routes → Screens → { Views (props only), Hooks (data), Sheet system (screens only) } → API Client
 
-**Example chain for the Usage feature (REST):**
+```mermaid
+flowchart TD
+    routes["app/ (routes)"]
+    screens["screens/\nowns hooks + useSheet"]
+    views["views/\npresentational only"]
+    ui["packages/ui"]
+    hooks["packages/hooks"]
+    apiclient["authz-rpc / api-rest"]
+
+    routes -->|renders one| screens
+    screens -->|"props + callbacks"| views
+    views --> ui
+    screens -->|"data fetching"| hooks
+    hooks --> apiclient
+    screens -.->|"types only, never a hook call"| views
+```
+
+Every `views/*.tsx` file was grepped for `@lightbridge/hooks` imports (2026-08-15): all matches are
+either `import type { ... }` or the pure, non-fetching `@lightbridge/hooks/budget-tiers` subpath
+(e.g. `formatMicroUsd` — see `apps/self-service/src/views/settings/budget-refill-view.tsx`, which
+has a comment explaining it imports that subpath specifically to avoid pulling in the full
+`@lightbridge/hooks` barrel and its `@lightbridge/authz-rpc`/`cborg` transitive chain, which Jest's
+resolver can't follow). Zero views call an actual data-fetching hook (`useQuery`, `useApiKeys`,
+etc.) — every one of those calls lives in a screen. `apps/self-service/src/screens/api-key-create-screen.tsx`
+is representative: it calls `useCreateApiKey`/`useEnsureDefaultAccount`/`useEnsureDefaultProject`/
+`usePermissions` directly and passes the results as props to the purely presentational
+`views/api-key-create-view.tsx`, which imports nothing from `@lightbridge/hooks` at all.
+
+**Example chain for the Usage feature (Grafana embed, not REST):**
 
 ```
 app/(tabs)/usage.tsx          → renders <UsageScreen />
-screens/usage-screen.tsx      → renders <UsageView />
-views/usage-view.tsx          → calls hooks, renders UI
-packages/hooks/src/usage.ts   → calls queryUsage()
-packages/api-rest/            → generated HTTP client (OpenAPI)
+screens/usage-screen.tsx      → reads useRuntimeConfig().usage, builds the dashboard URL
+views/usage-view.tsx          → presentational: receives embedUrl + onOpenExternal as props
+views/usage-dashboard-embed.web.tsx → renders an <iframe src={embedUrl}>
 ```
+
+This replaces the previous REST-based example (`packages/hooks/src/usage.ts` calling
+`queryUsage()`) — that file no longer exists in the tree. See `architecture.md`'s Usage flow for
+the full picture, including why `packages/api-rest` is currently unused.
 
 **Example chain for the API Keys feature (cratestack RPC):**
 
 ```
 app/api-keys/new.tsx                → renders <ApiKeyCreateScreen />
-screens/api-key-create-screen.tsx   → renders views, assembles state
-views/api-key-create-view.tsx       → calls hooks, renders UI
+screens/api-key-create-screen.tsx   → calls useCreateApiKey(), passes result to the view
+views/api-key-create-view.tsx       → presentational only; renders UI from props
 packages/hooks/src/api-keys.ts      → calls client.procedures.createApiKey({ args })
 packages/authz-rpc/                 → generated RPC client (POST /rpc/procedure.createApiKey)
 ```
+
+---
+
+## Two Load-Bearing Package Contracts
+
+These two rules aren't spelled out anywhere else in the docs, but breaking either one has already
+caused a real regression (see the second contract). Both exist for the same underlying reason:
+`views/` and `packages/ui` must be renderable in isolation, synchronously, with no provider tree —
+that's what makes them unit-testable standalone and reusable without dragging in the rest of the
+app.
+
+### `packages/ui` has zero i18n coupling and no data fetching
+
+Verified 2026-08-15 by reading `packages/ui/package.json` (no `i18next`/`react-i18next`, no
+`@tanstack/*`, no `axios` in `dependencies` or `devDependencies`) and by grepping
+`packages/ui/src` for `i18n`/`useTranslation`/`fetch(`/`axios`/`useQuery`: the only hits are code
+comments *about* the rule, not violations of it, e.g.:
+
+- `packages/ui/src/components/picker/component.tsx:22` — "Fetches no data and owns no i18n: every
+  string is a prop."
+- `packages/ui/src/components/confirm-dialog/component.tsx:41` — a fallback string "stays app-owned
+  since it's tied to i18n'd fallback copy."
+
+**Rule:** every user-visible string in `packages/ui` is a prop. The package never imports
+`react-i18next` and never calls `fetch`/`axios`/`useQuery` itself. This is what lets design-system
+work (adding a component, restyling a token) and feature work (wiring a screen to a real endpoint)
+proceed in parallel without both branches touching `packages/i18n`'s shared translation file.
+
+### `views/` must not import the sheet system; only `screens/` may
+
+`@lightbridge/ui/sheet` (the only way to reach `SheetProvider`/`useSheet`/`Sheet`) is a separate
+export subpath, deliberately **not** re-exported from `packages/ui`'s main barrel — see the
+`NOTE` comment at `packages/ui/src/index.ts:85`. Importing it pulls in `@gorhom/bottom-sheet` →
+`react-native-reanimated` → `react-native-worklets`: real native modules that need a running app
+runtime (`GestureHandlerRootView`, `SheetProvider`) to initialize. `views/` are unit-tested by
+rendering the component standalone with no such ancestor — a view that calls `useSheet()` crashes
+Jest with a `WorkletsError` (worklets never initialized) rather than a clean assertion failure.
+
+Verified 2026-08-15: grepping every file under `apps/self-service/src/screens` and
+`apps/self-service/src/views` for `useSheet`/`@lightbridge/ui/sheet` finds ten screen-layer hits
+(`delete-api-key-sheet.tsx`, `create-project-sheet.tsx`, `rotate-api-key-sheet.tsx`,
+`revoke-api-key-sheet.tsx`, `delete-account-sheet.tsx`, `delete-project-sheet.tsx`,
+`account-settings-screen.tsx`, `project-settings-screen.tsx`, `api-keys-screen.tsx`,
+`api-key-settings-screen.tsx`) and **zero** in `views/`.
+
+The entity-picker feature (see `architecture.md`) is the clearest worked example of the boundary in
+practice:
+
+- `apps/self-service/src/components/entity-picker-field.tsx` — used directly by three `views/`
+  modules — has "no Sheet/reanimated dependency on purpose" (its own doc comment) and takes a plain
+  `onOpenPicker: () => void` prop.
+- `apps/self-service/src/hooks/use-picker-sheet.tsx` — the thing that actually calls `useSheet()` —
+  is deliberately **screen-only**, per its own doc comment: "`EntityPickerField` (the view-facing
+  half of this feature) only ever receives a plain `onOpenPicker: () => void` callback; it has no
+  idea a sheet exists."
+
+**Rule:** if a component needs to open a sheet, the `useSheet()`/`sheet.present(...)` call goes in
+`screens/` (either the screen itself or a co-located hook like `use-picker-sheet.tsx`). The
+`views/` component underneath takes a plain callback prop and stays ignorant that a sheet exists.
+
+---
+
+## The Imperative Sheet System
+
+`SheetProvider` (`packages/ui/src/components/sheet/provider.tsx`) is mounted once at the app root —
+`AppSheetProvider` (`apps/self-service/src/navigation/app-sheet-provider.tsx`), inside
+`GestureHandlerRootView` in `apps/self-service/src/app/_layout.tsx` — and hosts a single reusable
+`@gorhom/bottom-sheet` `BottomSheetModal`. Any screen can then call `useSheet().present(render, options)`
+to show arbitrary content as a bottom sheet **without adding a route** — no new file under `app/`,
+no URL change. `present()` replaces whatever sheet is currently open; only one shows at a time.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Closed
+    Closed --> EntrySet: present(render, options)\n(screen calls useSheet().present)
+    EntrySet --> Open: content commits,\nmodalRef.present() fires
+    Open --> Open: present() again\n(replaces content)
+    Open --> Closed: dismiss() / drag down / backdrop tap\n(onClose fires, entry cleared)
+```
+
+The two-step `Closed → EntrySet → Open` transition (`packages/ui/src/components/sheet/provider.tsx`)
+is deliberate: `present()` sets React state synchronously, and only a `useEffect` that runs *after*
+that content commits calls `modalRef.current.present()` — so the sheet's first animated frame
+already has its body measured for dynamic sizing, instead of animating open on an empty sheet.
+
+### Sequence: a screen-owned mutation sheet (Delete API key)
+
+This is representative of every create/delete/rotate/revoke sheet in the app — only the mutation
+hook and the presentational view change.
+
+```mermaid
+sequenceDiagram
+    participant View as views/api-keys-list-view
+    participant Screen as screens/api-keys-screen
+    participant Sheet as SheetProvider
+    participant Content as screens/delete-api-key-sheet
+    participant Hook as useDeleteApiKey
+
+    View->>Screen: onDelete id, name
+    Screen->>Sheet: sheet.present renders DeleteApiKeySheet
+    Sheet-->>Content: mount, renders DeleteApiKeyView
+    Content->>Hook: mutateAsync id, projectId
+    Hook-->>Content: mutation settles
+    Content->>Sheet: onClose / dismiss
+    Sheet-->>View: sheet closes, list re-renders
+```
+
+### Sheet inventory
+
+Every current use of `useSheet().present(...)` in the app, and the screen that owns it (verified by
+grepping `apps/self-service/src/screens` for `sheet.present(` / `openPicker(`):
+
+| Action                    | Owning screen                                    | Sheet content component                         |
+| ------------------------- | -------------------------------------------------- | -------------------------------------------------- |
+| Create project             | `screens/project-settings-screen.tsx`              | `screens/create-project-sheet.tsx`                  |
+| Delete project             | `screens/project-settings-screen.tsx`              | `screens/delete-project-sheet.tsx`                  |
+| Delete account             | `screens/account-settings-screen.tsx`              | `screens/delete-account-sheet.tsx`                  |
+| Delete API key             | `screens/api-keys-screen.tsx`                      | `screens/delete-api-key-sheet.tsx`                  |
+| Rotate API key             | `screens/api-keys-screen.tsx`                      | `screens/rotate-api-key-sheet.tsx`                  |
+| Revoke API key             | `screens/api-keys-screen.tsx`                      | `screens/revoke-api-key-sheet.tsx`                  |
+| API key detail actions     | `screens/api-key-settings-screen.tsx`              | (inline `sheet.present(({dismiss}) => ...)`, no separate file) |
+| Account/project entity picker | `screens/api-keys-screen.tsx`, `screens/account-settings-screen.tsx`, `screens/project-settings-screen.tsx` (via `usePickerSheet()`) | `PickerList` (`packages/ui/src/components/picker`) |
+
+Notably, **creating an API key is not a sheet** — it navigates to a dedicated route
+(`app/api-keys/new.tsx` → `ApiKeyCreateScreen`) instead, because the create form is a focused,
+full-page flow (name entry → one-time secret display) rather than a quick in-context action. Every
+other lifecycle action (delete/rotate/revoke, project/account creation and deletion, entity
+selection) uses a sheet.
 
 ---
 
@@ -143,7 +307,7 @@ const { t } = useTranslation();
 | Subject                      | Convention                          | Example                               |
 | ---------------------------- | ----------------------------------- | ------------------------------------- |
 | Files (modules, components)  | `kebab-case`                        | `usage-view.tsx`, `auth-storage.ts`   |
-| Variables / functions        | `camelCase`                         | `useQueryUsage`, `loadStoredSession`  |
+| Variables / functions        | `camelCase`                         | `useApiKeys`, `loadStoredSession`     |
 | Types / Interfaces / Classes | `PascalCase`                        | `AuthSession`, `UsageQueryParams`     |
 | True constants               | `SCREAMING_SNAKE_CASE`              | `STORAGE_KEY`, `WEB_DB_NAME`          |
 | Interface names              | No `I` prefix                       | `UserService`, **not** `IUserService` |
@@ -191,33 +355,16 @@ Use **named exports** over default exports everywhere possible.
 
 **File:** `apps/self-service/src/app/(tabs)/usage.tsx`
 
-**Current state (as of codebase inspection):**
+**Current state, verified 2026-08-15 — rewritten since an earlier version of this doc, which
+described a "coming soon" placeholder and a `useQueryUsage` hook that no longer exist:**
 
-The route delegates to `UsageScreen` → `UsageView`. The current `UsageView` renders a **"coming soon" placeholder** only:
-
-```tsx
-// views/usage-view.tsx
-export function UsageView() {
-  const { t } = useTranslation();
-  return (
-    <ScreenShell title={t('usage.title')}>
-      <Stack gap="sm" align="center" justify="center" flex="grow">
-        <Text intent="eyebrow" align="center">
-          {t('usage.comingSoon')}
-        </Text>
-      </Stack>
-    </ScreenShell>
-  );
-}
-```
-
-The data-fetching hook (`useQueryUsage` in `packages/hooks/src/usage.ts`) **is** fully implemented and functional, but the view has not yet been wired to display the data. The hook:
-
-- Defaults to `scope = "project"`, last 30 days, `bucket = "1 day"`
-- Only fires when a current project is selected and the user is authenticated
-- Stores results reactively in `usageCollection` (TanStack DB live store)
-
-**Agent TODO:** When implementing the usage UI, import `useQueryUsage` or `useTokenUsage` from `packages/hooks` in the view, not the screen or route.
+The route delegates to `UsageScreen` → `UsageView` → `UsageDashboardEmbed`, and the feature is
+fully implemented — it embeds an external Grafana dashboard rather than fetching usage data through
+`packages/hooks`. See `architecture.md`'s "Usage flow" for the full walkthrough
+(`useRuntimeConfig().usage` → `buildUsageDashboardUrl()` → `<iframe>` on web / "open in Grafana" on
+native). There is no `packages/hooks/src/usage.ts` and no `useQueryUsage`/`useTokenUsage` in the
+current tree — do not reintroduce those names without first checking whether this feature has since
+moved back to an in-app query pipeline.
 
 ---
 
@@ -232,7 +379,17 @@ The data-fetching hook (`useQueryUsage` in `packages/hooks/src/usage.ts`) **is**
 
 ## Testing
 
-- Test framework: **Playwright** (E2E).
+**Corrected from an earlier version of this doc, which named Playwright:** there is no Playwright
+dependency or config anywhere in this repo (verified 2026-08-15 by grepping every `package.json`
+and searching for `playwright.config.*`). The actual, verified stack is:
+
+- `apps/self-service`: **Jest** + `jest-expo` + `@testing-library/react-native` (`pnpm --filter self-service test`). Screens and views are rendered standalone, per the layering rules above.
+- `packages/hooks`, `packages/authz-rpc`: **Vitest** (`test` script is `vitest run` in both).
+- `packages/ui`: no unit-test script; Storybook (`@storybook/react-native-web-vite`, `addon-a11y`) covers visual/interaction review instead.
+- No end-to-end test framework is present in this repo at all — there is no `e2e/` directory and no `*.spec.ts` Playwright/Cypress suite.
+
+Rules that still hold regardless of runner:
+
 - Unit tests: fast, isolated, no I/O, no network.
 - Integration tests: use real component interactions via dedicated test infrastructure.
 - 80%+ line coverage target on business logic; 100% on critical paths (auth, payment, validation).

--- a/docs/knowledge/architecture.md
+++ b/docs/knowledge/architecture.md
@@ -1,91 +1,124 @@
 # Architecture Overview — Converse-frontends
 
-> Sources: `AGENTS.md`, `apps/self-service/src/`, `packages/`, `openapi/`
+> Sources: `AGENTS.md`, `apps/self-service/src/`, `packages/*/package.json` + `src/`, `openapi/`
+> Verified against code at `main@8ea2b6b` (2026-08-15). See `architecture-conventions.md` for the
+> layering rules and the two load-bearing package contracts (`packages/ui` and the sheet-system
+> boundary) in detail.
 
 ---
 
 ## System Overview
 
-This repository is a **pnpm monorepo** containing the LightBridge self-service frontend — a React / React Native (Expo) application that serves as the self-service portal for Converse, an AI gateway platform.
+This repository is a **pnpm monorepo** (`lightbridge-ss`) containing the LightBridge self-service
+frontend — a React / React Native (Expo) application that serves as the self-service portal for
+Converse, an AI gateway platform.
 
 The system is a **static frontend** (no server-side rendering, no backend logic):
 
-- Compiled to a static web bundle via `expo export --platform web`
+- Compiled to a static web bundle via `expo export --platform web` (`apps/self-service`'s
+  `build:web` script)
 - Served by nginx as a static site
 - All business logic lives in the browser; the backend is LightBridge (external Rust service)
+- The one exception to "no other services" is the Usage tab, which embeds an external Grafana
+  dashboard in an iframe (see [Usage flow](#usage-flow) below) — the frontend still does no
+  server-side rendering itself, it just frames someone else's page.
 
 ---
 
-## Component Diagram
+## Monorepo Topology
 
+The dependency graph below is derived from each package's `dependencies`/`peerDependencies` in its
+`package.json`, cross-checked against real `import` statements (not just what's declared) — see
+"Verification" in the report for the exact commands. Two things this graph corrects relative to
+memory/assumption: `packages/hooks` depends on `@lightbridge/i18n` (for locale sync and translated
+mutation errors, e.g. `packages/hooks/src/projects.ts`), **not** on `@lightbridge/api-rest`; and
+`packages/ui` has **no** workspace dependencies at all — every `@lightbridge/*` string inside
+`packages/ui/src` is a comment, not an import (see the two-contracts section in
+`architecture-conventions.md`).
+
+```mermaid
+flowchart TD
+    app["apps/self-service"]
+    ui["packages/ui\n(design system, zero @lightbridge/* deps)"]
+    hooks["packages/hooks\n(data fetching, auth, business logic)"]
+    authzrpc["packages/authz-rpc\n(generated cratestack RPC client)"]
+    apinative["packages/api-native\n(clipboard, haptics)"]
+    i18n["packages/i18n\n(i18next config + resources)"]
+    apirest["packages/api-rest\n(generated OpenAPI REST client)"]
+
+    app --> ui
+    app --> hooks
+    app --> authzrpc
+    app --> apinative
+    app --> i18n
+
+    hooks --> authzrpc
+    hooks --> apinative
+    hooks --> i18n
 ```
-┌───────────────────────────────────────────────────────────────────────┐
-│                      self-service (Expo App)                          │
-│                                                                        │
-│  app/ (routes)                                                        │
-│    └─ screens/                                                        │
-│         └─ views/  ──── @lightbridge/ui (design system)               │
-│              └─ @lightbridge/hooks ──┬─── @lightbridge/authz-rpc      │
-│                   └─ @lightbridge/i18n│    (generated from             │
-│                                       │     authz.cstack, RPC)         │
-│                                       └─── @lightbridge/api-rest       │
-│                                            (generated from             │
-│                                             usage.backend.yaml, REST)  │
-└───────────────────────────────────────────────────────────────────────┘
-           │                                │
-           │ POST /rpc/{op_id}              │ REST + Bearer JWT
-           │ Bearer JWT, CBOR (prod)/        │
-           │ JSON (dev)                      │
-           ▼                                ▼
-  LightBridge AuthZ API          LightBridge Usage API
-  (cratestack-pg RPC transport;   (usage.backend.yaml)
-   schema: authz.cstack)
-           │
-           │ API Key issued to external clients
-           ▼
-  Converse AI Gateway  (api.ai.camer.digital/v1)
+
+`packages/api-rest` is generated from `openapi/usage.backend.yaml` but as of this writing **no
+package or app imports it** — not even `packages/hooks`. It is orphaned: the Usage tab it was
+presumably built for now embeds a Grafana dashboard instead (see below). It stays in the workspace
+and its `codegen` script still runs on `pnpm install`/`turbo run build:web` (per
+`architecture-conventions.md`), so it costs a codegen cycle but ships no code into the app bundle
+unless something starts importing it again.
+
+---
+
+## Component / Network Diagram
+
+```mermaid
+flowchart TB
+    subgraph frontend["self-service (Expo App)"]
+        routes["app/ (expo-router routes)"]
+        screens["screens/"]
+        views["views/"]
+        uipkg["packages/ui"]
+        hookspkg["packages/hooks"]
+        routes --> screens --> views --> uipkg
+        screens --> hookspkg
+    end
+
+    hookspkg -->|"POST /rpc/opId\nBearer JWT, CBOR (prod) / JSON (dev)"| authz["LightBridge AuthZ API\n(cratestack-pg RPC; schema authz.cstack)"]
+    frontend -->|"iframe src, same-site\nshared Keycloak SSO session"| grafana["Grafana\n(usage dashboard)"]
+    authz -->|"API Key issued to\nexternal clients"| gateway["Converse AI Gateway\n(api.ai.camer.digital/v1)"]
 ```
+
+The AuthZ RPC call originates in `packages/hooks` (screens call the hooks; see
+`architecture-conventions.md`'s layering section for why it's screens and not views). The Grafana
+iframe is embedded directly by `apps/self-service/src/views/usage-dashboard-embed.web.tsx` — there
+is no REST call and no `packages/hooks` involvement in the current Usage tab at all.
 
 ---
 
 ## Key Components
 
-| Component         | Package               | Responsibility                                                    | Tech Stack                                               |
-| ----------------- | --------------------- | ----------------------------------------------------------------- | -------------------------------------------------------- |
-| Self-service app  | `apps/self-service`   | Entry point, routing, screen assembly                             | Expo 54, React 19, Expo Router                           |
-| AuthZ RPC client  | `packages/authz-rpc`  | Generated cratestack RPC client (accounts/projects/api-keys)      | Hand-authored `.cstack` codegen, `cborg` (CBOR), `fetch` |
-| Usage REST client | `packages/api-rest`   | Auto-generated HTTP client from OpenAPI (usage-tracking API only) | `@hey-api/openapi-ts`                                    |
-| Shared hooks      | `packages/hooks`      | Data fetching, auth, business logic                               | TanStack Query, Zustand/TanStack DB                      |
-| Design system     | `packages/ui`         | Shared UI primitives, theming                                     | React Native, `cva`, `cn`                                |
-| i18n              | `packages/i18n`       | Translation files and config                                      | `react-i18next`                                          |
-| Native API utils  | `packages/api-native` | Mobile-specific API helpers                                       | React Native                                             |
+| Component          | Package                | Responsibility                                                       | Tech Stack                                                        |
+| ------------------- | ----------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Self-service app    | `apps/self-service`     | Entry point, routing, screen assembly, data-fetching wiring            | Expo 55, React 19, Expo Router                                        |
+| AuthZ RPC client    | `packages/authz-rpc`    | Generated cratestack RPC client (accounts/projects/api-keys)           | Generated by `@cratestack/cli` from `schema/authz.cstack`, `cborg` (CBOR) |
+| Usage REST client   | `packages/api-rest`     | Auto-generated HTTP client from `openapi/usage.backend.yaml`; **currently unused by the app** | `@hey-api/openapi-ts`, `axios`, `zod` |
+| Shared hooks        | `packages/hooks`        | Data fetching, auth, business logic — consumed by **screens**, not views | TanStack Query, TanStack DB (`@tanstack/react-db`) for reactive local stores |
+| Design system       | `packages/ui`           | Shared UI primitives, theming. No i18n coupling, no data fetching (see `architecture-conventions.md`) | React Native, `cva`, `clsx`/`tailwind-merge`, `@gorhom/bottom-sheet` (sheet subpath only) |
+| i18n                | `packages/i18n`         | Translation config and resources                                       | `i18next`, `react-i18next`                                            |
+| Native API utils    | `packages/api-native`   | Clipboard + haptics helpers                                            | `expo-clipboard`, `expo-haptics`                                      |
+
+Corrected from the previous version of this doc: the Tech Stack column no longer lists Zustand —
+nothing in this repo depends on it (`packages/hooks/package.json` has no `zustand` entry, and
+`packages/hooks/src/auth/auth-store.ts`, the one hand-rolled reactive store, uses
+`@tanstack/react-db`'s `createCollection`/`localOnlyCollectionOptions`, same as everywhere else).
 
 ---
 
 ## Layering (Strict Dependency Direction)
 
-```
-Routes (app/)
-  ↓ renders
-Screens (screens/)
-  ↓ assembles
-Views (views/)
-  ↓ calls
-Hooks (packages/hooks/)
-  ↓ calls
-API Client (packages/authz-rpc/ for accounts/projects/api-keys, packages/api-rest/ for usage)
-  ↓ HTTP (RPC or REST, per client)
-LightBridge Backend
-```
-
-**Rules:**
-
-- Routes render exactly one Screen. No logic, no hooks.
-- Screens assemble one or more Views. No direct API calls.
-- Views call hooks for data. No `fetch()` calls directly.
-- Hooks use `@tanstack/react-query` for all server state. No API calls in `useEffect`.
-- Both API clients are **always** auto-generated. Never hand-edit `packages/api-rest/src/client/`
-  or `packages/authz-rpc/generated/`.
+See `architecture-conventions.md` for the full layering diagram, the worked examples, and the two
+load-bearing contracts (`packages/ui`'s zero-i18n/zero-fetch rule and the views-must-not-import-the-
+sheet-system rule). The one-line summary: **Routes render a Screen. Screens own data fetching (call
+`packages/hooks`) and own sheet presentation (`useSheet`). Views are pure presentational components
+that receive data and callbacks as props** — this is the reverse of what an earlier version of this
+doc claimed ("views call hooks for data"); see the conventions doc for the code-level evidence.
 
 ---
 
@@ -93,32 +126,90 @@ LightBridge Backend
 
 ### Authentication flow
 
-1. App loads → reads `AuthSession` from storage (`loadStoredSession`)
-2. If no session → show Login screen → trigger Keycloak OAuth2/PKCE redirect
-3. Keycloak redirects back with auth code → frontend exchanges code for tokens
-4. Tokens stored in platform storage (IndexedDB on web, SecureStore on native)
-5. All subsequent API calls include `Authorization: Bearer <accessToken>`
+1. App loads → reads `AuthSession` from storage (`loadStoredSession`,
+   `packages/hooks/src/auth/auth-storage.ts`)
+2. If no session → show Login screen → trigger Keycloak OAuth2 Authorization Code + PKCE (S256)
+   redirect (`packages/hooks/src/auth/use-keycloak-login.ts`, `usePKCE: true`,
+   `codeChallengeMethod: CodeChallengeMethod.S256`)
+3. Keycloak redirects back with an auth code → frontend exchanges it for tokens
+4. Tokens stored in platform storage: `expo-secure-store` on native, IndexedDB on web
+   (`Platform.OS === 'web'` branch in `auth-storage.ts`)
+5. All subsequent RPC calls include `Authorization: Bearer <accessToken>`
 
 ### API key management flow
 
-1. Authenticated user navigates to API Keys tab
-2. `useQuery` hook calls `client.apiKeys.list(...)` (`packages/authz-rpc`, generated client
-   instance), which dispatches `POST /rpc/model.ApiKey.list` with
-   `{ limit, offset, filters: [{ key: "projectId", value }] }`
-3. User creates key → `client.procedures.createApiKey({ args })` dispatches
-   `POST /rpc/procedure.createApiKey` with `{ args: { projectId, name, expiresAt?, billingPlan } }`
-   — the server generates the id, hashes the secret, and validates the billing plan; the client
-   never constructs these itself
-4. Response is a flat `ApiKeySecret` — the one-time `secret` field sits alongside the key's own
-   fields, shown to the user immediately
-5. User copies secret for use in their external AI client
+1. Authenticated user navigates to the API Keys tab (`ApiKeysScreen`,
+   `apps/self-service/src/screens/api-keys-screen.tsx`)
+2. The **screen** calls `useApiKeys(projectId, { offset, limit })`
+   (`packages/hooks/src/api-keys.ts`), which dispatches `POST /rpc/model.ApiKey.list` — the
+   resulting `items`/`isLoading` are passed down as props to `ApiKeysListView`
+3. Create: the screen navigates to a dedicated route (`/api-keys/new`,
+   `apps/self-service/src/app/api-keys/new.tsx` → `ApiKeyCreateScreen`) rather than opening a
+   sheet — the only one of the four lifecycle actions that isn't a sheet. That screen calls
+   `useCreateApiKey()`, which dispatches `POST /rpc/procedure.createApiKey` with
+   `{ args: { projectId, name, expiresAt?, billingPlan } }`; the server generates the id, hashes
+   the secret, and validates the billing plan
+4. Delete / Rotate / Revoke: the screen calls `sheet.present(...)` with `DeleteApiKeySheet` /
+   `RotateApiKeySheet` / `RevokeApiKeySheet` (all in `apps/self-service/src/screens/`), each of
+   which owns its own mutation hook (`useDeleteApiKey`, `useRotateApiKey`, `useRevokeApiKey`) and
+   composes a presentational `views/` component for the confirmation UI. See "The imperative sheet
+   system" in `architecture-conventions.md` for the mechanics.
+5. A create/rotate response is a flat `ApiKeySecret` — the one-time `secret` (and, since #162,
+   `oauth2Url`) sits alongside the key's own fields, shown to the user immediately via
+   `apps/self-service/src/components/one-time-secret-card.tsx`
 
-### Usage data flow
+Both delete and revoke are live in the UI today (`ApiKeysListView` wires `onRevoke`/`onRotate`
+alongside the existing delete action) — an earlier ADR (0001) treated rotation as reserved-but-not-
+built and left the delete-vs-revoke product question open; both are now implemented side by side.
 
-1. User navigates to Usage tab (currently renders "coming soon" placeholder)
-2. `useQueryUsage` hook queries `POST /usage/v1/usage/query`
-3. Response `UsageSeriesPoint[]` stored in local reactive store (`usageCollection`)
-4. `useTokenUsage` hook provides live-queried data to the view via `@tanstack/react-db`
+### Usage flow
+
+The Usage tab does **not** call `packages/api-rest` or any `packages/hooks` query — this is a full
+rewrite since the previous version of this doc, which described a TanStack Query +
+`usageCollection` pipeline that no longer exists (there is no `packages/hooks/src/usage.ts` in the
+current tree).
+
+1. `UsageScreen` (`apps/self-service/src/screens/usage-screen.tsx`) reads `useRuntimeConfig().usage`
+   — an optional `{ grafanaUrl, dashboardPath }` sourced from `EXPO_PUBLIC_GRAFANA_URL` /
+   `EXPO_PUBLIC_GRAFANA_USAGE_DASHBOARD_PATH` (dev) or `/config.json` (prod web)
+2. If unset, the tab shows a plain "unavailable" empty state — the tab itself is also hidden from
+   navigation in that case (referenced in the screen's own comment; the responsive-tab-bar is
+   outside this doc's two files)
+3. If set, `buildUsageDashboardUrl()` (`apps/self-service/src/screens/usage-dashboard-url.ts`)
+   builds a Grafana URL with `orgId`, `theme` (matching the app's light/dark scheme), a fixed
+   30-day window, and `kiosk` (chrome-stripped) for the embed
+4. Web: `UsageDashboardEmbed` (`.web.tsx` variant) renders that URL in an `<iframe>`. Native: there's
+   no `react-native-webview` dependency, so the same component instead shows a card with an
+   "open in Grafana" button that opens the system browser
+5. Per-user scoping happens entirely on the Grafana side via the shared Keycloak SSO session — no
+   user id is placed in the URL, and no token is either
+6. An explicit "open in Grafana" action is always shown next to the embed, because a cross-origin
+   iframe blocked by `X-Frame-Options` renders blank with no catchable JS error
+
+No ADR records why this replaced the REST/TanStack-Query pipeline — the rationale is unrecorded in
+this repo; commit `d5c9467` ("embed per-user Grafana usage dashboard in a Usage tab") is the point
+this landed.
+
+### Entity picker flow (account/project selection)
+
+Introduced in #167 to fix a hard 10-item cap on the account/project selectors. See
+`architecture-conventions.md` for how this interacts with the sheet-system boundary — it is the
+concrete example the "views must not import the sheet system" rule is built around.
+
+1. Screen calls `useAllAccounts()` / `useAllProjects(accountId)`
+   (`packages/hooks/src/{accounts,projects}.ts`), which page through `accounts.list`/
+   `projects.list` until the server's `Page<T>` envelope reports `hasNextPage: false` (bounded by a
+   `MAX_*_PAGES` safety ceiling)
+2. Screen maps the results to `PickerOption[]` via `toAccountPickerOptions`/
+   `toProjectPickerOptions` (`apps/self-service/src/components/entity-picker-field.tsx`)
+3. Below a configurable `sheetThreshold`, `EntityPickerField` renders an inline
+   `packages/ui`-native picker. At/above it, selecting the field calls `onOpenPicker` — a plain
+   callback the view holds with no idea a sheet exists
+4. The **screen** wires `onOpenPicker` to `usePickerSheet()`
+   (`apps/self-service/src/hooks/use-picker-sheet.tsx`), which calls `useSheet().present(...)` with
+   a `PickerList` (search + scroll, `packages/ui`) as the sheet body
+5. If the fetch-all loop hit its page ceiling, the screen also passes a `truncationNotice` so the
+   sheet says the list may be incomplete instead of silently presenting a partial set as whole
 
 ---
 
@@ -127,23 +218,36 @@ LightBridge Backend
 | Decision                              | Rationale                                                                                                                                                                                      |
 | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Expo Router (file-based routing)      | Enables web + native from single codebase; routes map directly to file paths                                                                                                                   |
-| Auto-generated API clients            | The schema (OpenAPI for usage, `authz.cstack` for accounts/projects/api-keys) is the single source of truth; codegen eliminates drift between frontend types and backend contracts             |
+| Screens own data fetching, not views  | Keeps `views/` renderable standalone under Jest with no provider tree — see `architecture-conventions.md`'s layering section and the sheet-boundary contract, which share this rationale       |
+| Auto-generated API clients            | The schema (`authz.cstack` for accounts/projects/api-keys; OpenAPI for the currently-unused usage REST client) is the intended single source of truth; codegen eliminates drift from the backend contract when a client is actually wired up |
 | Schema-driven RPC for AuthZ, not REST | Backend migrated to `cratestack-pg` (ADR-0003 in `lightbridge-authz`), which has no OpenAPI generation — `packages/authz-rpc` hand-authors codegen against the copied `.cstack` schema instead |
-| TanStack Query for server state       | Declarative, caching-aware, no global store pollution                                                                                                                                          |
+| Grafana iframe embed for Usage        | Replaced an earlier TanStack Query + REST pipeline (see Usage flow above). Rationale for the switch is not recorded in an ADR or commit body beyond the feature commit itself                 |
+| TanStack Query for server state       | Declarative, caching-aware, no global store pollution                                                                                                                                           |
+| TanStack DB for reactive local state  | `packages/hooks/src/auth/auth-store.ts` and other collections use `@tanstack/react-db`'s `createCollection`; nothing in the repo depends on Zustand despite an earlier version of this table claiming otherwise |
 | Platform-specific token storage       | `expo-secure-store` on native (hardware-backed), IndexedDB on web — appropriate security per platform                                                                                          |
 | Static export + nginx                 | Simple, LTS-stable serving; no Node.js runtime required in production                                                                                                                          |
-| WireMock for local dev                | Allows frontend development without running the real Rust/Postgres backend                                                                                                                     |
+| WireMock for local dev                | Allows frontend development without running the real Rust/Postgres backend (`compose.yml`)                                                                                                     |
+| `@gorhom/bottom-sheet` over `@expo/ui`'s `BottomSheet` | ADR-0006: on the app's pinned Expo SDK 55, `@expo/ui`'s universal components (incl. `BottomSheet`) don't exist yet and have no web export — reaching them needs an SDK 56/57 upgrade, tracked separately |
 
 ---
 
 ## External Dependencies
 
-| Service               | Purpose                                              | URL (prod)                                   |
-| --------------------- | ---------------------------------------------------- | -------------------------------------------- |
-| Keycloak              | OAuth2/OIDC provider — issues Bearer tokens          | Configured via `EXPO_PUBLIC_KEYCLOAK_ISSUER` |
-| LightBridge AuthZ API | Account, project, API key management                 | Configured via `EXPO_PUBLIC_BACKEND_URL`     |
-| LightBridge Usage API | Time-series usage query                              | Configured via `EXPO_PUBLIC_USAGE_URL`       |
-| Converse AI Gateway   | LLM proxy (external clients only, not this frontend) | Configured via `EXPO_PUBLIC_GATEWAY_URL`     |
+| Service               | Purpose                                              | Configured via                                                        |
+| ---------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------ |
+| Keycloak               | OAuth2/OIDC provider — issues Bearer tokens           | `EXPO_PUBLIC_KEYCLOAK_ISSUER`, `_CLIENT_ID`, `_SCHEME`                    |
+| LightBridge AuthZ API  | Account, project, API key management (RPC)            | `EXPO_PUBLIC_BACKEND_URL` (+ optional `EXPO_PUBLIC_API_BASE_PATH`)        |
+| Grafana                | Usage dashboard, embedded as an iframe                | `EXPO_PUBLIC_GRAFANA_URL` (+ optional `EXPO_PUBLIC_GRAFANA_USAGE_DASHBOARD_PATH`); Usage tab is hidden entirely when unset |
+| Converse AI Gateway    | LLM proxy (used by external API clients only — this frontend never calls it) | Not read by application code; see note below |
+
+Corrected from the previous version of this table: `apps/self-service/src/configs/runtime-config.tsx`
+and `runtime-config-types.ts` (the actual source of the app's runtime config, both env-driven in
+dev and `/config.json`-driven in prod web) define no `gatewayUrl`/`usageUrl` field and read no
+`EXPO_PUBLIC_USAGE_URL`/`EXPO_PUBLIC_GATEWAY_URL` — those two variables are still threaded through
+`.docker/nginx/entrypoint.sh`'s `envsubst` list and the Helm chart, but nothing in `apps/self-service`
+consumes them. That's infra-side drift in files outside this doc's ownership (`infrastructure.md`,
+`development-setup.md`, `runbooks.md`, `api-reference.md`, `.docker/`, `charts/`) — flagged here
+because it directly affects what this table can claim, not fixed here.
 
 ---
 
@@ -154,7 +258,8 @@ LightBridge Backend
 - **Secrets:** No secrets baked into the container image. All config injected at runtime via environment variables.
 - **TLS:** Not terminated by the app or nginx — expected at ingress/load-balancer level.
 - **CORS:** Handled by the LightBridge backend; the frontend never bypasses CORS.
-- **Input validation:** Usage API shapes are typed via generated TypeScript types from OpenAPI
-  (`@hey-api/openapi-ts` + `zod`). AuthZ API shapes (accounts/projects/api-keys) are typed via
+- **Input validation:** AuthZ API shapes (accounts/projects/api-keys) are typed via
   `packages/authz-rpc`'s codegen against `authz.cstack` — no runtime schema validation on the
   frontend for this surface (the backend's `cratestack-pg` policy layer is the enforcement point).
+  `packages/api-rest`'s generated types (`@hey-api/openapi-ts` + `zod`) exist for the usage REST
+  surface but are currently unused (see Monorepo Topology above).

--- a/docs/knowledge/coding-conventions.md
+++ b/docs/knowledge/coding-conventions.md
@@ -9,7 +9,7 @@
 | Element | Convention | Example |
 |---------|-----------|---------|
 | Variables | `camelCase` | `isLoading`, `scopeId` |
-| Functions | `camelCase` | `loadStoredSession`, `useQueryUsage` |
+| Functions | `camelCase` | `loadStoredSession`, `buildUsageDashboardUrl` |
 | React hooks | `camelCase` prefixed with `use` | `useAuthSession`, `useKeycloakLogin` |
 | Classes / Types / Interfaces | `PascalCase` | `AuthSession`, `UsageQueryParams` |
 | Enums | `PascalCase` | `ApiKeyStatus` |
@@ -20,7 +20,8 @@
 | Files — classes/components | `kebab-case.tsx` (React Native convention) | `usage-view.tsx` |
 | Interfaces | No `I` prefix | `UserService` not `IUserService` |
 | Type parameters | Single uppercase or descriptive | `T`, `TResult`, `TInput` |
-| API endpoints | Defined by OpenAPI spec (snake_case path segments) | `/api/v1/api-keys/{key_id}` |
+| API endpoints (AuthZ RPC — accounts/projects/API keys, live) | `POST {basePath}/rpc/{op_id}`, not REST. **Corrected from an earlier version of this row**, which showed a REST-style `/api/v1/api-keys/{key_id}` path — that shape predates the cratestack RPC migration (ADR-0003 in `lightbridge-authz`) and no longer exists in this frontend | `POST /api/rpc/model.Account.list` |
+| API endpoints (usage REST, currently unused — see `architecture.md`) | Defined by `openapi/usage.backend.yaml` (snake_case path segments) | `/usage/v1/usage/query` |
 
 ---
 
@@ -32,21 +33,30 @@ converse-frontends/
 │   └── self-service/
 │       └── src/
 │           ├── app/          # Expo Router routes (thin, render screens only)
-│           ├── screens/      # Assemble views; no business logic
-│           ├── views/        # Presentational; calls hooks, renders UI
+│           ├── screens/      # Own data fetching (packages/hooks) + sheet presentation (useSheet);
+│           │                 # assemble views
+│           ├── views/        # Presentational only — render from props; no hook calls, no sheet
+│           │                 # imports (see architecture-conventions.md's "Application Layering"
+│           │                 # and "Two Load-Bearing Package Contracts" for the corrected rule
+│           │                 # and the code-level evidence)
 │           ├── configs/      # App-level configuration
-│           ├── hooks/        # App-specific hooks (wrap package hooks)
+│           ├── hooks/        # App-specific hooks (e.g. use-picker-sheet wraps packages/ui's
+│           │                 # useSheet; use-theme-colors is local theming logic)
 │           ├── navigation/   # Navigation config
-│           ├── queries/      # Query key factories
+│           ├── queries/      # Shared TanStack QueryClient instance (apps/self-service/src/queries/query-client.ts)
 │           ├── theme/        # App theme overrides
 │           └── types/        # App-specific shared types
 ├── packages/
-│   ├── api-rest/             # Auto-generated REST client (do NOT hand-edit)
+│   ├── authz-rpc/            # Generated cratestack RPC client for accounts/projects/api-keys
+│   │                         # (do NOT hand-edit packages/authz-rpc/generated/)
+│   ├── api-rest/             # Auto-generated REST client (do NOT hand-edit). Currently unused —
+│   │                         # nothing in the workspace imports it; see architecture.md
 │   ├── api-native/           # Native API utilities
-│   ├── hooks/                # Shared hooks (auth, usage, projects, accounts, API keys)
+│   ├── hooks/                # Shared hooks (auth, projects, accounts, API keys, budget) —
+│   │                         # consumed by screens/, not views/
 │   ├── i18n/                 # Translation resources
 │   └── ui/                   # Shared design-system components (see design-system-theming.md)
-├── openapi/                  # OpenAPI specs — source of truth for backend
+├── openapi/                  # OpenAPI spec for the usage REST API only (currently unused)
 ├── docs/knowledge/           # Agent-readable knowledge base
 └── charts/                   # Helm chart for Kubernetes deployment
 ```
@@ -101,10 +111,14 @@ Imports must be ordered as follows, **separated by blank lines**:
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
-import { usageBackendQueryUsage } from '@lightbridge/api-rest';
+import { useApiKeys } from '@lightbridge/hooks';
 
 import { useAuthSession } from './auth-session';
 ```
+
+Corrected from an earlier version of this example, which imported from `@lightbridge/api-rest` —
+that package is currently unused by the app (see architecture.md); `@lightbridge/hooks` is a live
+internal-package-alias example instead.
 
 Use **named exports** over default exports. Default exports are allowed only for Expo Router route files (framework requirement).
 


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Corrects and illustrates `docs/knowledge/architecture.md`, `architecture-conventions.md` and `coding-conventions.md`.
- Adds 5 mermaid diagrams: package dependency graph, component/network view, app layering, sheet lifecycle (`stateDiagram-v2`), sheet presentation sequence.
- **Documentation only.** Zero non-markdown files touched.

It solves:

- Part of https://github.com/ADORSYS-GIS/converse-frontends/issues/79's "screens compose" intent — you cannot compose from a library whose layering rules are documented backwards.

---

## 2. Intent

The intent of this PR is:

> Make the architecture legible, and fix what had drifted.
>
> **The headline correction: the documented layering was backwards.** All three files said views call hooks for data. They do not — every `apps/self-service/src/views/*.tsx` import of `@lightbridge/hooks` is either `import type` or the pure, non-fetching `@lightbridge/hooks/budget-tiers` subpath. **Every real data-fetching hook call lives in `screens/`.** Following the old docs, a contributor would wire data into the presentational layer — which is precisely the mistake that broke five pre-existing tests with `WorkletsError` earlier today.

---

## 3. Scope

### In Scope

- The three files above, and two previously-unwritten contracts (below).

### Out of Scope

- Auth/authorization, CI/deploy, and RPC/codegen — three sibling docs PRs.
- **ADR-0001's "rotation not exposed yet"**, which is now false. ADRs are historical records of a decision at a point in time; correcting them rewrites history. Current state is noted in `architecture.md` instead.
- The dead `EXPO_PUBLIC_USAGE_URL` / `EXPO_PUBLIC_GATEWAY_URL` plumbing in `.docker/` and `charts/` — tracked separately, since it crosses into infra and needs coordinating with `ai-helm`.

---

## 4. Verification

I verified this change by:

- [ ] Running automated tests
- [x] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Every claim was traced to source. Verified directly: the monorepo dependency graph (from `package.json` plus import checks), the `packages/ui` contract, the sheet boundary, the layering reversal, the Usage/Grafana flow, batch-link wiring, the test stack, and the sheet inventory. Carried over without independent re-verification: infra details owned by other docs (nginx, Helm values, WireMock).

**All 5 mermaid blocks were rendered with `mmdc`** by the author and **re-rendered independently by the orchestrator** — 5/5 produce valid SVG. A broken fence renders as a raw error block on GitHub, worse than plain text.

### Nine stale claims corrected

1. **Layering backwards** — views documented as calling hooks; they are presentational and receive props.
2. **Usage feature described as it was before commit `d5c9467`** — there is no `packages/hooks/src/usage.ts`, no `useQueryUsage`, no `usageCollection`. The Usage tab embeds a Grafana dashboard via `EXPO_PUBLIC_GRAFANA_URL`.
3. **`packages/api-rest` is orphaned** — generated from `openapi/usage.backend.yaml`, zero real imports anywhere in the repo. Now labelled unused.
4. **Zustand documented as a dependency** — it is not; the one hand-rolled store uses `@tanstack/react-db`.
5. **Playwright documented as the test stack** — no dependency, no config. Real stack: Jest + `jest-expo` + RNTL for the app, Vitest for `packages/hooks` and `packages/authz-rpc`.
6. **The authz-rpc batch link was documented as not wired** — `_layout.tsx` now constructs `createBatchLink()` and passes it in.
7. **`coding-conventions.md` omitted `packages/authz-rpc/` entirely** from its package tree — a major package simply missing.
8. **A pre-migration REST path was presented as the live API shape** — replaced with the real RPC shape (`POST {basePath}/rpc/{op_id}`) plus a correctly-labelled unused usage-REST row.
9. **Naming example used `useQueryUsage`**, which does not exist — replaced with a real function.

### Two load-bearing contracts, now written down

- **`packages/ui` has zero i18n coupling and no data fetching.** Confirmed against its `package.json` and by grep. This is what lets design-system and feature work proceed in parallel without contending over the shared i18n file.
- **`views/` must not import `@lightbridge/ui/sheet`; only `screens/` may.** Zero hits in `views/`, ten in `screens/`. That import pulls in reanimated/gorhom; a `useSheet()` call in a view broke five pre-existing tests with `WorkletsError`. Documented with the entity-picker (`entity-picker-field.tsx` / `use-picker-sheet.tsx`) as the worked example.

---

## 5. Screenshots / Evidence

Not applicable — the diagrams are the evidence and GitHub renders mermaid in the diff.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* A diagram encoding a stale claim is **worse** than no diagram — it reads as authoritative.
* Documentation drifts again.

Mitigation:

* Every statement verified against source before being drawn; the nine corrections are the result. Claims verified in code are distinguished from those carried over.
* Diagrams cite the files they derive from, so a reader can re-check rather than trust.
* No diagram was added to `coding-conventions.md` — its content is tables and lists, not graph-shaped, and a diagram there would have been decoration rather than correction.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [ ] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Written by Claude Code (Sonnet subagent under an Opus 5 orchestrator) on behalf of @stephane-segning. The agent was instructed to assume the prose was wrong and verify before drawing; that instruction produced all nine corrections.

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

**Human attestation pending @stephane-segning's review** — an agent must not tick the accountable human's boxes on their behalf.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [ ] Product intent
* [ ] Edge cases

Specifically: **the layering correction and the two contracts.** If the intended design really is that views may fetch, then this PR documents the wrong thing and the code is what should change — worth an explicit confirmation either way, because three files now assert the same rule.
