### PR TITLE
fix(rbac): sync DEFAULT_ROLE_PERMISSIONS with prod grants (lightbridge-authz#325)

### DIFF
--- a/apps/self-service/src/navigation/settings-categories.ts
+++ b/apps/self-service/src/navigation/settings-categories.ts
@@ -11,12 +11,16 @@ export type SettingsCategory = {
   iconName: FeatherIconName;
   route: `/${string}`;
   /**
-   * When set, the category is only shown to a caller who holds this permission (#148) --
-   * `budget:self-refill`/`budget:review` are unresolved-by-role as of ADORSYS-GIS/
-   * lightbridge-authz#294, so both budget rows must stay hidden by default rather than shown to
-   * everyone. `account`/`project`/`apikey` have no gate: every authenticated caller can reach
-   * them (the detail screen itself hides individual actions per `apikey:*` grants, same as the
-   * account/project screens do for their own danger-zone actions).
+   * When set, the category is only shown to a caller who holds this permission (#148). Which
+   * role(s) should carry `budget:self-refill`/`budget:review` was unresolved-by-role as of
+   * ADORSYS-GIS/lightbridge-authz#294; that resolved via lightbridge-authz#325, which granted
+   * `budget:self-refill` to `lightbridge-editor` (not `lightbridge-viewer`) in prod's
+   * `oauth2.rbac.role_permissions`, mirrored into `DEFAULT_ROLE_PERMISSIONS`
+   * (`packages/hooks/src/rbac.ts`). `budget:review` is still admin-only, so the "Budget review"
+   * row stays hidden for editor/viewer. `account`/`project`/`apikey` have no gate: every
+   * authenticated caller can reach them (the detail screen itself hides individual actions per
+   * `apikey:*` grants, same as the account/project screens do for their own danger-zone
+   * actions).
    */
   requiredPermission?: Permission;
 };

--- a/docs/knowledge/authorization-and-permissions.md
+++ b/docs/knowledge/authorization-and-permissions.md
@@ -40,21 +40,22 @@ app's own code comments.
 `packages/hooks/src/rbac.ts` opens with this doc comment, worth quoting verbatim because it is the
 authoritative statement of what this layer is for:
 
-> Client-side mirror of `lightbridge-authz-core::authz`... This is a *UI convenience*, not a
+> Client-side mirror of `lightbridge-authz-core::authz`... This is a _UI convenience_, not a
 > security boundary — the backend is the source of truth and still enforces every permission
 > server-side. Getting this out of sync only shows/hides the wrong control; it can never grant
 > access the server wouldn't otherwise allow.
 
 ### `ALL_PERMISSIONS`
 
-A flat, ordered array of 28 permission strings, grouped by resource:
+A flat, ordered array of 31 permission strings, grouped by resource:
 
-| Resource | Count | Permissions |
-| -------- | ----- | ----------- |
-| `account` | 5 | `create`, `read`, `update`, `delete`, `disable` |
-| `project` | 6 | `create`, `read`, `update`, `delete`, `disable`, `member` |
-| `apikey`  | 7 | `create`, `read`, `update`, `delete`, `revoke`, `rotate`, `validate` |
-| `budget`  | 10 | `read`, `self-refill`, `review`, `grant`, `revoke`, `audit-read`, `policy-read`, `policy-write`, `policy-simulate`, `policy-activate` |
+| Resource  | Count | Permissions                                                                                                                                       |
+| --------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `account` | 5     | `create`, `read`, `update`, `delete`, `disable`                                                                                                   |
+| `project` | 6     | `create`, `read`, `update`, `delete`, `disable`, `member`                                                                                         |
+| `apikey`  | 7     | `create`, `read`, `update`, `delete`, `revoke`, `rotate`, `validate`                                                                              |
+| `budget`  | 11    | `read`, `read-own`, `self-refill`, `review`, `grant`, `revoke`, `audit-read`, `policy-read`, `policy-write`, `policy-simulate`, `policy-activate` |
+| `session` | 2     | `revoke-own`, `revoke`                                                                                                                            |
 
 The `Permission` TypeScript type is `(typeof ALL_PERMISSIONS)[number]` — derived from the array, not
 declared independently, so the two can't drift apart inside this file. The **order** matters too:
@@ -69,10 +70,30 @@ The built-in role → grant mapping, used whenever the backend has no
 ```typescript
 export const DEFAULT_ROLE_PERMISSIONS: Record<string, string[]> = {
   'lightbridge-admin': ['*'],
-  'lightbridge-editor': ['account:read', 'project:*', 'apikey:*'],
-  'lightbridge-viewer': ['account:read', 'project:read', 'apikey:read'],
+  'lightbridge-editor': [
+    'account:create',
+    'account:read',
+    'project:*',
+    'apikey:*',
+    'budget:self-refill',
+    'budget:read-own',
+    'session:revoke-own',
+  ],
+  'lightbridge-viewer': [
+    'account:create',
+    'account:read',
+    'project:read',
+    'apikey:read',
+    'budget:read-own',
+    'session:revoke-own',
+  ],
 };
 ```
+
+`editor`/`viewer` both gained `account:create`, `budget:read-own`, and `session:revoke-own` in
+lightbridge-authz#325 (mirroring prod's `oauth2.rbac.role_permissions` in ai-helm-values'
+`environments/prod/values/lightbridge-app.yaml`); `editor` alone also gained `budget:self-refill`.
+See the "gotcha" section below for how this mapping stayed stale against prod for two releases.
 
 ### Wildcard expansion (`expandGrant`)
 
