### PR TITLE
fix(self-service): surface API-key creation failures instead of swallowing them

### DIFF
--- a/apps/self-service/src/__tests__/api-key-create-screen.test.tsx
+++ b/apps/self-service/src/__tests__/api-key-create-screen.test.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
+import { initI18n } from '@lightbridge/i18n';
+
+// api-key-create-screen.tsx pulls in `@lightbridge/hooks` (which drags in auth-session and the
+// generated authz-rpc client) — mock the barrel with just the hooks the screen actually calls at
+// render time, same spirit as api-keys-screen.test.tsx's mock of the same barrel.
+// Must be `mock`-prefixed — babel-plugin-jest-hoist only allows referencing out-of-scope
+// variables from inside a jest.mock() factory when the name starts with "mock".
+const mockCreateKey = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ back: jest.fn(), canGoBack: () => false, navigate: jest.fn(), replace: jest.fn() }),
+  useLocalSearchParams: () => ({ projectId: 'proj-1' }),
+}));
+
+jest.mock('@lightbridge/api-native', () => ({
+  copyToClipboard: jest.fn(),
+}));
+
+jest.mock('@lightbridge/hooks', () => ({
+  __esModule: true,
+  useCreateApiKey: () => ({ mutate: mockCreateKey, isPending: false }),
+  useEnsureDefaultAccount: () => ({ mutate: jest.fn(), isPending: false }),
+  useEnsureDefaultProject: () => ({ mutate: jest.fn(), isPending: false }),
+  usePermissions: () => ({ has: () => false }),
+}));
+
+import { ApiKeyCreateScreen } from '../screens/api-key-create-screen';
+
+beforeAll(() => {
+  initI18n('en');
+});
+
+beforeEach(() => {
+  mockCreateKey.mockReset();
+});
+
+describe('ApiKeyCreateScreen error handling', () => {
+  it('renders nothing about the failure before any attempt is made', async () => {
+    await render(<ApiKeyCreateScreen />);
+
+    // Sanity: the form itself rendered.
+    expect(screen.getByPlaceholderText('Production')).toBeTruthy();
+    expect(
+      screen.queryByText("Creating API keys here requires being this project's lead or its owning account.")
+    ).toBeNull();
+    expect(screen.queryByText("Couldn't create the API key. Please try again.")).toBeNull();
+  });
+
+  it('shows the permission-specific copy for a 403, not the generic fallback', async () => {
+    // Shape mirrors a real `CratestackRpcError` thrown by the RBAC gate: the generated
+    // `readErrorBody` can't parse that gate's `{error: "..."}` body (it only understands
+    // cratestack's own `{code, message}` shape), so it falls back to a generic "unrecognized
+    // error body" placeholder on `body.message` — exactly what must NOT end up on screen.
+    mockCreateKey.mockRejectedValue({
+      name: 'CratestackRpcError',
+      status: 403,
+      code: 'internal',
+      body: {
+        code: 'internal',
+        message: 'RPC call returned status 403 with an unrecognized error body',
+      },
+      message:
+        'RPC call failed with code internal (status 403): RPC call returned status 403 with an unrecognized error body',
+    });
+
+    await render(<ApiKeyCreateScreen />);
+
+    await fireEvent.changeText(screen.getByPlaceholderText('Production'), 'Prod key');
+    await act(async () => fireEvent.press(screen.getByText('Save key')));
+
+    expect(
+      screen.getByText("Creating API keys here requires being this project's lead or its owning account.")
+    ).toBeTruthy();
+    expect(screen.queryByText(/unrecognized error body/i)).toBeNull();
+    expect(screen.queryByText("Couldn't create the API key. Please try again.")).toBeNull();
+  });
+
+  it('falls back to the generic message for a non-403 failure with no informative body', async () => {
+    mockCreateKey.mockRejectedValue({
+      name: 'CratestackRpcTransportError',
+      message: 'Failed to fetch',
+    });
+
+    await render(<ApiKeyCreateScreen />);
+
+    await fireEvent.changeText(screen.getByPlaceholderText('Production'), 'Prod key');
+    await act(async () => fireEvent.press(screen.getByText('Save key')));
+
+    expect(screen.getByText("Couldn't create the API key. Please try again.")).toBeTruthy();
+  });
+
+  it('surfaces a genuinely informative body message for a non-403 failure', async () => {
+    mockCreateKey.mockRejectedValue({
+      name: 'CratestackRpcError',
+      status: 409,
+      code: 'conflict',
+      body: { code: 'conflict', message: 'An API key with this name already exists.' },
+      message: 'RPC call failed with code conflict (status 409): An API key with this name already exists.',
+    });
+
+    await render(<ApiKeyCreateScreen />);
+
+    await fireEvent.changeText(screen.getByPlaceholderText('Production'), 'Prod key');
+    await act(async () => fireEvent.press(screen.getByText('Save key')));
+
+    expect(screen.getByText('An API key with this name already exists.')).toBeTruthy();
+  });
+
+  it('clears the error as soon as a retry starts, not just once it resolves', async () => {
+    mockCreateKey.mockRejectedValueOnce({
+      name: 'CratestackRpcError',
+      status: 403,
+      code: 'internal',
+      body: { code: 'internal', message: 'RPC call returned status 403 with an unrecognized error body' },
+      message: 'RPC call failed with code internal (status 403)',
+    });
+
+    await render(<ApiKeyCreateScreen />);
+
+    await fireEvent.changeText(screen.getByPlaceholderText('Production'), 'Prod key');
+    await act(async () => fireEvent.press(screen.getByText('Save key')));
+
+    expect(
+      screen.getByText("Creating API keys here requires being this project's lead or its owning account.")
+    ).toBeTruthy();
+
+    // Second attempt: leave the mutation pending (never resolved within this test) so we can
+    // observe the state right after the new attempt starts, before any outcome is known.
+    let resolveSecondAttempt: (() => void) | undefined;
+    mockCreateKey.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSecondAttempt = () => resolve();
+        })
+    );
+
+    await act(async () => fireEvent.press(screen.getByText('Save key')));
+
+    expect(
+      screen.queryByText("Creating API keys here requires being this project's lead or its owning account.")
+    ).toBeNull();
+
+    // Cleanup: let the still-pending mutation settle so the test doesn't leak a dangling timer/act warning.
+    await act(async () => resolveSecondAttempt?.());
+  });
+});

