### PR TITLE
fix(hooks): parse the RPC error shape so error handling stops being dead code

### DIFF
--- a/apps/self-service/src/__tests__/budget-refill-screen.test.tsx
+++ b/apps/self-service/src/__tests__/budget-refill-screen.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { initI18n } from '@lightbridge/i18n';
+
+// This is the exact regression the fix targets: `getApiErrorStatus`/`getApiErrorMessage` used to
+// read the Axios `error.response.status` shape, which `CratestackRpcError` (the generated RPC
+// client's actual thrown error -- packages/authz-rpc/generated/src/runtime.ts) never has, so
+// `errorStatus` was always `undefined` and this screen showed no error UI on any failure at all
+// (see packages/hooks/src/api-error.ts's module comment). This test mocks `@lightbridge/hooks`'s
+// data hooks but deliberately keeps the REAL `getApiErrorStatus` (via the dependency-free
+// `@lightbridge/hooks/api-error` subpath, same pattern as the `./budget-tiers` subpath already
+// used by budget-refill-view.tsx) so the screen's actual wiring is exercised, not bypassed.
+const mockUseRequestBudgetRefill = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ back: jest.fn() }),
+}));
+
+jest.mock('@lightbridge/hooks', () => {
+  const apiError = jest.requireActual('@lightbridge/hooks/api-error');
+  return {
+    __esModule: true,
+    ...apiError,
+    createBudgetIdempotencyKey: () => 'idem-1',
+    currentBudgetPeriod: () => '2026-08',
+    useCurrentAccount: () => ({ data: { id: 'acc-1' } }),
+    usePermissions: () => ({ has: () => true }),
+    useRequestBudgetRefill: () => mockUseRequestBudgetRefill(),
+  };
+});
+
+import { BudgetRefillScreen } from '../screens/budget-refill-screen';
+
+beforeAll(() => {
+  initI18n('en');
+});
+
+beforeEach(() => {
+  mockUseRequestBudgetRefill.mockReset();
+});
+
+describe('BudgetRefillScreen -- reacts to a real CratestackRpcError, not just an Axios-shaped one', () => {
+  it('shows the permission-denied copy (not nothing) for a real 403 CratestackRpcError, and hides Retry', async () => {
+    mockUseRequestBudgetRefill.mockReturnValue({
+      mutateAsync: jest.fn(),
+      isPending: false,
+      data: null,
+      // Real shape: `.status` directly on the instance, no `.response` at all.
+      error: {
+        name: 'CratestackRpcError',
+        status: 403,
+        code: 'permission_denied',
+        body: {
+          code: 'permission_denied',
+          message: 'Forbidden: missing required permission: budget:self-refill',
+        },
+        message: 'RPC call failed with code permission_denied (status 403): Forbidden: ...',
+      },
+    });
+
+    await render(<BudgetRefillScreen />);
+
+    expect(screen.getByText("You don't have permission to request a budget refill.")).toBeTruthy();
+    expect(screen.queryByText('Retry')).toBeNull();
+  });
+
+  it('shows the retry hint and a Retry action for a non-403 (5xx) real CratestackRpcError', async () => {
+    mockUseRequestBudgetRefill.mockReturnValue({
+      mutateAsync: jest.fn(),
+      isPending: false,
+      data: null,
+      error: {
+        name: 'CratestackRpcError',
+        status: 500,
+        code: 'internal',
+        body: { code: 'internal', message: 'Something exploded server-side.' },
+        message: 'RPC call failed with code internal (status 500): Something exploded server-side.',
+      },
+    });
+
+    await render(<BudgetRefillScreen />);
+
+    expect(
+      screen.getByText(
+        "Something went wrong sending this request. Retrying reuses the same request so it won't be processed twice."
+      )
+    ).toBeTruthy();
+    expect(screen.getByText('Retry')).toBeTruthy();
+  });
+
+  it('shows no error UI at all when there is no error', async () => {
+    mockUseRequestBudgetRefill.mockReturnValue({
+      mutateAsync: jest.fn(),
+      isPending: false,
+      data: null,
+      error: null,
+    });
+
+    await render(<BudgetRefillScreen />);
+
+    expect(screen.queryByText("You don't have permission to request a budget refill.")).toBeNull();
+    expect(screen.queryByText('Retry')).toBeNull();
+  });
+
+  it("never shows the previous attempt's error UI while a new request is in flight", async () => {
+    mockUseRequestBudgetRefill.mockReturnValue({
+      mutateAsync: jest.fn(),
+      isPending: true,
+      data: null,
+      error: {
+        name: 'CratestackRpcError',
+        status: 403,
+        code: 'permission_denied',
+        body: { code: 'permission_denied', message: 'Forbidden' },
+        message: 'RPC call failed with code permission_denied (status 403): Forbidden',
+      },
+    });
+
+    await render(<BudgetRefillScreen />);
+
+    expect(screen.queryByText("You don't have permission to request a budget refill.")).toBeNull();
+    expect(screen.getByRole('button', { name: 'Requesting…' })).toBeTruthy();
+  });
+});