@@ -215,13 +236,18 @@ specific project, and a non-lead editor's roster mutation will be rejected serve
 that array is automatically included in every existing `'*'` grant, whether or not anyone reviewed
 that specific role for that specific new capability.
 
-This already happened once, and `rbac.ts`'s own comment records it happening:
-
-> NOTE ON `budget:*`: `lightbridge-admin`'s bare `'*'` grant now also expands to the ten `budget:*`
-> permissions added alongside `ALL_PERMISSIONS` above, including `budget:policy-activate`. That is
-> unreviewed here on purpose — which role(s) should carry `budget:self-refill` and the other budget
-> permissions is still open in ADORSYS-GIS/lightbridge-authz#294, so `editor`/`viewer` deliberately
-> do NOT get any `budget:*` grant yet.
+This already happened once. When the ten (now eleven, plus two `session:*`) budget/session
+permissions were first added to `ALL_PERMISSIONS`, `lightbridge-admin`'s bare `'*'` grant picked
+them all up automatically, while `editor`/`viewer` got none of them — deliberately, per `rbac.ts`'s
+comment at the time, because which role(s) should carry `budget:self-refill` and friends was still
+open in ADORSYS-GIS/lightbridge-authz#294. That went stale: prod's `oauth2.rbac.role_permissions`
+resolved #294 via lightbridge-authz#325, granting `budget:self-refill`/`budget:read-own`/
+`session:revoke-own` to `lightbridge-editor` and `budget:read-own`/`session:revoke-own` to
+`lightbridge-viewer` — but `DEFAULT_ROLE_PERMISSIONS` here was never updated to match, for two
+releases, silently hiding the "Budget" settings nav row (gated on `budget:self-refill`, see
+`apps/self-service/src/navigation/settings-categories.ts`) from every production editor until this
+was caught and fixed. The `'*'`-widens-silently behavior itself is unchanged and remains worth
+watching on the next new permission.
 
 `budget:policy-activate` gates `activateBudgetPolicy` — a platform-wide operation that overwrites
 which budget policy revision is live for every tenant at once (see the procedure comment in
@@ -229,7 +255,7 @@ which budget policy revision is live for every tenant at once (see the procedure
 grepping the app and `packages/hooks`/`packages/authz-rpc` for `policy-activate`/`policyActivate` —
 the only hits are the schema comments and `rbac.ts` itself); the product deliberately does not
 expose it here. Any `lightbridge-admin`-permissioned caller of this frontend's RPC client can still
-invoke it directly, though, since the *server-side* RBAC gate — not this app's UI — is what actually
+invoke it directly, though, since the _server-side_ RBAC gate — not this app's UI — is what actually
 grants or denies the call.
 
 **Lesson for future permission additions:** extending `ALL_PERMISSIONS` for an unrelated feature is

--- a/packages/hooks/src/rbac.test.ts
+++ b/packages/hooks/src/rbac.test.ts
@@ -39,12 +39,14 @@ describe('expandGrant', () => {
   });
 });
 
