### PR TITLE
docs(ci): diagram the pipeline and record four gaps that let main look healthy

### DIFF
--- a/docs/knowledge/ci-cd.md
+++ b/docs/knowledge/ci-cd.md
@@ -1,66 +1,330 @@
 # CI/CD — Converse-frontends
 
-> Source of truth: `.github/workflows/`
+> Source of truth: `.github/workflows/`. Verified directly against the YAML and against
+> live workflow runs on GitHub Actions as of 2026-08-15, `main` @ `8ea2b6b`.
 
 ---
 
 ## Pipeline Overview
 
-CI/CD is implemented with **GitHub Actions**. All Linux jobs run on the
-self-hosted **`adorsys-gis-runner`** pool (not GitHub-hosted `ubuntu-latest`).
-That runner bakes rootless **Buildah/Podman** (no Docker daemon / dind) and is
-integrated with a **Turbo remote cache**, so builds run through `turbo` and reuse
-cached outputs across runs. There are two categories of workflows:
+CI/CD is implemented with **GitHub Actions**, eight workflows under `.github/workflows/`.
 
-### 1. Docker Image Build & Push (`docker-image.yml`)
+**Runner:** every job in every workflow runs on GitHub-hosted **`ubuntu-latest`**
+(`runs-on: ubuntu-latest`, confirmed in each workflow file). This repo ran on a
+self-hosted `adorsys-gis-runner` pool with rootless Buildah baked in and an
+integrated Turbo remote cache until
+[#134 "ci: update GitHub Actions runners to ubuntu-latest"](https://github.com/ADORSYS-GIS/converse-frontends/pull/134)
+(2026-07-31) moved every job to GitHub-hosted runners. A handful of in-repo comments
+(e.g. `docker-image.yml`'s "Rootless Buildah on the self-hosted runner", `governance.yml`'s
+"runs on the self-hosted adorsys-gis-runner like every other job in this repo") still
+describe the pre-#134 topology and are stale — the `runs-on:` line in every workflow is
+authoritative. Two concrete consequences of the switch, both still true today and neither
+walked back anywhere else in this repo's docs:
 
-This is the primary delivery pipeline. The web bundle is built **on the runner**
-via Turbo, then baked into a thin nginx image with Buildah — the image has no
-build stage, no Node/pnpm, and no Docker/BuildKit layer cache (caching lives in
-Turbo). Single-arch **`linux/amd64`** (every cluster node is amd64).
+- **No persisted Turbo cache.** See [Caching Strategy](#caching-strategy) below —
+  `ubuntu-latest` runners are ephemeral, and no workflow adds an `actions/cache` step for
+  `.turbo/` or a `TURBO_TOKEN`/`TURBO_API`/`TURBO_TEAM` remote-cache config, so every
+  `turbo run` starts cold.
+- **The quality pipeline's non-native scanners and reviewdog are no longer installed.**
+  See [Known Gaps](#known-gaps) — `quality.yml` never installs them, and they were
+  previously "pre-provisioned on the runner" (a self-hosted-runner-only assumption).
+
+---
+
+## Trigger Matrix
+
+| Workflow | `pull_request` → `main` | `push` (any branch) | `push` → `main` only | Tag `v*` | Schedule | `workflow_dispatch` |
+|---|---|---|---|---|---|---|
+| `test.yml` | ✅ | ✅ | — | — | — | — |
+| `quality.yml` | ✅ | ✅ | — | — | ✅ weekly (Sun 02:00 UTC) | ✅ |
+| `security.yml` | ✅ | ✅ | — | — | — | — |
+| `governance.yml` | ✅ (opened/edited/synchronize/reopened) | — | — | — | — | — |
+| `opencode.yml` | ✅ (opened/synchronize)¹ | — | — | — | — | — |
+| `docker-image.yml` | ❌ **never** | — | ✅ | ✅ | — | ✅ |
+| `publish-charts-oci.yml` | — | — | ✅ (paths: `charts/**`) | — | — | ✅ |
+| `storybook-pages.yml` | — | — | ✅ (paths: `packages/ui/**`) | — | — | ✅ |
+
+¹ `opencode.yml` also runs on `issue_comment` and `pull_request_review_comment` (for the
+`/oc` slash-command path), and is a no-op unless the `OPENCODE_GATEWAY_AUDIENCE` repo/org
+variable is set.
+
+```mermaid
+flowchart LR
+    PR["Pull request opened/synchronize<br/>→ main"]
+    PUSHBRANCH["Push → any branch<br/>(includes main)"]
+    PUSHMAIN["Push → main only"]
+    TAG["Tag push v*"]
+    SCHED["Weekly schedule<br/>Sun 02:00 UTC"]
+
+    TEST["test.yml<br/>pnpm test"]
+    QUALITY["quality.yml<br/>ESLint + tsc + Prettier scan"]
+    SECURITY["security.yml<br/>Trivy fs scan"]
+    GOV["governance.yml<br/>AI usage declaration check"]
+    OC["opencode.yml<br/>AI PR review"]
+    DOCKER["docker-image.yml<br/>turbo run build:web + Buildah + GHCR push"]
+    CHARTS["publish-charts-oci.yml<br/>Helm chart → GHCR"]
+    PAGES["storybook-pages.yml<br/>Storybook → GitHub Pages"]
+
+    PR --> TEST
+    PR --> QUALITY
+    PR --> SECURITY
+    PR --> GOV
+    PR --> OC
+    PR -. never triggers .-> DOCKER
+
+    PUSHBRANCH --> TEST
+    PUSHBRANCH --> QUALITY
+    PUSHBRANCH --> SECURITY
+
+    PUSHMAIN --> DOCKER
+    PUSHMAIN --> CHARTS
+    PUSHMAIN --> PAGES
+
+    TAG --> DOCKER
+    SCHED --> QUALITY
+```
+
+The dashed edge is the load-bearing line in this diagram: **no event a PR can raise ever
+reaches `docker-image.yml`.** That workflow is the only place `pnpm turbo run build:web`
+(the real Expo web export) actually runs in CI. See [Known Gaps](#known-gaps).
+
+`docker-image.yml`'s `push.branches` list also names
+`8-align-lightbridge-ui-with-authz-usage-apis-before-deployment`, a branch that no longer
+exists on the remote (`git ls-remote --heads origin` returns nothing for it) — a harmless
+leftover, not a live trigger.
+
+---
+
+## Known Gaps
+
+These are real, verified against the current workflow files and live CI runs, not inferred
+from workflow names. They are the most important content in this document.
+
+### 1. `docker-image.yml` never runs on `pull_request` — no PR can fail the web build
+
+`docker-image.yml` triggers only on `push` to `main` (+ the dead branch above), `push` of a
+`v*` tag, and `workflow_dispatch` (`.github/workflows/docker-image.yml:3-10`). It is the
+only workflow that runs `pnpm turbo run build:web` — the actual `expo export --platform web`
+that produces `apps/self-service/dist`. None of the PR-triggered workflows (`test.yml`,
+`quality.yml`, `security.yml`) build the web export; `test.yml` runs `pnpm test` (Jest
+unit tests) and `quality.yml` runs ESLint/tsc/Prettier/SAST scans, neither of which invokes
+Expo's bundler. A change that breaks the Expo web export can merge to `main` and stay there
+across any number of subsequent PRs — none of which re-run `build:web` either — until the
+next push to `main` triggers `docker-image.yml` and the build fails there, post-merge, on
+someone else's unrelated change. This is exactly what happened: a broken web export sat in
+`main` across six unrelated merges before it was caught; the last known-green image predates
+2026-08-01.
+
+### 2. No PR-level `tsc` gate
+
+`tsc` does run in CI — `quality.yml` → `.ci/quality/run.sh` type-checks every workspace's
+`tsconfig.json` (`apps/self-service`, `packages/ui`, etc.) via `pnpm exec tsc --noEmit -p
+<cfg>`. But nothing in the pipeline turns a `tsc` finding into a failed PR check today:
+
+- `.ci/quality/gate.sh` is deliberately designed to fail *only* on a scanner
+  crashing/misconfiguring — it explicitly never fails on the number of findings in the
+  merged SARIF (`.ci/quality/gate.sh:6-17`), by design, so it doesn't fail every PR on the
+  pre-existing backlog.
+- The one mechanism meant to fail a PR on a *new* `error`-level finding is reviewdog
+  (`-filter-mode added -fail-level=error`, `.github/workflows/quality.yml:101-105`). On the
+  current `ubuntu-latest` runner it is not installed (see Gap 4 below) — the step prints
+  `reviewdog not found in PATH; skipping PR check` and exits `0` unconditionally, on PR runs
+  included.
+
+Metro/Expo's bundler (the thing `docker-image.yml` runs, and which never runs on a PR
+either — Gap 1) does not type-check. So `pnpm build` (`turbo run build:web`) succeeds on
+code `tsc` rejects, and no CI step gated on a PR currently disagrees. A dependency-bump PR
+nearly shipped a type regression today for exactly this combination of reasons.
+
+### 3. `pnpm lint` fails on `main` today — verified numbers, not the ones quoted at scoping time
+
+The root `lint` script (`package.json`) is:
 
 ```
-Trigger: push to main / tagged branch / v* tag / workflow_dispatch
+eslint "**/*.{js,jsx,ts,tsx}" && prettier -c "**/*.{js,jsx,ts,tsx,json,css,md}"
+```
+
+Run against `main` @ `8ea2b6b`, this **fails at the ESLint stage** — `pnpm lint` exits `1`
+before Prettier's half ever runs, because of the `&&`:
+
+- **ESLint: 6 errors, 129 warnings, 135 problems.** All 6 errors are
+  `react-hooks/rules-of-hooks` violations — a `useState` call inside a Storybook `render`
+  arg function (not a component or a hook by naming convention) — across
+  `packages/ui/src/components/{pagination,segmented-control,select}/component.stories.tsx`.
+- Running Prettier's check **independently of ESLint** — which is what
+  `.ci/quality/run.sh` actually does in CI, since it invokes each tool separately rather
+  than via `pnpm lint` — finds **91 files** not matching Prettier formatting: 46 `.md`,
+  30 `.tsx`, 8 `.ts`, 4 `.json`, 3 `.js`. That's roughly half markdown, not
+  "overwhelmingly markdown," and nowhere near "~960 files" — verify with
+  `pnpm exec prettier -c "**/*.{js,jsx,ts,tsx,json,css,md}"` yourself if the number matters
+  to a decision; it will drift as the backlog is worked down or grows.
+
+CI's "Code Quality Scan" job (`quality.yml`) passes on this same commit anyway, for two
+independent reasons layered on top of each other:
+
+1. `gate.sh` never fails on finding counts by design (see Gap 2).
+2. reviewdog — the only mechanism that could fail a PR check on these findings — isn't
+   installed on the runner (Gap 4), so it no-ops regardless of what ESLint/Prettier find.
+
+The documented local command (`pnpm lint`) and the CI gate (`quality.yml`) therefore
+disagree, and will keep disagreeing until either the local script's findings are fixed or
+the CI gate is reconnected.
+
+### 4. The quality pipeline's non-native scanners, and reviewdog, are not installed on the current runner (found during this verification pass, not in original scope)
+
+`quality-pipeline.md` documents Semgrep, Hadolint, Actionlint, jscpd, and reviewdog as
+"pre-provisioned on the runner." That was true of the retired self-hosted
+`adorsys-gis-runner`; it is not true of `ubuntu-latest`, and `quality.yml` never installs
+any of them (no `apt`/`pip`/`go install`/`npm install -g` step for any of the five). Verified
+against a real `pull_request`-triggered run
+([run 31891626188](https://github.com/ADORSYS-GIS/converse-frontends/actions/runs/31891626188),
+PR #167, 2026-08-15):
+
+```
+[4/7] Semgrep    ⊘ semgrep not found; skipping
+[5/7] Hadolint   ⊘ hadolint not found; skipping
+[6/7] Actionlint ⊘ actionlint not found; skipping
+[7/7] jscpd      ⊘ jscpd not found; skipping
+...
+reviewdog not found in PATH; skipping PR check
+```
+
+`run.sh`'s tool-absence handling treats "not found" as `skipped`, not `error`, so this
+doesn't fail `gate.sh` either — it's silent. In practice, on every PR today: ESLint,
+TypeScript, and Prettier are the only scanners that actually execute (all three ship via
+`pnpm`/`node`, already installed for the rest of the job), and none of their output can fail
+the PR check because reviewdog — the diff-aware, fail-on-`error` reporter — isn't present to
+post it. This is the mechanism behind Gap 3, not just stale numbers: the enforcement path is
+currently absent, not merely miscalibrated.
+
+---
+
+## Workflows
+
+### `test.yml` — Unit tests
+
+Triggers: `pull_request` → `main`, `push` to any branch. Installs deps (`pnpm install
+--frozen-lockfile`, which also regenerates the gitignored RPC/REST clients via
+`postinstall` — see [Codegen](#codegen)) and runs `pnpm test` (`pnpm -r --if-present run
+test`, i.e. Jest per-workspace).
+
+### `quality.yml` — Code Quality Scan
+
+Triggers: `pull_request` → `main`, `push` to any branch, weekly schedule (Sun 02:00 UTC),
+`workflow_dispatch`. Runs `.ci/quality/run.sh` (ESLint, TypeScript, Prettier, Semgrep,
+Hadolint, Actionlint, jscpd — the last four currently skipped, see Gap 4), merges SARIF,
+applies `.ci/quality/gate.sh` (fails only on a scanner crash), optionally uploads to GitHub
+Code Scanning on `main` if `vars.ENABLE_CODE_SCANNING == 'true'`, and attempts a reviewdog PR
+comment (currently a no-op — Gap 4). Full architecture in `docs/quality-pipeline.md`.
+
+### `security.yml` — Security Audit
+
+Triggers: `pull_request` → `main`, `push` to any branch. Delegates entirely to the reusable
+`ADORSYS-GIS/ai-governance/.github/workflows/security-gates.yml` workflow (pinned to an
+immutable commit SHA), configured for a filesystem Trivy scan (`trivy-scan-type: fs`,
+`trivy-target: .`) — dependency/config scanning, not the container image (the image itself
+is scanned separately, inside `docker-image.yml`, via `aquasecurity/trivy-action`).
+
+### `governance.yml` — AI Governance
+
+Triggers: `pull_request` (opened/edited/synchronize/reopened). Delegates to the reusable
+`ADORSYS-GIS/ai-governance/.github/workflows/governance-check.yml` (pinned SHA), which fails
+the PR if its description is missing an AI Usage Declaration, a source-of-truth reference, or
+verification evidence, and posts a sticky comment listing what's missing.
+
+### `opencode.yml` — Agentic code review
+
+Triggers: `pull_request` (opened/synchronize), `issue_comment` (created), `pull_request_review_comment`
+(created). No-ops unless the `OPENCODE_GATEWAY_AUDIENCE` variable is set. Delegates to the
+reusable `ADORSYS-GIS/ai-governance/.github/workflows/opencode-review.yml` (pinned SHA),
+authenticating to the AI gateway via GitHub OIDC (`id-token: write`), no shared secret.
+(The earlier Qwen-based review/triage subsystem — `qwen-review.yml`, `qwen-dispatch.yml`,
+`qwen-invoke.yml`, `qwen-triage.yml`, `qwen-scheduled-triage.yml` — was removed; it had
+become noise rather than signal. None of those files exist in `.github/workflows/` today.)
+
+### `docker-image.yml` — Docker Image Build & Push
+
+Triggers: `push` to `main` (+ the dead branch noted above), `push` of a `v*` tag,
+`workflow_dispatch`. **Never `pull_request`** — see Gap 1. This is the primary delivery
+pipeline: the web bundle is built **on the runner** via Turbo, then baked into a thin nginx
+image with Buildah — the image itself has no build stage, no Node/pnpm, and no Docker/BuildKit
+layer cache.
+
+```
+Trigger: push to main / v* tag / workflow_dispatch   (NEVER pull_request)
        │
-       ▼  (on adorsys-gis-runner)
-   Checkout → pnpm install (runs codegen) → turbo run build:web   # → apps/self-service/dist, Turbo-cached
-       │
+       ▼  (on ubuntu-latest)
+   Checkout → pnpm install (runs codegen via postinstall) → turbo run build:web
+       │                                                     → apps/self-service/dist
        ▼
    Extract metadata (tags, labels) · buildah login to ghcr.io
        │
        ▼
-   buildah build (amd64, no layer cache)  →  export tar  →  Trivy scan (HIGH/CRITICAL gate)
+   buildah build (amd64, no layer cache) → export tar → Trivy scan (HIGH/CRITICAL, gates push)
        │
        ▼
    buildah push (all tags)
 ```
 
-### 1b. Helm Chart Publish (`publish-charts-oci.yml`)
+### `publish-charts-oci.yml` — Helm Chart Publish
 
-On merge to `main` (paths `charts/**`), each application chart under `charts/` is
-packaged and pushed to GHCR as an OCI artifact at
-`oci://ghcr.io/adorsys-gis/charts/<name>` (no gh-pages Helm
-repo). The chart version is derived at publish time — `MAJOR.MINOR` from
-`Chart.yaml` plus a patch equal to the commit count touching the chart dir — so it
-is monotonic and never committed back. Publishing is idempotent (skips a version
-already in the registry). Authenticates with the built-in `GITHUB_TOKEN` +
-`permissions: { packages: write }`, same as the image workflow.
+Triggers: `push` to `main` with `paths: charts/**` (or the workflow file itself),
+`workflow_dispatch`. Packages every non-library chart under `charts/` and pushes it to GHCR
+as an OCI artifact at `oci://ghcr.io/adorsys-gis/charts/<name>` — no gh-pages Helm repo. The
+version is derived at publish time (`MAJOR.MINOR` from `Chart.yaml` + a patch equal to the
+commit count touching the chart's directory) and never committed back, so the workflow can't
+re-trigger itself. Idempotent — skips a version already published. Uses the built-in
+`GITHUB_TOKEN` with `packages: write`.
 
-### 2. Agentic Code Review
+### `storybook-pages.yml` — Storybook → GitHub Pages
 
-| Workflow | Trigger | Purpose |
-|----------|---------|---------|
-| `opencode.yml` | Various | OpenCode AI agent workflow |
+Triggers: `push` to `main` with `paths: packages/ui/**` (or the workflow file itself),
+`workflow_dispatch`. Builds Storybook via `pnpm turbo run build-storybook` and deploys the
+static output to GitHub Pages via `actions/deploy-pages`.
 
-The Qwen-based review/triage subsystem (`qwen-review.yml`, `qwen-dispatch.yml`,
-`qwen-invoke.yml`, `qwen-triage.yml`, `qwen-scheduled-triage.yml`) was removed —
-it had become noise rather than signal.
+---
+
+## Codegen
+
+`packages/authz-rpc/generated/` and `packages/api-rest/src/client/` are both gitignored
+build output — schema/OpenAPI-driven RPC/REST clients, never hand-edited.
+
+**Current state, verified:** `packages/authz-rpc/package.json`'s codegen script is named
+plain `codegen` (not `codegen:cratestack` — that name no longer exists anywhere in the repo,
+confirmed by `grep -rn "codegen:cratestack"` returning nothing). The rename landed in
+[#159 "fix(authz-rpc): make `pnpm install` regenerate the RPC client"](https://github.com/ADORSYS-GIS/converse-frontends/pull/159)
+(2026-08-15): the root `codegen:all` script (`pnpm -r --if-present ... run codegen`) only
+ever matched scripts literally named `codegen`, so the old `codegen:cratestack` name was
+silently skipped by `--if-present` — `packages/authz-rpc/generated/` was never produced by a
+plain `pnpm install`, only by CI's own separate, now-removed, curl-the-binary-then-run step.
+
+**Locally and in CI alike, today:** a bare `pnpm install` regenerates both clients
+unconditionally, via the root `postinstall` → `codegen:all` chain. `@cratestack/cli` (pinned
+exact, `0.7.16` — a lockstep contract with lightbridge-authz's deployed `cratestack`/
+`cratestack-pg`, see `packages/authz-rpc/README.md`) is a `devDependency` of `authz-rpc`
+whose own postinstall fetches the matching Rust binary from GitHub Releases; it's allowlisted
+under `pnpm-workspace.yaml`'s `onlyBuiltDependencies` so pnpm 11 actually runs that
+postinstall. No separately-installed tooling, no PATH setup, no cache/curl steps in
+`test.yml` or `docker-image.yml` anymore — both were simplified in #159 to a single `pnpm
+install --frozen-lockfile`.
+
+**Turbo wiring**, added on top in
+[#161 "feat(codegen): wire codegen into Turbo, closing the gap left by #159"](https://github.com/ADORSYS-GIS/converse-frontends/pull/161)
+(2026-08-15): `codegen` is a real Turbo task (root `turbo.json`) for both `authz-rpc` and
+`api-rest`, and `build:web`/`build-storybook` declare it as a `dependsOn` — so `turbo run
+build:web` (what `docker-image.yml` runs) pulls codegen through the same cache instead of
+regenerating unconditionally on every build. `packages/api-rest/turbo.json` overrides that
+package's `codegen` inputs to include `openapi/usage.backend.yaml` (which lives outside the
+package directory and isn't covered by Turbo's default per-package hashing). This is a cache
+layered on top of the unconditional `postinstall` regeneration above, not a replacement for
+it — `pnpm install` still always regenerates from scratch regardless of Turbo cache state.
 
 ---
 
 ## Required Checks
 
-No required status checks are enforced at the workflow level (branch protection rules are configured on GitHub, not in YAML). As a convention per `AGENTS.md`:
+No required status checks are enforced at the workflow level (branch protection rules are
+configured on GitHub, not in YAML). As a convention per `AGENTS.md`:
 
 - All CI checks must pass before a PR can be merged
 - At least one approving review is required
@@ -70,16 +334,62 @@ No required status checks are enforced at the workflow level (branch protection 
 
 ## Caching Strategy
 
-Caching is handled by **Turborepo**, not by the Docker build. `turbo run build:web`
-(and `build-storybook`) hash their inputs and restore outputs from the
-`adorsys-gis-runner`'s integrated **Turbo remote cache** — an unchanged input tree
-replays instantly (`>>> FULL TURBO`) instead of re-running `expo export`.
+Caching is handled by **Turborepo**, not by the Docker build — but see the runner note
+above: since the #134 migration to ephemeral GitHub-hosted `ubuntu-latest` runners, **no
+workflow persists a Turbo cache across runs.** There is no `actions/cache` step for `.turbo/`
+in any workflow, and no `TURBO_TOKEN`/`TURBO_API`/`TURBO_TEAM` remote-cache configuration
+anywhere in the repo. Every `turbo run build:web` / `turbo run build-storybook` /
+`turbo run codegen` therefore starts cold on every job — the previous self-hosted runner's
+"integrated Turbo remote cache" and the `>>> FULL TURBO` instant-replay behavior it enabled
+no longer apply. `pnpm/action-setup` + `actions/setup-node`'s `cache: 'pnpm'` still caches
+the **pnpm store** (via `actions/cache` under the hood, keyed on `pnpm-lock.yaml`) — that's
+a dependency-install cache, unrelated to Turbo's task-output cache, and still functions
+normally.
 
-The Docker build itself is deliberately **uncached**: the old GHA layer cache
-(`cache-from/to: type=gha`) and the Dockerfile's BuildKit `--mount=type=cache`
-pnpm-store mount were both removed. Buildah builds a thin runtime image with no
-`--layers`/`--cache-from`. (Note: `.turbo/` must stay in `.gitignore` — otherwise
-turbo counts its own run logs as task inputs and never hits the cache.)
+The Docker build itself is deliberately **uncached**: no `--layers`/`--cache-from`/`--cache-to`
+in the Buildah invocation — caching, to the extent any exists post-#134, is meant to live in
+Turbo. (Note: `.turbo/` must stay in `.gitignore` regardless — otherwise Turbo counts its own
+run logs as task inputs and never hits even an in-job cache.)
+
+---
+
+## Build-and-Deploy Chain
+
+**This repo's CI does not deploy.** `docker-image.yml` publishes a container image to GHCR;
+getting that image running in the cluster is a separate hop, owned by ArgoCD in the
+`ai-helm` repo. "Image built" is not "live."
+
+```mermaid
+sequenceDiagram
+    participant Dev
+    participant Main as GitHub main or tag push
+    participant CI as docker-image.yml runner
+    participant Buildah
+    participant Trivy
+    participant GHCR
+    participant ArgoCD as ai-helm converse-ui
+    participant K8s as home-os cluster
+
+    Dev->>Main: merge PR or push v* tag
+    Main->>CI: push or tag event
+    CI->>CI: pnpm install --frozen-lockfile, regenerates authz-rpc and api-rest clients
+    CI->>CI: pnpm turbo run build:web, Expo web export to apps/self-service/dist
+    CI->>Buildah: buildah build --platform linux/amd64, no layer cache
+    Buildah->>Trivy: export image tarball, scan HIGH and CRITICAL
+    Trivy-->>Buildah: exit 1 blocks push on unfixed HIGH or CRITICAL findings
+    Buildah->>GHCR: push tags, branch sha v* and latest-on-main
+    Note over GHCR,ArgoCD: CI stops here, publishing an image is not deploying it
+    ArgoCD->>GHCR: argocd-image-updater polls for a newer tag
+    ArgoCD->>K8s: sync the converse-ui Application
+    K8s-->>Dev: change is live only after this ArgoCD sync
+```
+
+The Helm chart itself follows a parallel, separate path: `publish-charts-oci.yml` packages
+`charts/converse-frontend/` and pushes it to `oci://ghcr.io/adorsys-gis/charts/converse-frontend`
+on merges that touch `charts/**`. `ai-helm`'s `converse-ui` Application floats on a semver
+range against that OCI chart, while `argocd-image-updater` (shown above) separately tracks
+the container image tag. Both are driven by ArgoCD reconciling against the `home-os` cluster
+— nothing in this repo's CI initiates that reconcile.
 
 ---
 
@@ -87,7 +397,7 @@ turbo counts its own run logs as task inputs and never hits the cache.)
 
 - **Container images** are pushed to GitHub Container Registry (GHCR): `ghcr.io/adorsys-gis/converse-frontends`
 - **Image tags** generated per build:
-  - `branch-name` — for branch pushes
+  - `branch-name` — for branch pushes (in practice, only `main` and the dead branch above)
   - `v*` — for version tags (semver)
   - `sha-<short>` — for every build (commit SHA)
   - `latest` — only on pushes to the default branch (`main`)
@@ -101,14 +411,19 @@ turbo counts its own run logs as task inputs and never hits the cache.)
 
 | Environment | Trigger | Image Used |
 |-------------|---------|-----------|
-| Development / Preview | Push to any branch | `ghcr.io/...:<branch-name>` |
-| Production | Push `v*` tag to `main` | `ghcr.io/...:v<semver>` |
+| Production | Push to `main`, or push of a `v*` tag | `ghcr.io/...:latest` / `ghcr.io/...:v<semver>` |
 
-Deployment to Kubernetes is driven by a separate GitOps process (ArgoCD in the
-`ai-helm` repo). Its `converse-ui` Application consumes the chart published to
-`oci://ghcr.io/adorsys-gis/charts/converse-frontend` and floats
-on a semver range, while `argocd-image-updater` tracks the container image tag.
-For local/manual work, install the chart from `charts/converse-frontend/`.
+There is no per-branch preview image: `docker-image.yml` only triggers on `main` and on
+tags (Gap 1), so a feature branch never gets a `ghcr.io/...:<branch-name>` image built for
+it despite the tag pattern (`type=ref,event=branch`) existing in the metadata step —
+that pattern only ever fires for the branches the workflow actually triggers on.
+
+Deployment to Kubernetes is driven by a separate GitOps process (ArgoCD in the `ai-helm`
+repo, targeting the `home-os` cluster) — see [Build-and-Deploy Chain](#build-and-deploy-chain)
+above. Its `converse-ui` Application consumes the chart published to
+`oci://ghcr.io/adorsys-gis/charts/converse-frontend` and floats on a semver range, while
+`argocd-image-updater` tracks the container image tag. For local/manual work, install the
+chart from `charts/converse-frontend/`.
 
 Rollback: re-deploy a previous image tag via Helm. See `runbooks.md` for the rollback procedure.
 

--- a/docs/knowledge/infrastructure.md
+++ b/docs/knowledge/infrastructure.md
@@ -77,10 +77,14 @@ These variables are **not** baked into the image at build time. They are injecte
 | Field | Value |
 |-------|-------|
 | Service type | `ClusterIP` |
-| Container port | `80` (HTTP, nginx) |
-| Service port | `80` |
+| Container port | `8080` (HTTP, nginx — named port `http`) |
+| Service port | `80` → `targetPort: http` (i.e. routes to container port `8080`) |
 
-The container does not expose HTTPS directly. TLS termination is expected at the ingress/load-balancer level (not defined in this chart).
+nginx listens on `8080`, not `80` (non-privileged port, see `KUBERNETES_DEPLOYMENT.md`) —
+`charts/converse-frontend/values.yaml`'s `conversefrontend.controllers.main.containers.frontend.ports`
+declares `containerPort: 8080`, and the Service's `port: 80` maps to it by name (`targetPort: http`),
+not by number. The container does not expose HTTPS directly. TLS termination is expected at the
+ingress/load-balancer level (not defined in this chart).
 
 ### Local Docker Compose
 
@@ -93,10 +97,10 @@ The container does not expose HTTPS directly. TLS termination is expected at the
 
 ## Runtime: Nginx Web Server
 
-- **Base image:** `nginx:1.27-alpine-slim`
-- **Config:** `.docker/nginx/default.conf` mounted to `/etc/nginx/conf.d/default.conf`
+- **Base image:** `docker.io/library/nginx:1.30.0-alpine3.23-slim` (fully qualified — see `Dockerfile`)
+- **Config:** `.docker/nginx/default.conf` mounted to `/etc/nginx/conf.d/default.conf`, `listen 8080`
 - **Static files:** Served from `/usr/share/nginx/html/` (Expo web export)
-- **Health check:** `wget -q -O /dev/null http://127.0.0.1/` — interval 30s, timeout 3s, start period 10s, 3 retries
+- **Health check:** `wget -q -O /dev/null http://127.0.0.1:8080/` — interval 30s, timeout 3s, start period 10s, 3 retries
 
 ---
 
@@ -111,7 +115,7 @@ The container does not expose HTTPS directly. TLS termination is expected at the
 
 ## Probes (Kubernetes)
 
-All three probe types are configured with HTTP GET on port `80` at path `/`:
+All three probe types are configured with HTTP GET on the `http` port (container port `8080`) at path `/`:
 
 | Probe | Enabled | Type | Path |
 |-------|---------|------|------|

--- a/docs/quality-pipeline.md
+++ b/docs/quality-pipeline.md
@@ -2,22 +2,36 @@
 
 ## Overview
 
-The quality pipeline is an offline-capable, self-hosted code quality scanning system that replaces SonarQube CE's practical responsibilities without introducing a SaaS platform.
+The quality pipeline is an offline-capable code quality scanning system that replaces SonarQube CE's practical responsibilities without introducing a SaaS platform. It was originally designed to run entirely on self-hosted infrastructure (`adorsys-gis-runner`), with every scanner pre-provisioned on that runner's image; [#134](https://github.com/ADORSYS-GIS/converse-frontends/pull/134) (2026-07-31) moved `quality.yml` to GitHub-hosted `ubuntu-latest` along with every other workflow, and the pre-provisioning assumption did not move with it — see the **Known Gap** below before trusting the "pull request checks via reviewdog" claim.
 
-**Key features:**
-- ✅ Runs entirely on self-hosted infrastructure (adorsys-gis-runner)
+**Key features (as designed):**
 - ✅ No external scanning platforms or cloud services
 - ✅ Pull request checks via GitHub Check API + reviewdog
 - ✅ Preserved reports as CI artifacts
 - ✅ Gradual adoption: only reports new findings on PRs
 - ✅ Comprehensive SAST, linting, and maintainability checks
 
+> **Known Gap — verified 2026-08-15, not yet fixed.** On the current `ubuntu-latest`
+> runner, `quality.yml` never installs Semgrep, Hadolint, Actionlint, jscpd, or reviewdog —
+> only ESLint, TypeScript, and Prettier actually run (they ship via `pnpm`/`node`, already
+> installed for the rest of the job). Confirmed from a live `pull_request` run
+> ([run 31891626188](https://github.com/ADORSYS-GIS/converse-frontends/actions/runs/31891626188),
+> PR #167): `⊘ semgrep not found; skipping`, `⊘ hadolint not found; skipping`,
+> `⊘ actionlint not found; skipping`, `⊘ jscpd not found; skipping`, and
+> `reviewdog not found in PATH; skipping PR check` — on the PR-triggered run itself, not
+> only the fork-PR degraded path the workflow anticipates. `run.sh` treats "tool not found"
+> as `skipped`, not `error`, so `gate.sh` doesn't fail on this either. Net effect: **no
+> scanner's findings can fail a PR check today** — not because `gate.sh` is lenient by
+> design (it always was, see below) but because the one enforcement path that was supposed
+> to catch new findings (reviewdog) is absent from the runner. This is documented in more
+> detail, with real current numbers, in `docs/knowledge/ci-cd.md`'s Known Gaps section.
+
 ## Architecture
 
 ```
 ┌─────────────────────────────────────────────┐
 │  GitHub Actions: quality.yml                │
-│  (runs on adorsys-gis-runner)               │
+│  (runs on GitHub-hosted ubuntu-latest)      │
 └─────────────────────────────────────────────┘
                     │
        ┌────────────┼────────────┐
@@ -216,17 +230,22 @@ jscpd --reporters sarif --output ./jscpd-report \
 When a PR is opened:
 
 1. **Workflow triggers** on `pull_request` with `fetch-depth: 0`
-2. **All scanners run** independently
+2. **Scanners run** independently — today this means ESLint, TypeScript, and Prettier
+   only; Semgrep/Hadolint/Actionlint/jscpd are skipped, absent from the runner (Known Gap)
 3. **SARIF files merge** into `quality.sarif`
 4. **`gate.sh` checks scanner health** — fails only if a tool crashed or
    mis-configured; does NOT fail on the repo-wide finding count (that would
    fail every PR on the existing backlog)
-5. **reviewdog posts** GitHub PR check with:
+5. **reviewdog attempts to post** a GitHub PR check with:
    - `reporter=github-pr-check` (GitHub Check API) — or `github-actions`
      (workflow annotations) on fork PRs, where the token can't write checks
    - `filter-mode=added` (only new/modified lines)
-   - `fail-on-error=true` — this is what actually fails the PR check, and
-     only for new `error`-level findings in the diff
+   - `fail-on-error=true` — designed to be what actually fails the PR check, for
+     new `error`-level findings in the diff
+   - **As of the current runner (Known Gap above), this step is a no-op**: reviewdog
+     isn't installed, so it prints `reviewdog not found in PATH; skipping PR check` and
+     exits `0` on every run, PR-triggered or not. Nothing currently fails a PR check on
+     scanner findings.
 6. **PR author** reviews check and either:
    - Fixes findings (preferred)
    - Suppresses with documented reason (if acceptable)
@@ -301,7 +320,9 @@ eslint: 9.39.4
 typescript: 5.9.3
 prettier: 3.8.3
 
-# System tools (pre-provisioned on runner)
+# System tools (NOT currently installed in CI — see the Known Gap above.
+# These versions are what the pipeline was designed against; jq is the only
+# one still present on the ubuntu-latest image out of the box.)
 semgrep: 1.45.0
 hadolint: 2.12.0
 actionlint: 1.7.1
@@ -310,7 +331,10 @@ jq: 1.7
 reviewdog: 0.20.0
 ```
 
-Then re-provision the self-hosted runner or update your local toolchain.
+Update your local toolchain to these versions. Re-provisioning a CI runner no longer
+applies — `quality.yml` runs on GitHub-hosted `ubuntu-latest`, which is rebuilt from
+GitHub's own image on every job; installing these five tools there would require adding
+explicit install steps to `quality.yml`, which does not currently exist.
 
 ## Suppressing Findings
 
@@ -434,14 +458,22 @@ Check:
 
 ### Tools report "not found"
 
-Solution:
-- Install locally: `pnpm install` (ESLint, TypeScript, Prettier)
-- Install system tools: `brew install semgrep hadolint actionlint` (macOS)
+Locally:
+- Install: `pnpm install` (ESLint, TypeScript, Prettier)
+- Install system tools: `brew install semgrep hadolint actionlint` (macOS), `npm install -g jscpd reviewdog`
 - Ensure tools are in `$PATH`
+
+In CI: this is currently expected, not a misconfiguration to chase — see the Known Gap at
+the top of this document. `quality.yml` runs on `ubuntu-latest` and never installs Semgrep,
+Hadolint, Actionlint, jscpd, or reviewdog. Fixing it means adding install steps to
+`quality.yml` (or moving the job back to a runner that provisions them), not debugging the
+existing script.
 
 ### reviewdog not posting checks
 
-Ensure:
+On the current runner, reviewdog isn't installed at all (see Known Gap) — the step prints
+`reviewdog not found in PATH; skipping PR check` and exits `0` unconditionally. If/when
+reviewdog is installed in CI again, the remaining checks are:
 - Workflow has `pull-requests: write` permission
 - `REVIEWDOG_GITHUB_API_TOKEN` is set — reviewdog's GitHub reporters read
   this specific variable name, **not** `GITHUB_TOKEN`


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Rewrites `docs/knowledge/ci-cd.md`, `docs/knowledge/infrastructure.md` and `docs/quality-pipeline.md` against the actual workflow files and live CI run logs.
- Adds 2 mermaid diagrams: a trigger matrix with an explicit "never triggers" edge into `docker-image.yml`, and a build → Buildah → GHCR → ArgoCD sequence.
- **Documentation only.** Zero non-markdown files touched.

It solves:

- Documents the CI gaps established by #151, the hotfix for a two-week web-build outage that no PR-level check could have caught, and by #134, the runner migration that invalidated the existing prose.
- Failing run that exposed the outage: https://github.com/ADORSYS-GIS/converse-frontends/actions/runs/31871199429
- The docs described a CI topology that stopped being true on 2026-07-31, and none of the four gaps that let a broken `main` look healthy were written down anywhere.

---

## 2. Intent

The intent of this PR is:

> Describe CI as it actually behaves, and record the gaps as gaps.
>
> This matters concretely: the web export was broken on `main` for two weeks — last green image 2026-08-01 — across six unrelated merges, because **no PR-level check can fail the web build**. That is not a hypothetical; it is what happened, and nothing in the docs would have told anyone why.

---

## 3. Scope

### In Scope

- The three files above, the verified trigger matrix, four known gaps, and the deploy chain through to ArgoCD.

### Out of Scope

- **Fixing any of the gaps.** Documentation only — the recommendations live in the prose, not in the workflows.
- Architecture, auth, and RPC/codegen — three sibling docs PRs.

---

## 4. Verification

I verified this change by:

- [ ] Running automated tests
- [x] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Verified against `.github/workflows/*.yml`, `.ci/quality/*.sh`, `Dockerfile`, `charts/converse-frontend/values.yaml`, **and live `gh run view --log` output from real runs** — not from the YAML alone.

**Trigger matrix (8 workflows):** `test.yml` / `quality.yml` / `security.yml` run on `pull_request→main` and `push` to any branch. `governance.yml` / `opencode.yml` are PR-only. `docker-image.yml` runs **only** on `push→main`, `v*` tags and `workflow_dispatch` — confirmed via `gh run list` that it has never once fired on a `pull_request`. `publish-charts-oci.yml` and `storybook-pages.yml` are `push→main`, path-filtered.

**Both mermaid blocks rendered with `mmdc`** by the author and **re-rendered independently by the orchestrator** — 2/2 valid SVG.

### Four gaps, now documented

1. **No PR can fail the web build.** `docker-image.yml` never runs on `pull_request`; the PR-level workflows never invoke `build:web`.
2. **No PR-level `tsc` gate.** Metro does not typecheck, so `pnpm build` passes on code `tsc` rejects — a dependency PR nearly shipped a type regression today for exactly this reason.
3. **The Code Quality Scan runs no scanners.** Since the runner migration, `semgrep`, `hadolint`, `actionlint` and `jscpd` are all absent from `ubuntu-latest` and `.ci/quality/run.sh` skips each; `reviewdog` is likewise not in `PATH` and exits 0 unconditionally. Confirmed from live run 31891626188 on PR #167. **A passing Code Quality Scan is currently evidence of nothing.**
4. **`pnpm lint` fails on `main`.** It fails at the **ESLint** stage first — 6 errors (all `react-hooks/rules-of-hooks` in `packages/ui` Storybook render args) plus 129 warnings — and because the script is `eslint && prettier`, Prettier never runs locally. Run independently as CI does, Prettier flags **91 files**: 46 `.md`, 30 `.tsx`, 8 `.ts`, 4 `.json`, 3 `.js`.

### Five stale claims corrected

1. Both docs said jobs run on the self-hosted `adorsys-gis-runner`; **every `runs-on:` has been `ubuntu-latest` since PR #134 (2026-07-31)**.
2. Following from that, the documented integrated Turbo remote cache no longer applies — no workflow persists `.turbo/` or sets remote-cache env vars, so **every CI build is cold**.
3. `ci-cd.md` said `docker-image.yml` triggers on push to any branch; it is `main` and tags only.
4. `infrastructure.md` said container port `80`; Dockerfile, `values.yaml` and the nginx config all use `8080` (Service `80` maps via `targetPort: http`).
5. `infrastructure.md` said base image `nginx:1.27-alpine-slim`; the Dockerfile pins `docker.io/library/nginx:1.30.0-alpine3.23-slim`.

**Codegen state confirmed:** `codegen:cratestack` no longer exists anywhere; `packages/authz-rpc` has a plain `codegen` script (#159) and `turbo.json` wires it as a `dependsOn` of `build:web` / `build-storybook` (#161).

---

## 5. Screenshots / Evidence

Not applicable — the diagrams and the cited live run IDs are the evidence.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* Documenting gaps without fixing them can read as accepting them.
* A diagram encoding a stale claim is worse than none.

Mitigation:

* Each gap is recorded with its consequence and a concrete remedy in the prose, so the next person has a starting point rather than a complaint.
* Every claim was checked against live CI output, not just workflow YAML — which is how the "scanners silently absent" finding surfaced at all, since the YAML alone looks fine.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [ ] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Written by Claude Code (Sonnet subagent under an Opus 5 orchestrator) on behalf of @stephane-segning. Note the agent **corrected its orchestrator**: the brief asserted "~960 files fail prettier," which came from a broader glob than the repo's own script. The real figure is 91, and the more important detail — that ESLint fails first so Prettier never runs locally — was the agent's finding, not the brief's.

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

**Human attestation pending @stephane-segning's review** — an agent must not tick the accountable human's boxes on their behalf.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [x] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [ ] Product intent
* [ ] Edge cases

Specifically **gap 3**. A green "Code Quality Scan" that installs none of its scanners is worse than having no such check, because it manufactures confidence. Either the tools should be installed on the runner or `run.sh` should fail loudly when they are missing — right now it skips silently and exits 0. Every merge today passed that check.