--- a/apps/self-service/src/__tests__/project-settings-screen.test.tsx
+++ b/apps/self-service/src/__tests__/project-settings-screen.test.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+
+// Regression coverage for the same bug as budget-refill-screen.test.tsx: `getApiErrorMessage`
+// used to read the Axios `error.response.data` shape and otherwise fall back to a technical
+// `Error.message` string (e.g. `RPC call failed with code internal (status 403): ...`).
+// `CratestackRpcError` (the generated RPC client's actual thrown error) never has `.response`, so
+// `memberError`/`statusError`/`setDefaultError` degraded to that raw technical string on every
+// real failure -- see packages/hooks/src/api-error.ts's module comment. This mocks
+// `@lightbridge/hooks`'s data hooks but keeps the REAL `getApiErrorMessage` (via the
+// dependency-free `@lightbridge/hooks/api-error` subpath) so the screen's actual derivation is
+// exercised. `ProjectSettingsView` itself is a large presentational component covered by its own
+// tests (`views/settings/__tests__/project-settings-view.test.tsx`); it's stubbed here purely to
+// expose the three derived error props as queryable text, same pattern as
+// `__tests__/api-keys-screen.test.tsx`'s stub of its list view.
+let mockDisableProjectError: unknown = null;
+let mockEnableProjectError: unknown = null;
+let mockSetDefaultProjectError: unknown = null;
+let mockAddMemberError: unknown = null;
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ back: jest.fn() }),
+}));
+
+jest.mock('@lightbridge/i18n', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('@lightbridge/ui/sheet', () => ({
+  useSheet: () => ({ present: jest.fn() }),
+}));
+
+// Must be its own top-level `mock`-prefixed function -- babel-plugin-jest-hoist's scope check
+// trips on identifiers referenced inside a jest.mock() factory otherwise. Same pattern as
+// __tests__/api-keys-screen.test.tsx.
+function mockUseQueryState(_key: string): [string | null, (value: string | null) => void] {
+  return require('react').useState(null);
+}
+
+jest.mock('@lightbridge/hooks', () => {
+  const apiError = jest.requireActual('@lightbridge/hooks/api-error');
+  return {
+    __esModule: true,
+    ...apiError,
+    useAllAccounts: () => ({ data: [{ id: 'acc-1' }], isLoading: false, totalCount: 1 }),
+    useAllProjects: () => ({
+      data: [{ id: 'proj-1', name: 'Project One', isDefault: false, isActive: true }],
+      isLoading: false,
+      totalCount: 1,
+    }),
+    useProjectMembers: () => ({ data: [], isLoading: false }),
+    useUpdateProject: () => ({ mutateAsync: jest.fn(), isPending: false, error: null }),
+    useDisableProject: () => ({
+      mutateAsync: jest.fn(),
+      isPending: false,
+      error: mockDisableProjectError,
+    }),
+    useEnableProject: () => ({
+      mutateAsync: jest.fn(),
+      isPending: false,
+      error: mockEnableProjectError,
+    }),
+    useSetDefaultProject: () => ({
+      mutateAsync: jest.fn(),
+      isPending: false,
+      error: mockSetDefaultProjectError,
+    }),
+    useAddProjectMember: () => ({
+      mutateAsync: jest.fn(),
+      isPending: false,
+      error: mockAddMemberError,
+    }),
+    useRemoveProjectMember: () => ({ mutateAsync: jest.fn(), isPending: false, error: null }),
+    useSetProjectMemberRole: () => ({ mutateAsync: jest.fn(), isPending: false, error: null }),
+    useSetProjectMemberQuotaTier: () => ({ mutateAsync: jest.fn(), isPending: false, error: null }),
+    usePermissions: () => ({ has: () => true }),
+    useQueryState: mockUseQueryState,
+  };
+});
+
+jest.mock('../views/settings/project-settings-view', () => {
+  const { Text } = require('react-native');
+  return {
+    ProjectSettingsView: (props: {
+      statusError?: string | null;
+      memberError?: string | null;
+      setDefaultError?: string | null;
+    }) => (
+      <>
+        <Text testID="status-error">{props.statusError ?? ''}</Text>
+        <Text testID="member-error">{props.memberError ?? ''}</Text>
+        <Text testID="set-default-error">{props.setDefaultError ?? ''}</Text>
+      </>
+    ),
+  };
+});
+
+import { ProjectSettingsScreen } from '../screens/project-settings-screen';
+
+beforeEach(() => {
+  mockDisableProjectError = null;
+  mockEnableProjectError = null;
+  mockSetDefaultProjectError = null;
+  mockAddMemberError = null;
+});
+
+describe('ProjectSettingsScreen -- derives error copy from a real CratestackRpcError, not an Axios shape', () => {
+  it('surfaces the real server message for a status-change 403, not the technical Error.message', async () => {
+    mockDisableProjectError = {
+      name: 'CratestackRpcError',
+      status: 403,
+      code: 'permission_denied',
+      body: {
+        code: 'permission_denied',
+        message: 'Forbidden: only the project lead can disable this project.',
+      },
+      message:
+        'RPC call failed with code permission_denied (status 403): Forbidden: only the project lead can disable this project.',
+    };
+
+    await render(<ProjectSettingsScreen />);
+
+    expect(screen.getByTestId('status-error').props.children).toBe(
+      'Forbidden: only the project lead can disable this project.'
+    );
+  });
+
+  it("replaces readErrorBody's own placeholder text with a generic message instead of leaking it", async () => {
+    mockSetDefaultProjectError = {
+      name: 'CratestackRpcError',
+      status: 403,
+      code: 'internal',
+      body: {
+        code: 'internal',
+        message: 'RPC call returned status 403 with an unrecognized error body',
+      },
+      message:
+        'RPC call failed with code internal (status 403): RPC call returned status 403 with an unrecognized error body',
+    };
+
+    await render(<ProjectSettingsScreen />);
+
+    const setDefaultError = screen.getByTestId('set-default-error').props.children;
+    expect(setDefaultError).not.toMatch(/unrecognized error body/i);
+    expect(setDefaultError).toBe('Something went wrong. Please try again.');
+  });
+
+  it('surfaces a real member-mutation error message the same way', async () => {
+    mockAddMemberError = {
+      name: 'CratestackRpcError',
+      status: 409,
+      code: 'conflict',
+      body: { code: 'conflict', message: 'This account is already a member of the project.' },
+      message:
+        'RPC call failed with code conflict (status 409): This account is already a member of the project.',
+    };
+
+    await render(<ProjectSettingsScreen />);
+
+    expect(screen.getByTestId('member-error').props.children).toBe(
+      'This account is already a member of the project.'
+    );
+  });
+
+  it('shows no error text at all when nothing failed', async () => {
+    await render(<ProjectSettingsScreen />);
+
+    expect(screen.getByTestId('status-error').props.children).toBe('');
+    expect(screen.getByTestId('member-error').props.children).toBe('');
+    expect(screen.getByTestId('set-default-error').props.children).toBe('');
+  });
+});

--- a/packages/authz-rpc/src/index.ts
+++ b/packages/authz-rpc/src/index.ts
@@ -3,5 +3,12 @@ export * from './codec';
 export * from './runtime';
 export * from './client';
 export * from '../generated/src/models';
-export type { JsonValue } from '../generated/src/runtime';
+export type { JsonValue, RpcErrorBody } from '../generated/src/runtime';
+// Re-exported so callers can construct/recognize the real error shapes a failed RPC call throws
+// (`instanceof CratestackRpcError`, `.status`, `.code`, `.body`; or `CratestackRpcTransportError`
+// for a network-layer failure with no server response at all) instead of duck-typing them or
+// hand-rolling a mock. Added alongside the `@lightbridge/hooks` error-helper fix (see
+// `packages/hooks/src/api-error.ts`) -- previously these were only reachable via the
+// `../generated/src/runtime` deep import, which is not part of this package's public surface.
+export { CratestackRpcError, CratestackRpcTransportError } from '../generated/src/runtime';
 export { LightbridgeAuthzRpcClient } from '../generated/src/client';

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -8,7 +8,8 @@
     ".": "./src/index.ts",
     "./pagination": "./src/pagination.ts",
     "./use-query-state": "./src/use-query-state.ts",
-    "./budget-tiers": "./src/budget-tiers.ts"
+    "./budget-tiers": "./src/budget-tiers.ts",
+    "./api-error": "./src/api-error.ts"
   },
   "dependencies": {
     "@lightbridge/api-native": "workspace:*",

--- a/packages/hooks/src/api-error.test.ts
+++ b/packages/hooks/src/api-error.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// This file exercises real error instances, not hand-rolled mocks — `@lightbridge/authz-rpc`'s
+// `getAuthzRpcClient`/`createId` still need stubbing (constructing a real client has side
+// effects this file doesn't want), but `importOriginal` keeps every other export -- including
+// `CratestackRpcError`/`CratestackRpcTransportError` -- wired to the real generated class. Same
+// spirit as `budget.test.ts`'s mock of this module, minus discarding the error classes.
+vi.mock('@lightbridge/authz-rpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@lightbridge/authz-rpc')>();
+  return {
+    ...actual,
+    getAuthzRpcClient: () => ({}),
+    createId: () => 'test-id',
+  };
+});
+
+import { CratestackRpcError, CratestackRpcTransportError } from '@lightbridge/authz-rpc';
+import { getApiErrorMessage, getApiErrorStatus, isPermissionDeniedError } from './api-error';
+
+describe('getApiErrorStatus / isPermissionDeniedError', () => {
+  it('reads .status directly off a real CratestackRpcError (a 403 permission denial)', () => {
+    const error = new CratestackRpcError(403, {
+      code: 'permission_denied',
+      message: 'Forbidden: missing required permission: budget:self-refill',
+    });
+    expect(getApiErrorStatus(error)).toBe(403);
+    expect(isPermissionDeniedError(error)).toBe(true);
+  });
+
+  it('treats a non-403 status as not permission-denied', () => {
+    const error = new CratestackRpcError(500, { code: 'internal', message: 'boom' });
+    expect(getApiErrorStatus(error)).toBe(500);
+    expect(isPermissionDeniedError(error)).toBe(false);
+  });
+
+  it('returns undefined for a transport-level failure with no HTTP status at all', () => {
+    // CratestackRpcTransportError is thrown for a network failure / malformed response, before
+    // any status is ever known — see packages/authz-rpc/generated/src/runtime.ts.
+    const error = new CratestackRpcTransportError('Failed to fetch');
+    expect(getApiErrorStatus(error)).toBeUndefined();
+    expect(isPermissionDeniedError(error)).toBe(false);
+  });
+
+  it('returns undefined for a plain non-RPC error', () => {
+    expect(getApiErrorStatus(new Error('network down'))).toBeUndefined();
+    expect(isPermissionDeniedError(new Error('network down'))).toBe(false);
+  });
+
+  it('does NOT match the legacy Axios shape (this app has no Axios client left)', () => {
+    // packages/api-rest is generated but has zero importers anywhere in the repo -- there is no
+    // live code path that can ever throw this shape. Asserted here so a future re-introduction
+    // of an Axios-based client doesn't silently regress back to `undefined` for every RPC error.
+    const axiosShapedError = { response: { status: 403, data: 'Forbidden' } };
+    expect(getApiErrorStatus(axiosShapedError)).toBeUndefined();
+  });
+});
+
+describe('getApiErrorMessage', () => {
+  it("surfaces a real CratestackRpcError's decoded body message verbatim", () => {
+    const error = new CratestackRpcError(409, {
+      code: 'conflict',
+      message: 'An API key with this name already exists.',
+    });
+    expect(getApiErrorMessage(error)).toBe('An API key with this name already exists.');
+  });
+
+  it("replaces readErrorBody's own placeholder text with a generic message instead of leaking it", () => {
+    // Mirrors what `readErrorBody` (packages/authz-rpc/generated/src/runtime.ts) actually
+    // constructs when a handler's body doesn't match cratestack's own `{code, message}` shape --
+    // e.g. the RBAC gate's `{error: "..."}` on a 403. This exact string is not something a user
+    // should ever see.
+    const error = new CratestackRpcError(403, {
+      code: 'internal',
+      message: 'RPC call returned status 403 with an unrecognized error body',
+    });
+    const message = getApiErrorMessage(error);
+    expect(message).not.toMatch(/unrecognized error body/i);
+    expect(message).not.toMatch(/^RPC call returned status/);
+    expect(message).toBe('Something went wrong. Please try again.');
+  });
+
+  it('falls back to .message for a transport-level failure (no server-decoded body exists)', () => {
+    const error = new CratestackRpcTransportError('Failed to fetch');
+    expect(getApiErrorMessage(error)).toBe('Failed to fetch');
+  });
+
+  it('falls back to .message for a plain, non-RPC Error', () => {
+    expect(getApiErrorMessage(new Error('network down'))).toBe('network down');
+  });
+
+  it('falls back to String(error) for a non-object thrown value', () => {
+    expect(getApiErrorMessage('just a string')).toBe('just a string');
+    expect(getApiErrorMessage(null)).toBe('null');
+  });
+
+  it('does NOT read the legacy Axios .response.data shape (this app has no Axios client left)', () => {
+    const axiosShapedError = {
+      response: { data: 'Forbidden: missing permission' },
+      message: 'Request failed',
+    };
+    // No `.body`, so this falls through to the generic `.message` branch rather than the
+    // Axios-specific `.response.data` a pre-migration caller might expect.
+    expect(getApiErrorMessage(axiosShapedError)).toBe('Request failed');
+  });
+});