-describe('budget:* permissions (issue #147)', () => {
-  // The backend's Permission::ALL declares these ten budget permissions immediately after the
-  // apikey:* group, in this exact order. Asserted as a literal array (not just "contains") so
-  // any accidental reorder/alphabetization fails loudly.
+describe('budget:*/session:* permissions (issue #147, lightbridge-authz#325)', () => {
+  // The backend's Permission::ALL declares these eleven budget permissions immediately after the
+  // apikey:* group, in this exact order (budget:read-own added by lightbridge-authz#325, right
+  // after budget:read). Asserted as a literal array (not just "contains") so any accidental
+  // reorder/alphabetization fails loudly.
   const BUDGET_PERMISSIONS_IN_ORDER = [
     'budget:read',
+    'budget:read-own',
     'budget:self-refill',
     'budget:review',
     'budget:grant',
@@ -56,51 +58,82 @@ describe('budget:* permissions (issue #147)', () => {
     'budget:policy-activate',
   ] as const;
 
-  it('ALL_PERMISSIONS has exactly 28 entries: the original 18 plus the ten budget:* additions', () => {
-    expect(ALL_PERMISSIONS).toHaveLength(28);
+  // Declared immediately after the budget:* group, at the very end of Permission::ALL
+  // (lightbridge-authz#325).
+  const SESSION_PERMISSIONS_IN_ORDER = ['session:revoke-own', 'session:revoke'] as const;
+
+  it('ALL_PERMISSIONS has exactly 31 entries: the original 18, plus the eleven budget:* additions, plus the two session:* additions', () => {
+    expect(ALL_PERMISSIONS).toHaveLength(31);
   });
 
-  it('all ten budget permissions are present, in the backend declaration order, after apikey:*', () => {
+  it('all eleven budget permissions are present, in the backend declaration order, immediately after apikey:*', () => {
     const lastApikeyIndex = ALL_PERMISSIONS.lastIndexOf('apikey:validate');
-    const budgetSlice = ALL_PERMISSIONS.slice(lastApikeyIndex + 1);
+    const budgetSlice = ALL_PERMISSIONS.slice(
+      lastApikeyIndex + 1,
+      lastApikeyIndex + 1 + BUDGET_PERMISSIONS_IN_ORDER.length
+    );
     expect(budgetSlice).toEqual(BUDGET_PERMISSIONS_IN_ORDER);
   });
 
-  it('every budget permission appears in ALL_PERMISSIONS in relative order', () => {
-    const indices = BUDGET_PERMISSIONS_IN_ORDER.map((permission) =>
-      ALL_PERMISSIONS.indexOf(permission)
+  it('both session permissions are present, in the backend declaration order, as the final two entries', () => {
+    const sessionSlice = ALL_PERMISSIONS.slice(-SESSION_PERMISSIONS_IN_ORDER.length);
+    expect(sessionSlice).toEqual(SESSION_PERMISSIONS_IN_ORDER);
+  });
+
+  it('every budget/session permission appears in ALL_PERMISSIONS in relative order', () => {
+    const indices = [...BUDGET_PERMISSIONS_IN_ORDER, ...SESSION_PERMISSIONS_IN_ORDER].map(
+      (permission) => ALL_PERMISSIONS.indexOf(permission)
     );
     expect(indices.every((index) => index !== -1)).toBe(true);
     const sorted = [...indices].sort((a, b) => a - b);
     expect(indices).toEqual(sorted);
   });
 
-  it('`*` expands to include every budget permission, including the hyphenated ones', () => {
+  it('`*` expands to include every budget/session permission, including the hyphenated ones', () => {
     const all = expandGrant('*');
-    for (const permission of BUDGET_PERMISSIONS_IN_ORDER) {
+    for (const permission of [...BUDGET_PERMISSIONS_IN_ORDER, ...SESSION_PERMISSIONS_IN_ORDER]) {
       expect(all).toContain(permission);
     }
   });
 
-  it('`budget:*` expands to exactly the ten budget permissions and nothing else', () => {
+  it('`budget:*` expands to exactly the eleven budget permissions and nothing else', () => {
     const budget = expandGrant('budget:*');
-    expect(budget).toHaveLength(10);
+    expect(budget).toHaveLength(11);
     expect(budget).toEqual(BUDGET_PERMISSIONS_IN_ORDER);
     expect(budget).not.toContain('apikey:validate');
     expect(budget).not.toContain('account:create');
+    expect(budget).not.toContain('session:revoke-own');
+  });
+
+  it('`session:*` expands to exactly the two session permissions and nothing else', () => {
+    const session = expandGrant('session:*');
+    expect(session).toHaveLength(2);
+    expect(session).toEqual(SESSION_PERMISSIONS_IN_ORDER);
+    expect(session).not.toContain('budget:self-refill');
   });
 
   it('resourceOf-driven expansion is not fooled by the hyphen or extra segment in the action', () => {
-    // budget:audit-read and budget:policy-simulate each contain a hyphen AND, textually, an
-    // internal '-' that must NOT be mistaken for a second ':' resource separator. Confirm they
-    // land under the `budget` resource, not e.g. a phantom `budget:audit` or `budget:policy`.
+    // budget:audit-read, budget:policy-simulate, budget:read-own, and session:revoke-own each
+    // contain a hyphen AND, textually, an internal '-' that must NOT be mistaken for a second ':'
+    // resource separator. Confirm they land under their real resource, not e.g. a phantom
+    // `budget:audit`/`budget:policy`/`budget:read`/`session:revoke`.
     const budget = expandGrant('budget:*');
     expect(budget).toContain('budget:audit-read');
     expect(budget).toContain('budget:policy-simulate');
+    expect(budget).toContain('budget:read-own');
+    const session = expandGrant('session:*');
+    expect(session).toContain('session:revoke-own');
     // And exact-match grants for the hyphenated permissions resolve to themselves only.
     expect(expandGrant('budget:audit-read')).toEqual(['budget:audit-read']);
     expect(expandGrant('budget:policy-simulate')).toEqual(['budget:policy-simulate']);
     expect(expandGrant('budget:self-refill')).toEqual(['budget:self-refill']);
+    expect(expandGrant('budget:read-own')).toEqual(['budget:read-own']);
+    expect(expandGrant('session:revoke-own')).toEqual(['session:revoke-own']);
+    // `budget:read` is a distinct, non-hyphenated exact grant -- it must NOT pull in the
+    // hyphenated `budget:read-own` permission just because it's a string prefix.
+    expect(expandGrant('budget:read')).toEqual(['budget:read']);
+    // Same for the admin `session:revoke` vs the self-service `session:revoke-own`.
+    expect(expandGrant('session:revoke')).toEqual(['session:revoke']);
   });
 
   it('a near-miss grant string does not accidentally match a hyphenated permission', () => {
@@ -108,22 +141,58 @@ describe('budget:* permissions (issue #147)', () => {
     expect(expandGrant('budget:audit')).toEqual([]);
     expect(expandGrant('budget:policy')).toEqual([]);
     expect(expandGrant('budget:self')).toEqual([]);
+    expect(expandGrant('budget:read-own-extra')).toEqual([]);
   });
 
-  it('lightbridge-admin (bare "*") now also carries every budget permission', () => {
+  it('lightbridge-admin (bare "*") now also carries every budget/session permission', () => {
     const admin = permissionsForRoles(['lightbridge-admin']);
-    for (const permission of BUDGET_PERMISSIONS_IN_ORDER) {
+    for (const permission of [...BUDGET_PERMISSIONS_IN_ORDER, ...SESSION_PERMISSIONS_IN_ORDER]) {
       expect(admin.has(permission)).toBe(true);
     }
     expect(admin.size).toBe(ALL_PERMISSIONS.length);
   });
 
-  it('lightbridge-editor and lightbridge-viewer do NOT carry any budget:* grant (unresolved: lightbridge-authz#294)', () => {
+  it('lightbridge-editor carries budget:self-refill/budget:read-own/session:revoke-own but no other budget:*/session:* grant (lightbridge-authz#325, resolves #294)', () => {
     const editor = permissionsForRoles(['lightbridge-editor']);
+    expect(editor.has('budget:self-refill')).toBe(true);
+    expect(editor.has('budget:read-own')).toBe(true);
+    expect(editor.has('session:revoke-own')).toBe(true);
+    const adminOnlyGrants: readonly string[] = [
+      'budget:read',
+      'budget:review',
+      'budget:grant',
+      'budget:revoke',
+      'budget:audit-read',
+      'budget:policy-read',
+      'budget:policy-write',
+      'budget:policy-simulate',
+      'budget:policy-activate',
+      'session:revoke',
+    ];
+    for (const permission of adminOnlyGrants) {
+      expect(editor.has(permission as (typeof ALL_PERMISSIONS)[number])).toBe(false);
+    }
+  });
+
+  it('lightbridge-viewer carries budget:read-own/session:revoke-own but NOT budget:self-refill or any other budget:*/session:* grant (lightbridge-authz#325, resolves #294)', () => {
     const viewer = permissionsForRoles(['lightbridge-viewer']);
-    for (const permission of BUDGET_PERMISSIONS_IN_ORDER) {
-      expect(editor.has(permission)).toBe(false);
-      expect(viewer.has(permission)).toBe(false);
+    expect(viewer.has('budget:read-own')).toBe(true);
+    expect(viewer.has('session:revoke-own')).toBe(true);
+    expect(viewer.has('budget:self-refill')).toBe(false);
+    const adminOnlyGrants: readonly string[] = [
+      'budget:read',
+      'budget:review',
+      'budget:grant',
+      'budget:revoke',
+      'budget:audit-read',
+      'budget:policy-read',
+      'budget:policy-write',
+      'budget:policy-simulate',
+      'budget:policy-activate',
+      'session:revoke',
+    ];
+    for (const permission of adminOnlyGrants) {
+      expect(viewer.has(permission as (typeof ALL_PERMISSIONS)[number])).toBe(false);
     }
   });
 });
@@ -135,17 +204,32 @@ describe('permissionsForRoles (default mapping)', () => {
     expect(admin.has('account:delete')).toBe(true);
   });
 
-  it('viewer role is read-only', () => {
+  it('viewer role is read-only for account/project/apikey, plus self-service budget/session grants (lightbridge-authz#325)', () => {
     const viewer = permissionsForRoles(['lightbridge-viewer']);
     expect(viewer.has('project:read')).toBe(true);
     expect(viewer.has('project:create')).toBe(false);
     expect(viewer.has('account:delete')).toBe(false);
+    // account:create was added to the viewer role by lightbridge-authz#325 (mirrors prod's
+    // oauth2.rbac.role_permissions) -- it does NOT make the role broadly "account write", it's a
+    // deliberate single addition alongside the self-service budget/session grants below.
+    expect(viewer.has('account:create')).toBe(true);
+    expect(viewer.has('account:update')).toBe(false);
+    // Self-service grants every authenticated caller needs regardless of role.
+    expect(viewer.has('budget:read-own')).toBe(true);
+    expect(viewer.has('session:revoke-own')).toBe(true);
+    // But NOT the self-refill/admin/review grants -- viewer stays read-only for those.
+    expect(viewer.has('budget:self-refill')).toBe(false);
+    expect(viewer.has('budget:review')).toBe(false);
+    expect(viewer.has('session:revoke')).toBe(false);
   });
 
-  it('editor role can manage projects and api-keys but not accounts', () => {
+  it('editor role can manage projects and api-keys, self-refill budget, and manage own sessions, but not admin account/budget/session actions', () => {
     const editor = permissionsForRoles(['lightbridge-editor']);
     expect(editor.has('account:read')).toBe(true);
-    expect(editor.has('account:create')).toBe(false);
+    // account:create was added to the editor role by lightbridge-authz#325 (mirrors prod's
+    // oauth2.rbac.role_permissions); editors still cannot update/delete/disable accounts.
+    expect(editor.has('account:create')).toBe(true);
+    expect(editor.has('account:update')).toBe(false);
     expect(editor.has('account:disable')).toBe(false);
     expect(editor.has('project:create')).toBe(true);
     expect(editor.has('project:disable')).toBe(true);
@@ -155,6 +239,14 @@ describe('permissionsForRoles (default mapping)', () => {
     // if editors should not manage rosters, the default mapping has to list grants individually
     // instead of using the wildcard, on this side AND in the backend's default_role_permissions.
     expect(editor.has('project:member')).toBe(true);
+    // Self-service budget/session grants added by lightbridge-authz#325.
+    expect(editor.has('budget:self-refill')).toBe(true);
+    expect(editor.has('budget:read-own')).toBe(true);
+    expect(editor.has('session:revoke-own')).toBe(true);
+    // Still no admin-only budget/session actions.
+    expect(editor.has('budget:review')).toBe(false);
+    expect(editor.has('budget:grant')).toBe(false);
+    expect(editor.has('session:revoke')).toBe(false);
   });
 
   it('unions grants across multiple roles and ignores unknown roles', () => {

--- a/packages/hooks/src/rbac.ts
+++ b/packages/hooks/src/rbac.ts
@@ -29,6 +29,7 @@ export const ALL_PERMISSIONS = [
   'apikey:rotate',
   'apikey:validate',
   'budget:read',
+  'budget:read-own',
   'budget:self-refill',
   'budget:review',
   'budget:grant',
@@ -38,6 +39,8 @@ export const ALL_PERMISSIONS = [
   'budget:policy-write',
   'budget:policy-simulate',
   'budget:policy-activate',
+  'session:revoke-own',
+  'session:revoke',
 ] as const;
 
 export type Permission = (typeof ALL_PERMISSIONS)[number];
@@ -55,16 +58,35 @@ export type Permission = (typeof ALL_PERMISSIONS)[number];
  * If editors should not manage rosters, both sides have to list grants individually instead of
  * using the wildcard.
  *
- * NOTE ON `budget:*`: `lightbridge-admin`'s bare `'*'` grant now also expands to the ten
- * `budget:*` permissions added alongside `ALL_PERMISSIONS` above, including `budget:policy-activate`.
- * That is unreviewed here on purpose — which role(s) should carry `budget:self-refill` and the
- * other budget permissions is still open in ADORSYS-GIS/lightbridge-authz#294, so `editor`/`viewer`
- * deliberately do NOT get any `budget:*` grant yet. Revisit this mapping once #294 resolves.
+ * NOTE ON `budget:*`/`session:*`: `lightbridge-admin`'s bare `'*'` grant now also expands to the
+ * eleven `budget:*` permissions (including `budget:read-own`) and the two `session:*` permissions
+ * added alongside `ALL_PERMISSIONS` above. Which role(s) should carry `budget:self-refill` and the
+ * other self-service grants was open in ADORSYS-GIS/lightbridge-authz#294; that resolved via
+ * lightbridge-authz#325, which granted `budget:self-refill`/`budget:read-own`/`session:revoke-own`
+ * to `editor`, and `budget:read-own`/`session:revoke-own` (but not self-refill) to `viewer` — mirrored
+ * here from prod's `oauth2.rbac.role_permissions` in ai-helm-values'
+ * `environments/prod/values/lightbridge-app.yaml`. Both roles still get no other `budget:*` grant
+ * (review/grant/revoke/audit/policy-* stay admin-only).
  */
 export const DEFAULT_ROLE_PERMISSIONS: Record<string, string[]> = {
   'lightbridge-admin': ['*'],
-  'lightbridge-editor': ['account:read', 'project:*', 'apikey:*'],
-  'lightbridge-viewer': ['account:read', 'project:read', 'apikey:read'],
+  'lightbridge-editor': [
+    'account:create',
+    'account:read',
+    'project:*',
+    'apikey:*',
+    'budget:self-refill',
+    'budget:read-own',
+    'session:revoke-own',
+  ],
+  'lightbridge-viewer': [
+    'account:create',
+    'account:read',
+    'project:read',
+    'apikey:read',
+    'budget:read-own',
+    'session:revoke-own',
+  ],
 };
 
 function resourceOf(permission: Permission): string {


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `packages/hooks/src/rbac.ts`: adds the three permissions missing from `ALL_PERMISSIONS`
  (`budget:read-own`, `session:revoke-own`, `session:revoke`) and updates
  `DEFAULT_ROLE_PERMISSIONS['lightbridge-editor'|'lightbridge-viewer']` to match prod's actual
  `oauth2.rbac.role_permissions` grants.
- `packages/hooks/src/rbac.test.ts`: corrects the assertions that encoded the old, wrong model
  (an editor NOT having `account:create` was asserted as fact) and adds coverage for every
  newly-granted permission on both roles.
- `apps/self-service/src/navigation/settings-categories.ts`: updates the stale doc comment that
  cited an unresolved GitHub issue as the reason both budget nav rows were gated off.
- `docs/knowledge/authorization-and-permissions.md`: updates the permission table, the
  `DEFAULT_ROLE_PERMISSIONS` code sample, and the "gotcha" section's verbatim quote of the old
  `rbac.ts` comment, all of which had gone stale against the same drift.

It solves:

- A confirmed permission-model drift: `usePermissions()` only ever consults
  `DEFAULT_ROLE_PERMISSIONS` (`permissionsForRoles(roles)` is called with no override argument
  anywhere in `packages/hooks/src/use-permissions.ts:20`), and that mapping was stale against
  prod. **Live symptom**: `lightbridge-editor` in production could not see or reach the
  self-service budget refill screen at all — `settings-categories.ts` gates the "Budget" nav row
  on `has('budget:self-refill')`, which prod grants to editors but the stale frontend mapping did
  not.

---

## 2. Intent

Source of truth:

- lightbridge-authz#325 ("wire up the five inert budget:\* permissions"), which resolved the
  previously-open lightbridge-authz#294 by shipping the role→permission grants into prod's
  `oauth2.rbac.role_permissions`.
- `ai-helm-values` `environments/prod/values/lightbridge-app.yaml` (the deployed config; see
  Verification below for the exact lines read).

The frontend's client-side RBAC mirror exists purely to decide what to show/hide in the UI — the
backend is the actual enforcement boundary (`rbac.ts`'s own doc comment: "This is a *UI
convenience*, not a security boundary"). But when this mirror falls behind the backend's real
grants, the failure mode is asymmetric: it can only ever hide a control the caller is actually
entitled to use, never grant one they aren't. That's exactly what happened here — for two releases,
production editors had `budget:self-refill` on the backend but the frontend never showed them the
button to use it.

---

## 3. Scope

### In Scope

- `ALL_PERMISSIONS`/`DEFAULT_ROLE_PERMISSIONS` in `packages/hooks/src/rbac.ts`, re-verified against
  the backend's `Permission` enum (`lightbridge-authz`
  `crates/lightbridge-authz-core/src/authz.rs`, 31 variants as of #325 — NOT the 28-variant version
  still checked out in a stale local clone; see Verification) and against prod's
  `oauth2.rbac.role_permissions`.
- `packages/hooks/src/rbac.test.ts` — corrected, not deleted, per house testing rules.
- The one stale comment in `settings-categories.ts` this task named explicitly.
- The doc file that directly quotes the `rbac.ts` comment I changed (left unfixed, it would have
  been fresh drift introduced by this same PR).
- A knock-on check (see Verification) of every UI control gated on the newly-added permission
  strings, specifically `budget:read-own` and `session:revoke-own`.

### Out of Scope

- The backend (`lightbridge-authz`) itself — already shipped via #325, not touched here.
- `ai-helm-values` — already reflects the grants; not touched here.
- Anything in `packages/authz-rpc/generated/`, `packages/hooks/src/authz-types.ts`, or
  `apps/self-service/src/__tests__/api-key-create-screen.test.tsx` — another agent is concurrently
  working in those files on an unrelated API-key-creation crash fix; this branch never touches
  them (built from `origin/main` in an isolated worktree specifically to avoid collision).
- Building the drift-prevention mechanism flagged under Risk Assessment below — flagged, not built,
  per this task's instructions.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [x] Testing permissions/security behavior (this whole PR *is* a permissions-behavior fix)
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [ ] Testing error cases
- [ ] Testing rollback or failure behavior, if relevant

**Re-verified the prod grants directly** (not taken on trust from a prior read) —
`ai-helm-values/environments/prod/values/lightbridge-app.yaml:314-331`:

```yaml
rbac:
  roles_claim: "lightbridge_api_roles"
  role_permissions:
    lightbridge-admin:
      - "*"
    lightbridge-editor:
      - "account:create"
      - "account:read"
      - "project:*"
      - "apikey:*"
      - "budget:self-refill"
      - "budget:read-own"
      - "session:revoke-own"
    lightbridge-viewer:
      - "account:create"
      - "account:read"
      - "project:read"
      - "apikey:read"
      - "budget:read-own"
      - "session:revoke-own"
```

This confirms the table in the task description exactly.

**Re-verified against the backend's `Permission` enum directly.** Note: a stale local clone of
`lightbridge-authz` (not pulled) still shows the OLD 28-permission enum with no
`budget:read-own`/`session:revoke-own`/`session:revoke` — I did not use that clone. The
`lightbridge-authz` worktree actually checked out at HEAD (`119d0ba`, `release 3.5.0`, which
contains `9f095e0 feat(budget): wire up the five inert budget:* permissions (#325)`) has all 31
variants, `budget:read-own` immediately after `budget:read` and `session:revoke-own`/
`session:revoke` as the final two entries in `Permission::ALL` — this repo's `ALL_PERMISSIONS` now
mirrors that exact order.

**Break-it-and-watch-it-fail, as required:**

1. Wrote the corrected `DEFAULT_ROLE_PERMISSIONS`/tests first, confirmed 71/71 hooks tests green.
2. Reverted *only* `DEFAULT_ROLE_PERMISSIONS` back to the old, stale mapping
   (`account:read`/`project:*`/`apikey:*` for editor, no `account:create`, no `budget:*`, no
   `session:*`), keeping the new tests as-is.
3. Ran `pnpm test -- rbac.test.ts` — **4 tests failed, all `expected false to be true`**, each on
   the exact assertion predicted (`editor.has('budget:self-refill')`,
   `viewer.has('budget:read-own')`, `viewer.has('account:create')`,
   `editor.has('account:create')`). Full failing output captured; representative excerpt:

   ```text
   × lightbridge-editor carries budget:self-refill/budget:read-own/session:revoke-own but no
     other budget:*/session:* grant (lightbridge-authz#325, resolves #294)
     → expected false to be true
   × lightbridge-viewer carries budget:read-own/session:revoke-own but NOT budget:self-refill...
     → expected false to be true
   × viewer role is read-only for account/project/apikey, plus self-service budget/session
     grants (lightbridge-authz#325)
     → expected false to be true
   × editor role can manage projects and api-keys, self-refill budget, and manage own sessions...
     → expected false to be true

   Test Files  1 failed | 4 passed (5)
        Tests  4 failed | 67 passed (71)
   ```

4. Restored the fix (verified byte-identical to the pre-revert version via `diff`).
5. Re-ran — back to green.

**Full suite, after the fix, repo-wide:**

```bash
$ pnpm test
```

```text
packages/authz-rpc test:  Test Files  3 passed (3)
packages/authz-rpc test:       Tests  18 passed (18)
packages/hooks test:  Test Files  5 passed (5)
packages/hooks test:       Tests  71 passed (71)
apps/self-service test: Test Suites: 37 passed, 37 total
apps/self-service test: Tests:       197 passed, 197 total
```

**Typecheck** (this repo's actual CI enforcement point for types, per `.github/workflows/test.yml`
`typecheck` job — `tsc` isn't run by Metro/Expo's bundler):

```bash
$ pnpm exec tsc --noEmit -p apps/self-service/tsconfig.json
```

Clean, no output. (`packages/hooks` has no `tsconfig.json` of its own — it isn't a target of this
CI job; `packages/ui`'s tsconfig is unaffected by this change and wasn't touched.)

**Lint.** This repo uses ESLint + Prettier (not Biome) — followed that existing choice per house
convention, flagging the divergence here for visibility rather than migrating it.

```bash
$ pnpm exec eslint packages/hooks/src/rbac.ts packages/hooks/src/rbac.test.ts \
    apps/self-service/src/navigation/settings-categories.ts
```

Clean, zero output. `pnpm exec prettier -c` flagged `docs/knowledge/authorization-and-permissions.md`
— fixed with `--write`. That pulled in one unrelated, pre-existing formatting fix (`*emphasis*` →
`_emphasis_`) elsewhere in the same file; confirmed via `git show origin/main:<path> | prettier -c`
that the file was **already** non-compliant on `main` before this PR touched it, i.e. this is not a
regression I introduced, just Prettier normalizing the whole file once it ran.

`pnpm run lint` (whole repo) reports 6 pre-existing errors / 154 pre-existing warnings, entirely in
files this PR does not touch (`packages/ui/**/*.stories.tsx` `react-hooks/rules-of-hooks`,
generated `packages/authz-rpc` unused-var warnings, `packages/i18n/src/i18n-config.ts`, etc.) —
confirmed by name against the diff; none are in `rbac.ts`, `rbac.test.ts`,
`settings-categories.ts`, or the doc file.

**Knock-on check (task step 6): does the newly-revealed Budget nav entry actually work?**

Searched the whole frontend for consumers of the two brand-new permission strings
(`budget:read-own`, `session:revoke-own`) and the corresponding backend RPCs
(`getMyBudgetBalance`, `listMyBudgetGrants`, `revokeOwnSessions`, `revokeSubjectSessions`): **zero
UI consumers exist today.** They're only present in `packages/authz-rpc/schema/authz.cstack`. So
granting these two permissions has no UI-visibility effect at all right now — nothing is gated on
them yet.

The one permission that *does* newly reveal a control is `budget:self-refill` → the "Budget"
settings nav row (`apps/self-service/src/navigation/settings-categories.ts:46-52`) and the
re-check inside `BudgetRefillScreen`/`BudgetRefillView`.

**On whether that screen actually works, given current infra — this task's premise turned out to
be stale, and I'm reporting the discrepancy rather than the assumption:**

The task brief states budget ingress is "currently OFF in prod... a separate change is enabling
it," and asked me to report, not fix, whatever I found. What I actually found reading
`ai-helm-values/environments/prod/values/lightbridge-app.yaml` around line 1479 directly:

```yaml
# Ingress ENABLED — reverses the "Ingress left OFF" note this block used to carry. The budget
# domain's 14 RPC procedures live on their own `POST /budget/rpc/{op_id}` surface (moved off the
# shared authz-api `/rpc/` surface), so they need their own public host rather than riding on
# api's ingress. ...
ingress:
  main:
    enabled: true
    ...
    hosts:
      - host: budget.ai.camer.digital
        paths:
          - path: /budget/rpc
```

That change already landed (`ai-helm-values` commit `79cb50f`, "automatic update of
lightbridge-app", **2026-08-17 14:35 UTC** — today). And on the frontend side, `origin/main`'s tip
commit is `35b22e4`, **"fix: point budget RPC calls at the new authz-budget /budget/rpc/ prefix
(#177)"** (2026-08-17 13:19 CEST / 11:19 UTC — also today, and *before* the ai-helm-values sync),
which re-pointed `getBudgetRpcClient` at the new `/budget/rpc` prefix
(`packages/hooks/src/budget.ts:53-59` confirms every budget mutation is routed through it, "calling
them through the CRUD client 404s").

**So: as of right now, revealing the Budget nav entry to editors lands them on a working screen,
not a 404.** Both halves of the previously-blocking infra gap (ingress off; frontend pointed at the
old prefix) have already been closed, independently of this PR, earlier today. I'm flagging this
explicitly because the task's own premise assumed otherwise — worth double-checking against
`ai-helm-values` at review time in case anything reverts before this merges.

---

## 5. Screenshots / Evidence

No UI screenshot captured (headless CI environment, no running backend/Keycloak instance available
in this session to drive an end-to-end screen). Evidence is the test output and file:line citations
above and in Verification.

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* This PR only *reveals* controls the backend already permits for these roles — per `rbac.ts`'s own
  contract, the client mirror can never grant access the server wouldn't otherwise allow, only
  hide/show a control. Worst case of a mistake here is a control shown that then 403s, not an
  actual privilege escalation.
* `account:create` is now granted to `lightbridge-viewer` in the UI mirror. Confirmed this is not a
  broad "account write" grant — the role still lacks `account:update`/`account:delete`/
  `account:disable`. No frontend control today is gated on `account:create` alone as a distinct
  capability toggle from `account:read` (checked: no UI consumer references `'account:create'`
  directly), so this addition currently has no additional UI-visibility effect beyond matching
  reality.

Mitigation:

* Full test coverage added for the exact new/old boundary on both roles (see `rbac.test.ts`).
* Verified via break-it-and-watch-it-fail that the tests actually catch a regression back to the
  old mapping.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Refactoring
* [x] Generating tests
* [x] Drafting documentation
* [ ] Reviewing the diff

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

This PR was generated by an AI agent per an explicit task brief (permission-model drift fix,
`lightbridge-authz#325` as source of truth). It has **not yet been reviewed by the human directed
in the task** — the checkboxes above are intentionally left unchecked pending that review; do not
merge without a human completing them.

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [x] Security
* [ ] Performance
* [x] Tests
* [x] Maintainability
* [x] Product intent
* [x] Edge cases

Specifically:

- Confirm the prod grants table in Verification still matches `ai-helm-values` at review time (it
  can drift again before this merges — that's the whole point of the structural problem below).
- Confirm the "Budget ingress is now ON" finding against `ai-helm-values` at review time too — it's
  a today-dated change and worth a fresh look rather than trusting this PR's snapshot.
- `account:create` newly granted to `lightbridge-viewer` — is that actually intended, or is prod's
  YAML itself the thing that's wrong? I mirrored prod as instructed and re-verified it directly,
  but did not have standing to second-guess prod's own RBAC config as part of this task.

**Structural problem (flagging, not fixing, per this task's brief):** this role→permission mapping
lives in three independent, hand-maintained places that must be kept in sync by a human noticing —
prod's `ai-helm-values` YAML, the backend's `Permission` enum
(`lightbridge-authz-core::authz::default_role_permissions`, used when no config override is
supplied), and this repo's `DEFAULT_ROLE_PERMISSIONS`. Nothing detects drift between them; this
exact drift sat unnoticed for two releases and only surfaced because someone went looking. A
concrete follow-up worth considering (not built here, scope-out per the task): a CI job in this repo
that pulls current prod's `oauth2.rbac.role_permissions` (or a checked-in copy of it) and diffs it
byte-for-byte against `DEFAULT_ROLE_PERMISSIONS`, failing the build on any mismatch — turning "went
stale silently" into "PR fails until someone reconciles it." A lighter-weight alternative: a
scheduled workflow that opens an issue on drift, if a hard CI gate is considered too tightly
coupling this repo's release cadence to `ai-helm-values`' own.
