### PR TITLE
ci: gate pull requests on typecheck and the real web build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,3 +36,105 @@ jobs:
 
       - name: Run tests
         run: pnpm test
+
+  # tsc is not run by Metro/Expo's bundler (see the `build-web` job below) and
+  # nothing else on the pull_request path turns a type error into a failed
+  # check — quality.yml's tsc step never fails the PR (see docs/knowledge/ci-cd.md,
+  # "Known Gaps" #2). This job is the actual enforcement point. A separate job
+  # (rather than an extra step on `test`) costs one more `pnpm install`, but buys
+  # a distinctly-named, independently-attributable check in the PR list — a type
+  # error and a failing Jest test must not look like the same red X.
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Discover every workspace's tsconfig.json rather than hardcoding
+      # `apps/self-service` + `packages/ui` (the two that exist today) — this
+      # mirrors the discovery already used by .ci/quality/run.sh, so a workspace
+      # that gains a tsconfig.json later is picked up automatically instead of
+      # becoming a second stale hardcoded list.
+      #
+      # `-maxdepth 2` is deliberate, not arbitrary: pnpm-workspace.yaml declares
+      # the workspaces as `apps/*` and `packages/*`, so a workspace root is
+      # always exactly one level down and its tsconfig.json exactly two. A
+      # tsconfig nested deeper than that belongs to something that is not a
+      # workspace root, and `tsc -p` on it would not be this gate's job. If the
+      # workspace globs in pnpm-workspace.yaml ever gain a level, this depth
+      # must change with them.
+      #
+      # Exit codes are captured directly (never through a pipe into another
+      # command) so a `tsc` failure can't be swallowed.
+      #
+      # `shell: bash` is explicit, not incidental: GitHub Actions' implicit
+      # default for a `run:` step with no `shell:` is `bash -e {0}`, and `-e`
+      # is NOT cleared by this script's own `set -uo pipefail`. Under `-e`,
+      # `pnpm exec tsc ...; cfg_exit=$?; [ "$cfg_exit" -ne 0 ] && ...` would
+      # abort the step at the first failing workspace instead of checking the
+      # rest — the accumulation loop would silently never run past the first
+      # failure. `cmd || tsc_status=1` sidesteps this because a command on the
+      # left of `||` is exempt from `-e` by POSIX shell semantics, regardless
+      # of which shell (implicit or pinned) is running it.
+      - name: Typecheck all workspaces
+        shell: bash
+        run: |
+          set -uo pipefail
+          mapfile -t tsconfigs < <(find apps packages -maxdepth 2 -name tsconfig.json \
+            -not -path '*/node_modules/*' -not -path '*/generated/*' | sort)
+          if [ "${#tsconfigs[@]}" -eq 0 ]; then
+            echo "::error::No tsconfig.json found under apps/ or packages/ — the typecheck gate would be a no-op"
+            exit 1
+          fi
+          tsc_status=0
+          for cfg in "${tsconfigs[@]}"; do
+            echo "::group::tsc --noEmit -p $cfg"
+            pnpm exec tsc --noEmit -p "$cfg" || tsc_status=1
+            echo "::endgroup::"
+          done
+          exit "$tsc_status"
+
+  # Metro/Expo's bundler does not typecheck, so `pnpm build` can succeed on code
+  # `tsc` rejects — that's the `typecheck` job's job, not this one's. This job
+  # exists because, before it, `docker-image.yml` (push-to-main/tag only) was
+  # the *only* place `turbo run build:web` ran in CI: a broken Expo web export
+  # could merge and sit on main across any number of unrelated PRs until the
+  # next push to main caught it post-merge (see docs/knowledge/ci-cd.md, Known
+  # Gap #1 — this happened for two weeks before it was caught). `pnpm build` is
+  # the root task name (`turbo run build:web`); `pnpm build:web` doesn't exist
+  # at the root. Turbo's `build:web` task already declares `codegen` as a
+  # `dependsOn` (turbo.json), so no separate codegen step is added here.
+  build-web:
+    name: Web build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build web export (Turbo)
+        run: pnpm build


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds two `pull_request`-triggered jobs to `.github/workflows/test.yml`: **Typecheck** (`tsc --noEmit` across every workspace with a `tsconfig.json`) and **Web build** (`pnpm build` → the real Expo web export).
- Only `.github/workflows/test.yml` changed. No application code.

It solves:

- Known Gaps 1 and 2 recorded in `docs/knowledge/ci-cd.md` (added in #170): **no PR can fail the web build**, and **no PR-level typecheck exists**.

---

## 2. Intent

The intent of this PR is:

> Make two whole classes of breakage visible on a pull request instead of after merge.
>
> Both gaps are load-bearing, not theoretical. `docker-image.yml` is the only workflow that runs `build:web` and it triggers solely on `push`→`main` and `v*` tags, so a broken Expo web export sat in `main` for two weeks across six unrelated merges — last green image 2026-08-01, fixed in #151. Separately, Metro does not typecheck: during #166, `pnpm build` and the full test suite were green while `tsc --noEmit` exited 2 on a duplicate-`@react-navigation` type conflict.

---

## 3. Scope

### In Scope

- The two new jobs and their verification.

### Out of Scope — each a separate decision, deliberately untouched

- **The Code Quality Scan's missing scanners.** `semgrep`, `hadolint`, `actionlint`, `jscpd` and `reviewdog` are all absent from `ubuntu-latest` and skipped silently, so that check passes while examining nothing.
- **The `pnpm lint` / Prettier disagreement** — `pnpm lint` fails on `main` at the ESLint stage.
- **Branch protection.** See Risk Assessment: without it these gates inform but do not enforce.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

**A gate that cannot fail is worse than no gate** — this repo already has one. So these were proven to fail, not just read for correctness. The committed step script was extracted and run under real `bash -e`:

```text
# clean tree
::group::tsc --noEmit -p apps/self-service/tsconfig.json
::endgroup::
::group::tsc --noEmit -p packages/ui/tsconfig.json
::endgroup::
exit: 0

# BOTH workspaces broken simultaneously
apps/self-service/src/__orch2.ts(1,14): error TS2322: Type 'string' is not assignable to type 'number'.
packages/ui/src/__orch2.ts(1,14): error TS2322: Type 'string' is not assignable to type 'number'.
exit: 1          <- both reported, not just the first

# reverted
exit: 0
```

The web-build gate was proven the same way, using the realistic failure: an unresolvable import in `_layout.tsx` — the exact shape of the two-week outage — produced `Unable to resolve module …` and exit 1, then reverted to green.

Clean-tree baselines: `tsc --noEmit` exit 0 in both `apps/self-service` and `packages/ui`; `pnpm build` succeeds. **No pre-existing failure on `main` is exposed by either gate.**

All of the above was re-run independently by the orchestrator against the **committed** content (`git show HEAD:…`), not the working tree.

---

## 5. Screenshots / Evidence

Not applicable — the command output above is the evidence. Real GitHub Actions timings could not be measured without pushing; see the estimate below.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* **A gate that silently becomes a no-op** — the exact failure mode of the existing Code Quality Scan.
* **Shell semantics hiding failures.** GitHub runs `run:` as `bash -e {0}` on Linux.
* Added CI wall-clock.

Mitigation:

* The typecheck job **discovers** `tsconfig.json` files rather than hardcoding today's two, mirroring the discovery `.ci/quality/run.sh` already uses — so a new workspace is covered automatically instead of silently skipped. If discovery ever finds **zero** configs it emits `::error::` and exits 1, so the gate cannot degrade into a green no-op.
* `shell: bash` is pinned explicitly and failures are captured as `cmd || tsc_status=1`. An earlier revision used `cmd; cfg_exit=$?`, which under `-e` aborted at the first failing workspace and never reached the accumulation — the fix was verified by running the **old** script side by side: it stopped after one failure and exited `2` instead of `1`. No workflow step pipes an exit-bearing command into another (`| tail`, `| grep`), which would mask a failure behind the pipe's status.
* Both new jobs run in parallel with `test` (no `needs:`), so the net addition to "all checks green" is roughly **1–2 minutes**, with `build-web` likely the new critical path. **This is an estimate, not measured** — a local Turbo cache made a true cold build unmeasurable, and `ubuntu-latest` never persists one.

### The limitation worth stating plainly

**`main` has no branch protection** (`GET /branches/main/protection` returns 404). These checks will show red on a PR but will not *block* a merge. They make breakage visible, which is what was missing — but enforcement requires enabling branch protection and marking these checks required, which is a repo-settings decision outside this PR.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [ ] Generating tests
* [x] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Implemented by Claude Code (Sonnet subagent under an Opus 5 orchestrator) on behalf of @stephane-segning. The agent was told that proving the gates can fail was the deliverable, not the YAML — which is why the break/pass cycles exist. It also caught its own `git commit --amend` slip (amending the message without staging the fix, leaving the buggy script committed) by inspecting `git show` output rather than trusting the amend.

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

**Human attestation pending @stephane-segning's review** — an agent must not tick the accountable human's boxes on their behalf.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [ ] Performance
* [ ] Tests
* [x] Maintainability
* [ ] Product intent
* [x] Edge cases

Two things worth your call:

1. **Separate jobs vs. steps on `test`.** Separate jobs cost one extra `pnpm install` each but give three independently named checks, so a type error and a failing Jest test are never the same red X. If CI minutes matter more than attribution, folding them into `test` is the cheaper trade.
2. **Branch protection.** Without it this PR buys visibility, not enforcement — and the outage it addresses happened *because* nothing surfaced the failure, so visibility may be sufficient. Worth deciding explicitly rather than by default.