--- a/packages/hooks/src/api-error.ts
+++ b/packages/hooks/src/api-error.ts
@@ -1,15 +1,49 @@
 /**
- * Extracts a human-readable message from an error thrown by the generated API client.
+ * Pure, dependency-free helpers for reading errors thrown by the generated RPC client
+ * (`@lightbridge/authz-rpc`). This app has no Axios-based client left: `packages/api-rest` is
+ * generated but has zero importers anywhere in the repo, so there is no other shape to support.
+ *
+ * A failed call throws `CratestackRpcError` (`packages/authz-rpc/generated/src/runtime.ts`),
+ * which puts the HTTP status and the server's decoded error body directly on the instance --
+ * `error.status` and `error.body.message` -- never under an Axios-style `error.response`.
  *
  * Backend error responses (see `lightbridge-authz-core::error::Error`'s `IntoResponse`) are
- * plain text, not JSON — e.g. a 403 body is `"Forbidden: missing required permission: ..."`.
- * Axios surfaces that as `error.response.data`; falls back to the generic Axios message.
+ * often plain text, not JSON -- e.g. a 403 body is `"Forbidden: missing required permission:
+ * ..."`. The generated decoder (`readErrorBody`) only understands cratestack's own `{code,
+ * message}` shape, though; a handler that emits something else -- e.g. the RBAC gate's `{error:
+ * "..."}` -- can't be parsed, so `readErrorBody` falls back to a placeholder body message like
+ * `"RPC call returned status 403 with an unrecognized error body"`. `RPC_PLACEHOLDER_MESSAGE_PATTERN`
+ * below detects that placeholder so it's never surfaced to a user verbatim. `readErrorBody`
+ * itself is generated output and is not fixed here -- see PR #172's `api-key-create-screen.tsx`
+ * for the same detection done locally, ahead of this shared fix, for status-driven copy instead
+ * of a raw message.
+ */
+
+// readErrorBody's own fallback text (packages/authz-rpc/generated/src/runtime.ts) always starts
+// this way when it can't parse a real error body -- it only restates the status the caller
+// already knows, never anything a user should read.
+const RPC_PLACEHOLDER_MESSAGE_PATTERN = /^RPC call returned status \d+/;
+
+// Shown whenever nothing better is available: the placeholder above, or a thrown value with no
+// usable message at all.
+const GENERIC_ERROR_MESSAGE = 'Something went wrong. Please try again.';
+
+/**
+ * Extracts a human-readable message from an error thrown by the generated RPC client. Prefers
+ * `CratestackRpcError.body.message` (the server's decoded error body); falls back to the error's
+ * own `.message` for anything else thrown (e.g. `CratestackRpcTransportError` for a network
+ * failure); falls back to `String(error)` as a last resort so this never throws.
  */
 export function getApiErrorMessage(error: unknown): string {
   if (error && typeof error === 'object') {
-    const data = (error as { response?: { data?: unknown } }).response?.data;
-    if (typeof data === 'string' && data.trim().length > 0) {
-      return data;
+    const body = (error as { body?: unknown }).body;
+    if (body && typeof body === 'object') {
+      const bodyMessage = (body as { message?: unknown }).message;
+      if (typeof bodyMessage === 'string' && bodyMessage.trim().length > 0) {
+        return RPC_PLACEHOLDER_MESSAGE_PATTERN.test(bodyMessage)
+          ? GENERIC_ERROR_MESSAGE
+          : bodyMessage;
+      }
     }
     const message = (error as { message?: unknown }).message;
     if (typeof message === 'string' && message.trim().length > 0) {
@@ -17,4 +51,24 @@ export function getApiErrorMessage(error: unknown): string {
     }
   }
   return String(error);
+}
+
+/**
+ * Extracts the HTTP status code from an error thrown by the generated RPC client, when present.
+ * `CratestackRpcError.status` is set directly on the instance -- see the module comment above for
+ * the full shape. Needed to distinguish a `403` (permission denied, not retryable) from any other
+ * failure (network/5xx, retryable via the same idempotency key where applicable).
+ */
+export function getApiErrorStatus(error: unknown): number | undefined {
+  if (error && typeof error === 'object') {
+    const status = (error as { status?: unknown }).status;
+    if (typeof status === 'number') {
+      return status;
+    }
+  }
+  return undefined;
+}
+
+export function isPermissionDeniedError(error: unknown): boolean {
+  return getApiErrorStatus(error) === 403;
 }

--- a/packages/hooks/src/budget-tiers.ts
+++ b/packages/hooks/src/budget-tiers.ts
@@ -1,5 +1,5 @@
 /**
- * Pure, dependency-free budget helpers (tier ladder, dollar formatting, error-status extraction).
+ * Pure, dependency-free budget helpers (tier ladder, dollar formatting, period formatting).
  * Deliberately split out of `./budget.ts`: that file also defines the mutation/query hooks, which
  * import `@lightbridge/authz-rpc` at the top level -- and that package's `codec.ts` imports
  * `cborg`, whose package.json `exports` map Jest's resolver cannot follow (fails with "Cannot
@@ -94,24 +94,4 @@ export function currentBudgetPeriod(date: Date = new Date()): string {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, '0');
   return `${year}-${month}`;
-}
-
-/**
- * Extracts the HTTP status code from an error thrown by the generated API client, when present.
- * Mirrors `getApiErrorMessage` in `./api-error.ts` but for the status code rather than the
- * message -- needed here specifically to distinguish a `403` (permission denied, not retryable)
- * from any other failure (network/5xx, retryable via the same idempotency key).
- */
-export function getApiErrorStatus(error: unknown): number | undefined {
-  if (error && typeof error === 'object') {
-    const status = (error as { response?: { status?: unknown } }).response?.status;
-    if (typeof status === 'number') {
-      return status;
-    }
-  }
-  return undefined;
-}
-
-export function isPermissionDeniedError(error: unknown): boolean {
-  return getApiErrorStatus(error) === 403;
 }

--- a/packages/hooks/src/budget.test.ts
+++ b/packages/hooks/src/budget.test.ts
@@ -17,9 +17,7 @@ import {
   currentBudgetPeriod,
   formatBudgetTierAmount,
   formatMicroUsd,
-  getApiErrorStatus,
   isBudgetTier,
-  isPermissionDeniedError,
   pendingAugmentationRequestsListQueryKey,
   pendingAugmentationRequestsQueryKey,
 } from './budget';
@@ -106,24 +104,11 @@ describe('createBudgetIdempotencyKey', () => {
   });
 });
 