--- a/apps/self-service/src/screens/api-key-create-screen.tsx
+++ b/apps/self-service/src/screens/api-key-create-screen.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useTranslation } from '@lightbridge/i18n';
 import { copyToClipboard } from '@lightbridge/api-native';
 import {
   useCreateApiKey,
@@ -9,11 +10,78 @@ import {
 } from '@lightbridge/hooks';
 import { ApiKeyCreateView } from '../views/api-key-create-view';
 
+/**
+ * `createApiKey` is lead/owner-gated for the entire mutation (see the procedure's doc comment in
+ * `packages/authz-rpc/schema/authz.cstack`): a caller who holds the coarse `apikey:create`
+ * permission but is only a `'member'` on the target project is rejected with a 403, for any plan.
+ *
+ * The thrown error is a `CratestackRpcError` (see `packages/authz-rpc/generated/src/runtime.ts`),
+ * NOT an Axios error — it carries the HTTP status directly on `.status`, not under
+ * `.response.status`. `getApiErrorStatus`/`getApiErrorMessage` (`@lightbridge/hooks`) assume the
+ * Axios shape and silently return nothing useful here, so this reads `.status`/`.body.message`
+ * directly instead of routing through those helpers. Duck-typed rather than `instanceof
+ * CratestackRpcError` because `@lightbridge/authz-rpc`'s public index doesn't re-export that
+ * class (only the hand-written runtime/codec/client surface).
+ *
+ * The generated `readErrorBody` only understands cratestack's own `{code, message}` error shape;
+ * the RBAC gate that produces this particular 403 emits `{error: "..."}` instead, so
+ * `readErrorBody` can't parse it and falls back to a generic `"RPC call returned status 403 with
+ * an unrecognized error body"` placeholder — useless for exactly the failure users hit most. The
+ * HTTP status survives that fallback intact, so branch on status rather than trusting body text.
+ */
+function getRpcErrorStatus(error: unknown): number | undefined {
+  if (error && typeof error === 'object' && 'status' in error) {
+    const status = (error as { status?: unknown }).status;
+    if (typeof status === 'number') return status;
+  }
+  return undefined;
+}
+
+/**
+ * Only recognizes a real `CratestackRpcError.body.message` — never falls back to a raw
+ * `Error.message` (e.g. a `CratestackRpcTransportError`'s network-failure text), so an
+ * unrecognized/transport failure always renders the polished generic copy instead of a
+ * leaked technical string.
+ */
+function getRpcErrorBodyMessage(error: unknown): string | undefined {
+  if (error && typeof error === 'object' && 'body' in error) {
+    const body = (error as { body?: unknown }).body;
+    if (body && typeof body === 'object' && 'message' in body) {
+      const message = (body as { message?: unknown }).message;
+      if (typeof message === 'string' && message.trim().length > 0) {
+        return message;
+      }
+    }
+  }
+  return undefined;
+}
+
+// `readErrorBody`'s own fallback strings (runtime.ts) all start this way when it can't parse a
+// real error body — restating the status the caller already knows, never genuinely informative.
+const RPC_PLACEHOLDER_MESSAGE_PATTERN = /^RPC call returned status \d+/;
+
+/** Resolves the copy shown for a failed `createApiKey` call. 403 always gets the specific
+ * permission message (regardless of body content, since the body is unreliable for this exact
+ * failure — see the module comment above); any other status uses the body's message when it
+ * looks like real server content, otherwise a generic fallback. */
+function resolveCreateApiKeyErrorMessage(error: unknown, t: (key: string) => string): string {
+  if (getRpcErrorStatus(error) === 403) {
+    return t('apiKeys.createForbidden');
+  }
+  const bodyMessage = getRpcErrorBodyMessage(error);
+  if (bodyMessage && !RPC_PLACEHOLDER_MESSAGE_PATTERN.test(bodyMessage)) {
+    return bodyMessage;
+  }
+  return t('apiKeys.createErrorGeneric');
+}
+
 export function ApiKeyCreateScreen() {
   const router = useRouter();
+  const { t } = useTranslation();
   const params = useLocalSearchParams<{ projectId?: string }>();
   const [generatedSecret, setGeneratedSecret] = useState<string | null>(null);
   const [generatedOauth2Url, setGeneratedOauth2Url] = useState<string | null>(null);
+  const [createError, setCreateError] = useState<string | null>(null);
   const { mutate: ensureAccount, isPending: isAccountEnsuring } = useEnsureDefaultAccount();
   const { mutate: ensureProject, isPending: isProjectEnsuring } = useEnsureDefaultProject();
   const { mutate: createKey, isPending: isKeyCreating } = useCreateApiKey();
@@ -42,6 +110,9 @@ export function ApiKeyCreateScreen() {
   };
 
   const handleCreate = async (name: string, billingPlan: string) => {
+    // Clear any stale failure from a previous attempt as soon as a new one starts, so a retry
+    // never shows an old error next to a fresh, still-in-flight submission.
+    setCreateError(null);
     try {
       const resolvedProjectId = projectId ?? (await ensureProject((await ensureAccount()).id)).id;
 
@@ -58,6 +129,7 @@ export function ApiKeyCreateScreen() {
       );
     } catch (error) {
       console.error('Failed to create API key with bootstrap:', error);
+      setCreateError(resolveCreateApiKeyErrorMessage(error, t));
     }
   };
 
@@ -72,6 +144,7 @@ export function ApiKeyCreateScreen() {
       canChoosePlan={canChoosePlan}
       generatedSecret={generatedSecret}
       generatedOauth2Url={generatedOauth2Url}
+      createError={createError}
     />
   );
 }

--- a/apps/self-service/src/views/__tests__/api-key-create-view.error.test.tsx
+++ b/apps/self-service/src/views/__tests__/api-key-create-view.error.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { initI18n } from '@lightbridge/i18n';
+
+import { ApiKeyCreateView } from '../api-key-create-view';
+
+const noop = () => undefined;
+
+beforeAll(() => {
+  initI18n('en');
+});
+
+describe('ApiKeyCreateView createError', () => {
+  it('renders nothing when there is no error', async () => {
+    await render(<ApiKeyCreateView onBack={noop} onCreate={noop} onCopy={noop} />);
+
+    // Sanity: the form itself rendered.
+    expect(screen.getByPlaceholderText('Production')).toBeTruthy();
+    expect(
+      screen.queryByText("Creating API keys here requires being this project's lead or its owning account.")
+    ).toBeNull();
+  });
+
+  it('renders the resolved error copy the screen hands it', async () => {
+    await render(
+      <ApiKeyCreateView
+        onBack={noop}
+        onCreate={noop}
+        onCopy={noop}
+        createError="Creating API keys here requires being this project's lead or its owning account."
+      />
+    );
+
+    expect(
+      screen.getByText("Creating API keys here requires being this project's lead or its owning account.")
+    ).toBeTruthy();
+  });
+});

--- a/apps/self-service/src/views/api-key-create-view.tsx
+++ b/apps/self-service/src/views/api-key-create-view.tsx
@@ -18,8 +18,12 @@ import { OneTimeSecretCard } from '../components/one-time-secret-card';
 import { useThemeColors } from '../hooks/use-theme-colors';
 
 /**
- * Plan every new key defaults to. Callers who cannot choose a plan (no `project:member`
- * permission) always mint keys on this plan — the backend rejects anything else for them.
+ * Plan every new key defaults to when the caller cannot pick one (no `project:member`
+ * permission). This is cosmetic, not a working fallback: `createApiKey` is lead/owner-gated for
+ * the entire mutation (see the procedure's doc comment in `packages/authz-rpc/schema/authz.cstack`),
+ * so a caller who isn't this project's lead or its owning account cannot mint a key here AT ALL,
+ * on `free` or any other plan — pinning the field to `free` just avoids offering a picker that
+ * would always be rejected anyway. `createError` is what actually surfaces that rejection.
  */
 const DEFAULT_API_KEY_BILLING_PLAN = 'free';
 
@@ -33,6 +37,12 @@ type ApiKeyCreateViewProps = {
   generatedSecret?: string | null;
   /** `ApiKeySecret.oauth2Url` from the create response, if the backend returned one. */
   generatedOauth2Url?: string | null;
+  /**
+   * Resolved copy for the last failed `createApiKey` attempt, if any — `null` once a new attempt
+   * starts or after a success. See `resolveCreateApiKeyErrorMessage` in
+   * `../screens/api-key-create-screen.tsx` for how this is derived from the thrown error.
+   */
+  createError?: string | null;
 };
 
 export function ApiKeyCreateView({
@@ -43,6 +53,7 @@ export function ApiKeyCreateView({
   canChoosePlan = false,
   generatedSecret = null,
   generatedOauth2Url = null,
+  createError = null,
 }: Readonly<ApiKeyCreateViewProps>) {
   const { t } = useTranslation();
   const colors = useThemeColors();
@@ -149,6 +160,19 @@ export function ApiKeyCreateView({
                       {t('apiKeys.planLockedNote')}
                     </Text>
                   )}
+                  {createError ? (
+                    <Callout
+                      tone="error"
+                      icon={
+                        <Feather
+                          name="alert-circle"
+                          size={designTokens.icon.action}
+                          color={colors.error}
+                        />
+                      }>
+                      {createError}
+                    </Callout>
+                  ) : null}
                   <Button
                     variant="primary"
                     onPress={submit}

--- a/packages/i18n/src/i18n-config.ts
+++ b/packages/i18n/src/i18n-config.ts
@@ -96,6 +96,9 @@ const resources = {
         planLabel: 'Billing plan',
         planPlaceholder: 'free',
         planLockedNote: 'New keys are created on the free plan.',
+        createForbidden:
+          "Creating API keys here requires being this project's lead or its owning account.",
+        createErrorGeneric: "Couldn't create the API key. Please try again.",
         save: 'Save key',
         saving: 'Saving...',
         createTitle: 'Create or Update',


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Threads the create-key mutation error into `ApiKeyCreateView` and renders it. Previously the catch block was `console.error` and nothing else, and the view had **no error prop at all**.
- Derives the message from the **HTTP status**, not the response body, so a 403 gets specific, actionable copy.
- Corrects a misleading comment about the `free`-plan fallback.

It solves:

- The "shown but unusable" finding for API-key creation raised in the permission-scoping audit on #79, and the failure path documented in the authorization model added in #168.

---

## 2. Intent

The intent of this PR is:

> Make a failure visible. A caller who holds `apikey:create` but is only a plain `'member'` on the target project is rejected by the server for **any** plan — `createApiKey` is lead/owner-gated for the entire mutation, not just for plan selection. Today those users fill the form, tap Save, and **nothing happens at all**.

---

## 3. Scope

### In Scope

- Error state in the screen, an error prop on the view, status-derived copy, and tests.

### Out of Scope

- **Pre-emptively disabling the form for non-lead callers.** See the assessment below — it needs data this screen does not load.
- Fixing `readErrorBody` in the generated client. Tracked separately; this change is deliberately built so it does not depend on that fix.
- The wider error-helper defect this uncovered (see Reviewer Focus) — a separate change with a much larger blast radius.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [x] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
pnpm -r --if-present run test
pnpm lint
pnpm build
cd apps/self-service && npx tsc --noEmit ; echo "exit: $?"
```

Results:

```text
tests:  self-service 35 suites / 189 tests, hooks 4 suites / 56 tests — all pass, 7 new
tsc:    exit: 0, 0 errors   (captured directly, not through a pipe)
build:  turbo run build:web succeeded, real Metro/Expo web export
lint:   6 pre-existing errors in packages/ui stories, identical to baseline via git stash.
        Adds one import/first warning in the new test file, matching the existing
        jest.mock-before-import pattern in api-keys-screen.test.tsx.
```

Seven new tests. The point of this PR is that a failure becomes visible, so the tests assert exactly that: no error before an attempt, 403 renders the permission copy rather than the generic one, non-403 with an uninformative body renders the generic copy, non-403 with an informative body renders it verbatim, the error clears the instant a retry starts, and the view renders/hides purely on the prop.

Rebased onto `6ad27e5` and re-verified independently by the orchestrator.

### Copy added

```
apiKeys.createForbidden:    "Creating API keys here requires being this project's lead or its owning account."
apiKeys.createErrorGeneric: "Couldn't create the API key. Please try again."
```

The 403 copy names the actual condition, because it is something the user can act on — "contact support" would be a worse answer for a cause this specific.

### Why status and not the body

`readErrorBody` in the generated client accepts only cratestack's `{code, message}` shape. The RBAC gate emits `{error: "..."}`, which falls through to a placeholder — *"RPC call returned status 403 with an unrecognized error body"*. So the body message is useless for precisely the failure users hit most. `CratestackRpcError.status` survives intact, so:

- `403` → the permission copy, unconditionally, regardless of body content.
- otherwise → the body's `message`, unless it matches `readErrorBody`'s own placeholder pattern, in which case the generic copy.

This works whether or not the separate `readErrorBody` fix ever lands.

### Corrected comment

`api-key-create-view.tsx` claimed callers without `project:member` "always mint keys on this plan — the backend rejects anything else for them." They cannot mint a key **at all** without lead/owner standing; the `free` pin is cosmetic, not a working fallback. Corrected rather than deleted.

---

## 5. Screenshots / Evidence

**No screenshots** — Keycloak-gated, no auth stack. The seven tests are the evidence.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* A stale error persisting beside a fresh submission.
* Over-claiming the cause: showing "you lack permission" for a network failure would be worse than the generic message.

Mitigation:

* The error is cleared at the top of `handleCreate`, before the first `await`, and a test asserts it clears the instant a retry starts rather than when the retry resolves.
* The permission copy is gated strictly on `status === 403`; everything else falls to the generic path or the body's own message.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [x] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Implemented by Claude Code (Sonnet subagent under an Opus 5 orchestrator) on behalf of @stephane-segning. The agent was told the pre-emptive lead/owner check was out of scope and to report on feasibility instead of building it — that assessment is below.

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

**Human attestation pending @stephane-segning's review** — an agent must not tick the accountable human's boxes on their behalf.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [ ] Maintainability
* [x] Product intent
* [x] Edge cases

### A larger defect this uncovered — not fixed here

`getApiErrorStatus` (`packages/hooks/src/budget-tiers.ts:105`) reads **only** `error.response.status`, the Axios shape. `CratestackRpcError` exposes `.status` directly with no `.response`, so **the helper returns `undefined` for every RPC error**. `getApiErrorMessage` (`packages/hooks/src/api-error.ts`) has the same problem — its own doc comment still says *"Axios surfaces that as `error.response.data`"*, written before the RPC migration.

Consequences, verified:

- **`budget-refill-screen.tsx` shows no error UI on any failure.** With `errorStatus` always `undefined`, `isPermissionError`, `isOtherError` and `canRetry` are all false. The 403 handling that #148 explicitly required is dead code — shipped in #158.
- `project-settings-screen.tsx`'s `memberError` / `statusError` / `setDefaultError` degrade to raw technical strings rather than the intended messages.

The unit tests do not catch it because they construct the wrong shape — `budget.test.ts:110` is literally titled *"extracts a numeric status from an axios-shaped error"* and builds `{ response: { status: 403 } }`, which this runtime never produces.

This PR deliberately does not use those helpers, which is why it works. Fixing them properly means correcting the shape, updating tests that currently assert the wrong contract, and re-verifying every consumer — worth its own change rather than riding along here.

### The pre-emptive check, assessed

Disabling the form for non-lead callers is more expensive than it looks. "Owning account" is a cheap comparison of `project.accountId` against the caller's account — but **this screen never loads the `Project` object**, only a bare `projectId` route param, so even that needs a new fetch. "Is caller lead" requires `listProjectRoster` per project. That is a real extra round-trip plus a design call about when to spend it (every visit, only for non-default projects, or lazily on submit). Left out deliberately; this PR makes the failure visible rather than preventing it.