-describe('getApiErrorStatus / isPermissionDeniedError', () => {
-  it('extracts a numeric status from an axios-shaped error', () => {
-    const error = { response: { status: 403, data: 'Forbidden' } };
-    expect(getApiErrorStatus(error)).toBe(403);
-    expect(isPermissionDeniedError(error)).toBe(true);
-  });
-
-  it('treats a non-403 status as not permission-denied', () => {
-    const error = { response: { status: 500 } };
-    expect(getApiErrorStatus(error)).toBe(500);
-    expect(isPermissionDeniedError(error)).toBe(false);
-  });
-
-  it('returns undefined for an error with no response status', () => {
-    expect(getApiErrorStatus(new Error('network down'))).toBeUndefined();
-    expect(isPermissionDeniedError(new Error('network down'))).toBe(false);
-  });
-});
+// `getApiErrorStatus`/`isPermissionDeniedError` used to live here, tested against an
+// axios-shaped error (`{ response: { status } }`) this app's RPC transport never actually
+// produces -- see git history. They now live in `./api-error.ts` alongside `getApiErrorMessage`
+// (a generic API-error helper, not budget-specific) and are tested in `./api-error.test.ts`
+// against a real `CratestackRpcError`, the shape the generated RPC client actually throws.
 
 describe('pendingAugmentationRequestsListQueryKey', () => {
   it('appends the resolved budgetAccountId on top of the bare prefix', () => {


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Fixes `getApiErrorStatus` / `getApiErrorMessage` / `isPermissionDeniedError` to parse the **RPC** error shape this app actually throws, instead of the Axios shape it abandoned.
- Consolidates all three into `packages/hooks/src/api-error.ts`, exports `CratestackRpcError` / `CratestackRpcTransportError` from `@lightbridge/authz-rpc`'s public index, and adds a `./api-error` subpath to `@lightbridge/hooks`.
- Replaces the tests that asserted the wrong contract, and adds screen-level tests proving the consumers now react.

It solves:

- The defect surfaced in #172's Reviewer Focus: error handling that has been silently dead since the RPC migration.

---

## 2. Intent

The intent of this PR is:

> Make error handling work again on the screens that already have it written.
>
> `getApiErrorStatus` read only `error.response?.status`. `CratestackRpcError` puts `status`, `code` and `body` **directly on the instance** — there is no `.response`. So the helper returned `undefined` for **every** RPC error, and `getApiErrorMessage` fell through to the raw `Error.message` technical string.

---

## 3. Scope

### In Scope

- The three helpers, their new home, the package exports, the tests, and the two screens whose error handling was dead.

### Out of Scope

- **`readErrorBody`** in the generated client, which mangles the RBAC gate's `{error}` shape into a placeholder. Gitignored, regenerated on install; tracked separately. This PR detects the placeholder instead of depending on a fix.
- The three files PR #172 owns — it derives copy from `status` locally and deliberately does not use these helpers, which is why it worked.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [x] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
pnpm -r --if-present run test
pnpm lint
pnpm build
cd apps/self-service && npx tsc --noEmit ; echo "exit: $?"
```

Results:

```text
tests:  authz-rpc 14, hooks 64, self-service 190 — all pass
tsc:    exit: 0, 0 errors   (captured directly, not through a pipe)
build:  turbo run build:web succeeded, real Metro/Expo web export
lint:   6 pre-existing errors, identical to baseline via git stash. New warnings are
        import/first in test files, matching the repo's existing mock-before-import convention.
```

Rebased onto `main` after #172 merged and re-verified independently by the orchestrator: `tsc` 0 errors, build green, and confirmed this branch touches no i18n so the two changes stayed disjoint.

### Consumers that were broken, now fixed

- **`budget-refill-screen.tsx` showed no error UI on any failure.** With `errorStatus` permanently `undefined`, `isPermissionError`, `isOtherError` **and** `canRetry` in `budget-refill-view.tsx` were all false. The 403 handling #148 explicitly required and #158 shipped was dead on arrival.
- **`project-settings-screen.tsx`** leaked technical strings — `RPC call failed with code internal (status 403): …` — through `memberError` / `statusError` / `setDefaultError`.
- A repo-wide grep also found `account-settings-screen.tsx` and `budget-review-screen.tsx`, both `getApiErrorMessage`-only consumers that are fixed for free by the helper change.

### Why the old tests passed

`budget.test.ts` contained a case literally titled *"extracts a numeric status from an **axios-shaped** error"*, constructing `{ response: { status: 403, data: 'Forbidden' } }` — a shape this runtime never produces. **That block was deleted, not adapted**, and replaced with a comment recording where the tests moved and why the old shape was wrong.

The new unit tests in `api-error.test.ts` construct **real `CratestackRpcError` / `CratestackRpcTransportError` instances**, which required exporting them from the `authz-rpc` public index (previously reachable only via a deep `../generated/src/runtime` path). A test that invents its own error shape is what allowed this bug to survive a migration; the fix should not re-arm that trap.

The screen-level tests pull the **real** helpers back in via `jest.requireActual('@lightbridge/hooks/api-error')` while mocking the rest of the barrel, and feed them `CratestackRpcError`-shaped literals. Full class construction is impractical under Jest here because importing `@lightbridge/authz-rpc` drags in the React Native entry point — a constraint already documented in this repo. **Flagging that honestly:** unit tests use real instances, screen tests use duck-typed literals matching the same convention #172 used.

---

## 5. Screenshots / Evidence

**No screenshots** — Keycloak-gated. The screen-level tests are the evidence that the UI now reacts.

---

## 6. Risk Assessment

Risk level:

* [ ] Low
* [x] Medium
* [ ] High

This changes shared helpers used by five screens, and it moves code between modules.

Potential risks:

* A consumer relying on the old (always-`undefined`) behaviour, e.g. treating "no status" as a safe default.
* Import-path breakage from consolidating the helpers.
* Surfacing a raw placeholder string to users once messages start flowing.

Mitigation:

* Every consumer was found by repo-wide grep and checked; the two with real logic gained screen-level tests asserting they now react. Nothing depended on `undefined` — that was the bug.
* The move is import-path-neutral: `@lightbridge/hooks`'s barrel already re-exports both modules at the top level, and no consumer imported these two symbols through the `./budget-tiers` subpath. Verified.
* The `readErrorBody` placeholder (`"RPC call returned status <n> with an unrecognized error body"`) is detected centrally by pattern and swapped for a generic user-facing message — the same defect #172 handles locally, so the app converges on one convention rather than two.

### Decisions taken deliberately

- **The Axios branch was removed, not kept as a fallback.** `packages/api-rest` is generated but has zero real importers anywhere in the repo, so no live path can throw that shape. Keeping a branch for an impossible shape is exactly the dormant code that let this rot unnoticed.
- **The helpers moved out of `budget-tiers.ts` into `api-error.ts`.** A generic API-error helper living in a budget-specific module is how `getApiErrorStatus` ended up with budget-only test coverage in the first place.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Refactoring
* [x] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Implemented by Claude Code (Sonnet subagent under an Opus 5 orchestrator) on behalf of @stephane-segning. The agent was instructed to **replace** the existing tests rather than adapt them, and to prove the consumers react rather than that the helper returns the right number — both because a passing test over an invented shape is what hid this defect through an entire migration.

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

**Human attestation pending @stephane-segning's review** — an agent must not tick the accountable human's boxes on their behalf.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Architecture
* [ ] Security
* [ ] Performance
* [x] Tests
* [ ] Maintainability
* [ ] Product intent
* [x] Edge cases

Specifically:

1. **Was anything relying on the broken behaviour?** The helpers returned `undefined` for every RPC error, so any consumer whose "no status" branch was the de-facto path now takes a different one. The two screens with real logic are tested, but a second pair of eyes on the other three is worth it.
2. **Is the placeholder-detection regex the right place for that logic?** It compensates centrally for a defect in generated code. When `readErrorBody` is fixed properly the regex becomes dead and should be removed — worth a comment linking the two so it does not outlive its cause.
