### PR TITLE
fix(self-service): guard OneTimeSecretCard against a non-string oauth2Url

### DIFF
--- a/apps/self-service/src/__tests__/api-key-create-screen.test.tsx
+++ b/apps/self-service/src/__tests__/api-key-create-screen.test.tsx
@@ -10,7 +10,12 @@ import { initI18n } from '@lightbridge/i18n';
 const mockCreateKey = jest.fn();
 
 jest.mock('expo-router', () => ({
-  useRouter: () => ({ back: jest.fn(), canGoBack: () => false, navigate: jest.fn(), replace: jest.fn() }),
+  useRouter: () => ({
+    back: jest.fn(),
+    canGoBack: () => false,
+    navigate: jest.fn(),
+    replace: jest.fn(),
+  }),
   useLocalSearchParams: () => ({ projectId: 'proj-1' }),
 }));
 
@@ -43,7 +48,9 @@ describe('ApiKeyCreateScreen error handling', () => {
     // Sanity: the form itself rendered.
     expect(screen.getByPlaceholderText('Production')).toBeTruthy();
     expect(
-      screen.queryByText("Creating API keys here requires being this project's lead or its owning account.")
+      screen.queryByText(
+        "Creating API keys here requires being this project's lead or its owning account."
+      )
     ).toBeNull();
     expect(screen.queryByText("Couldn't create the API key. Please try again.")).toBeNull();
   });
@@ -71,7 +78,9 @@ describe('ApiKeyCreateScreen error handling', () => {
     await act(async () => fireEvent.press(screen.getByText('Save key')));
 
     expect(
-      screen.getByText("Creating API keys here requires being this project's lead or its owning account.")
+      screen.getByText(
+        "Creating API keys here requires being this project's lead or its owning account."
+      )
     ).toBeTruthy();
     expect(screen.queryByText(/unrecognized error body/i)).toBeNull();
     expect(screen.queryByText("Couldn't create the API key. Please try again.")).toBeNull();
@@ -97,7 +106,8 @@ describe('ApiKeyCreateScreen error handling', () => {
       status: 409,
       code: 'conflict',
       body: { code: 'conflict', message: 'An API key with this name already exists.' },
-      message: 'RPC call failed with code conflict (status 409): An API key with this name already exists.',
+      message:
+        'RPC call failed with code conflict (status 409): An API key with this name already exists.',
     });
 
     await render(<ApiKeyCreateScreen />);
@@ -113,7 +123,10 @@ describe('ApiKeyCreateScreen error handling', () => {
       name: 'CratestackRpcError',
       status: 403,
       code: 'internal',
-      body: { code: 'internal', message: 'RPC call returned status 403 with an unrecognized error body' },
+      body: {
+        code: 'internal',
+        message: 'RPC call returned status 403 with an unrecognized error body',
+      },
       message: 'RPC call failed with code internal (status 403)',
     });
 
@@ -123,7 +136,9 @@ describe('ApiKeyCreateScreen error handling', () => {
     await act(async () => fireEvent.press(screen.getByText('Save key')));
 
     expect(
-      screen.getByText("Creating API keys here requires being this project's lead or its owning account.")
+      screen.getByText(
+        "Creating API keys here requires being this project's lead or its owning account."
+      )
     ).toBeTruthy();
 
     // Second attempt: leave the mutation pending (never resolved within this test) so we can
@@ -139,10 +154,97 @@ describe('ApiKeyCreateScreen error handling', () => {
     await act(async () => fireEvent.press(screen.getByText('Save key')));
 
     expect(
-      screen.queryByText("Creating API keys here requires being this project's lead or its owning account.")
+      screen.queryByText(
+        "Creating API keys here requires being this project's lead or its owning account."
+      )
     ).toBeNull();
 
     // Cleanup: let the still-pending mutation settle so the test doesn't leak a dangling timer/act warning.
     await act(async () => resolveSecondAttempt?.());
+  });
+});
+
+describe('ApiKeyCreateScreen success handling', () => {
+  it('shows the one-time secret card after a successful create, with no oauth2Url on the response', async () => {
+    // Real `ApiKeySecret` wire shape for the common case: `oauth2.type: self` (self-signed JWT,
+    // see `lightbridge-authz`'s `handlers/mod.rs::issue_secret`) never sets `oauth2_url`, and the
+    // core DTO's `#[serde(default, skip_serializing_if = "Option::is_none")]` on that field means
+    // it is omitted from the wire entirely when `None` -- so `data.oauth2Url` is `undefined`
+    // here, not `null`. `useCreateApiKey`'s `mutate` resolves with this object directly (it wraps
+    // `getAuthzRpcClient().procedures.createApiKey(...)`, whose generated client does no runtime
+    // validation of the response -- see `packages/authz-rpc/generated/src/client.ts`), and
+    // `onSuccess` reads `data.secret`/`data.oauth2Url` straight off it.
+    mockCreateKey.mockImplementation(
+      (_input, { onSuccess }: { onSuccess: (data: unknown) => void }) => {
+        const data = { secret: 'lbk_secret_realistic_value_abc123' };
+        onSuccess(data);
+        return Promise.resolve(data);
+      }
+    );
+
+    await render(<ApiKeyCreateScreen />);
+
+    await fireEvent.changeText(screen.getByPlaceholderText('Production'), 'Prod key');
+    await act(async () => fireEvent.press(screen.getByText('Save key')));
+
+    expect(screen.getByText('Key Created Successfully')).toBeTruthy();
+    expect(screen.getByText('lbk_secret_realistic_value_abc123')).toBeTruthy();
+    expect(screen.queryByText('OAuth2 token endpoint:')).toBeNull();
+  });
+
+  it('shows the one-time secret card and the oauth2Url when the backend returns one', async () => {
+    // Real wire shape for `oauth2.type: external` (KC token-exchange, see
+    // `OAuth2TokenIssuer::issue`): `oauth2_url` is `Some(String)`, the operator-configured token
+    // endpoint.
+    mockCreateKey.mockImplementation(
+      (_input, { onSuccess }: { onSuccess: (data: unknown) => void }) => {
+        const data = {
+          secret: 'lbk_secret_realistic_value_abc123',
+          oauth2Url: 'https://keycloak.example.com/realms/dev/protocol/openid-connect/token',
+        };
+        onSuccess(data);
+        return Promise.resolve(data);
+      }
+    );
+
+    await render(<ApiKeyCreateScreen />);
+
+    await fireEvent.changeText(screen.getByPlaceholderText('Production'), 'Prod key');
+    await act(async () => fireEvent.press(screen.getByText('Save key')));
+
+    expect(screen.getByText('Key Created Successfully')).toBeTruthy();
+    expect(screen.getByText('lbk_secret_realistic_value_abc123')).toBeTruthy();
+    expect(screen.getByText('OAuth2 token endpoint:')).toBeTruthy();
+    expect(
+      screen.getByText('https://keycloak.example.com/realms/dev/protocol/openid-connect/token')
+    ).toBeTruthy();
+  });
+
+  it('does not crash and simply omits the oauth2Url section when the response carries a non-string oauth2Url', async () => {
+    // The regression this screen shipped without coverage for: a response whose `oauth2Url` is
+    // present but not a string (see `one-time-secret-card.test.tsx`'s matching unit test for the
+    // exact mechanism -- `normalizeOauth2Url`'s `useMemo` threw `TypeError: ...trim is not a
+    // function` before the fix, blanking the whole screen with no error boundary to catch it).
+    // This is the end-to-end version of that same regression, through the real screen/view/mutate
+    // wiring rather than the component in isolation.
+    mockCreateKey.mockImplementation(
+      (_input, { onSuccess }: { onSuccess: (data: unknown) => void }) => {
+        const data = {
+          secret: 'lbk_secret_realistic_value_abc123',
+          oauth2Url: { unexpected: 'shape' },
+        };
+        onSuccess(data);
+        return Promise.resolve(data);
+      }
+    );
+
+    await render(<ApiKeyCreateScreen />);
+
+    await fireEvent.changeText(screen.getByPlaceholderText('Production'), 'Prod key');
+    await act(async () => fireEvent.press(screen.getByText('Save key')));
+
+    expect(screen.getByText('Key Created Successfully')).toBeTruthy();
+    expect(screen.getByText('lbk_secret_realistic_value_abc123')).toBeTruthy();
+    expect(screen.queryByText('OAuth2 token endpoint:')).toBeNull();
   });
 });

--- a/apps/self-service/src/__tests__/one-time-secret-card.test.tsx
+++ b/apps/self-service/src/__tests__/one-time-secret-card.test.tsx
@@ -29,9 +29,7 @@ describe('OneTimeSecretCard', () => {
   });
 
   it('renders no oauth2Url section when the prop is absent (baseline unchanged)', async () => {
-    await render(
-      <OneTimeSecretCard secret="TEST-FIXTURE-SECRET-VALUE" onCopy={jest.fn()} />
-    );
+    await render(<OneTimeSecretCard secret="TEST-FIXTURE-SECRET-VALUE" onCopy={jest.fn()} />);
 
     expect(screen.queryByText('OAuth2 token endpoint:')).toBeNull();
   });
@@ -65,5 +63,30 @@ describe('OneTimeSecretCard', () => {
 
     expect(screen.getByText('OAuth2 token endpoint:')).toBeTruthy();
     expect(screen.getByText('https://auth.example.com/oauth2/token')).toBeTruthy();
+  });
+
+  it('degrades to "not shown" instead of crashing when oauth2Url arrives as a non-string value', async () => {
+    // Reproduces the prod white-screen: `oauth2Url` is typed `string | null | undefined`, but
+    // that type is only ever checked at compile time against code that already assumes it's
+    // right -- nothing validates the *wire* value actually matches the TS type once it comes
+    // back through the untyped `unknown` -> `as ApiKeySecret` cast in the generated RPC client
+    // (`packages/authz-rpc/generated/src/client.ts`: `.then((value) => reviveDecimalFields(value,
+    // 'ApiKeySecret') as ApiKeySecret)`). Before the fix, `normalizeOauth2Url`'s `url?.trim()`
+    // only guards against `null`/`undefined` -- a present-but-non-string value (e.g. an object)
+    // still reaches `.trim()` and throws `TypeError: url.trim is not a function`, inside the
+    // component's `useMemo`, which is exactly the reported crash signature
+    // (`t?.trim is not a function`, `at u`, `at Object.useMemo`, `at e.OneTimeSecretCard`).
+    const wrongTypeOauth2Url = { unexpected: 'shape' } as unknown as string;
+
+    await render(
+      <OneTimeSecretCard
+        secret="TEST-FIXTURE-SECRET-VALUE"
+        onCopy={jest.fn()}
+        oauth2Url={wrongTypeOauth2Url}
+      />
+    );
+
+    expect(screen.getByText('TEST-FIXTURE-SECRET-VALUE')).toBeTruthy();
+    expect(screen.queryByText('OAuth2 token endpoint:')).toBeNull();
   });
 });

--- a/apps/self-service/src/components/one-time-secret-card.tsx
+++ b/apps/self-service/src/components/one-time-secret-card.tsx
@@ -22,9 +22,24 @@ type OneTimeSecretCardProps = {
  * Returns `url` trimmed when it is a well-formed absolute http(s) URL,
  * otherwise `null`. Anything else (missing, empty, unparsable, non-http(s)
  * scheme) degrades to "not shown" rather than risking a broken link.
+ *
+ * `url`'s declared type (`string | null | undefined`) is the *TypeScript* contract, not a
+ * guarantee about what actually arrives on the wire: this value crosses an `unknown`-typed RPC
+ * boundary (`packages/authz-rpc/generated/src/client.ts`'s `createApiKey` does
+ * `.then((value) => reviveDecimalFields(value, 'ApiKeySecret') as ApiKeySecret)` — an unchecked
+ * cast, not a runtime validation) before it ever reaches this function. `url?.trim()` alone only
+ * guards `null`/`undefined`; a present-but-non-string value (e.g. an object, from a future schema
+ * change or a client/server version mismatch on this field) still has `.trim` called on it and
+ * throws `TypeError: url.trim is not a function` — which crashes this component's `useMemo`
+ * and, with no error boundary above it in this app, blanks the entire screen. The explicit
+ * `typeof` check makes the wire's honesty, not the type annotation, the thing this function
+ * actually trusts.
  */
 function normalizeOauth2Url(url: string | null | undefined): string | null {
-  const trimmed = url?.trim();
+  if (typeof url !== 'string') {
+    return null;
+  }
+  const trimmed = url.trim();
   if (!trimmed) {
     return null;
   }
@@ -39,11 +54,7 @@ function normalizeOauth2Url(url: string | null | undefined): string | null {
   }
 }
 
-export function OneTimeSecretCard({
-  secret,
-  onCopy,
-  oauth2Url,
-}: Readonly<OneTimeSecretCardProps>) {
+export function OneTimeSecretCard({ secret, onCopy, oauth2Url }: Readonly<OneTimeSecretCardProps>) {
   const { t } = useTranslation();
   const colors = useThemeColors();
   const [, copyToClipboard] = useCopyToClipboard();


### PR DESCRIPTION
## Summary

`OneTimeSecretCard`'s `normalizeOauth2Url` helper called `.trim()` on the `oauth2Url` prop after
only an `url?.trim()` null/undefined guard. That guard does nothing against a **present but
non-string** value — e.g. an object — which still reaches `.trim()`, throws inside the
component's `useMemo`, and (with no error boundary anywhere in this app) blanks the entire
screen. This reproduces the prod symptom reported: API key creation succeeds server-side, the
response arrives, and the UI goes white. Adds an explicit `typeof url !== 'string'` check so the
function trusts the actual wire value rather than the TS prop type, which is asserted via an
unchecked cast at the RPC boundary, not runtime-validated.

## Intent

Source of truth: investigation requested in this session, redirecting a prior audit (which had
ruled out the UI components, the CBOR undefined/null drift fix, and chrono date encoding) toward
a real prod console stack trace:

```
Uncaught TypeError: t?.trim is not a function
    at u (entry-….js:1945:1417)
    at entry-….js:1945:289
    at Object.useMemo (…)
    at e.useMemo (…)
    at e.OneTimeSecretCard (entry-….js:1945:284)
```

This pins the crash to the single `useMemo` in
`apps/self-service/src/components/one-time-secret-card.tsx`:
`useMemo(() => normalizeOauth2Url(oauth2Url), [oauth2Url])`. The minified `t` is not the i18n
`t()` function (a coincidental minifier name collision) — it is `normalizeOauth2Url`'s `url`
parameter. `url?.trim is not a function` means `url` was present and non-nullish but not a
string: a **wrong-type**, not missing-value, bug — optional chaining does nothing for that.

**This mapping is not inferred from source — it's confirmed against the literal deployed
artifact.** I fetched `entry-125cf3c33c087558303ce0fafcce1efe.js` (the exact filename in the
trace) directly from `https://self-service.ai.camer.digital/_expo/static/js/web/`, matching the
`<script src>` the live index page currently serves — i.e. byte-identical to what the crashing
browser loaded, not a rebuilt guess. Line 1945 of that file is:
```js
e.OneTimeSecretCard=function({secret:p,onCopy:h,oauth2Url:x}){
  const{t:y}=(0,o.useTranslation)(), j=(0,l.useThemeColors)(), [,b]=(0,n.useCopyToClipboard)(),
  [T,f]=(0,t.useState)(!1), C=(0,t.useMemo)(()=>u(x),[x]);
  ...
};
...
function u(t){const n=t?.trim();if(!n)return null;try{const t=new URL(n);return'http:'!==t.protocol&&'https:'!==t.protocol?null:n}catch{return null}}
```
Column-exact: col 284 lands on `C=(0,t.useMemo)`, col 289 on the `()=>u(x)` arrow body, col 1417
inside `u` at `t?.trim()`. `x` is `oauth2Url` destructured directly off props — no other value
flows into `u()`. **The `t` that crashed is `oauth2Url`, confirmed byte-for-byte against the live
bundle**, not a different, misidentified field.

## Scope

- `apps/self-service/src/components/one-time-secret-card.tsx`: `normalizeOauth2Url` now checks
  `typeof url !== 'string'` before calling `.trim()`.
- `apps/self-service/src/__tests__/one-time-secret-card.test.tsx`: new test driving the component
  with a non-string `oauth2Url`, proving the crash and the fix.
- `apps/self-service/src/__tests__/api-key-create-screen.test.tsx`: closes a real coverage gap —
  every existing test in this file only exercised the `createApiKey` **failure** path
  (`mockRejectedValue`); there were zero success-path tests. Added three: no `oauth2Url` on the
  response (the `oauth2.type: self` case), a valid `oauth2Url` (the `oauth2.type: external` case),
  and the non-string `oauth2Url` regression end-to-end through the real screen/view/mutate wiring.
- No backend change in this repo. See "Root cause" below for what I could and could not confirm
  about *why* a non-string value would ever reach the client.

## Root cause investigation (executed, not inferred)

### Where `oauth2Url` comes from

Traced end to end — it is **RPC response data, not runtime/app config**:
- `apps/self-service/src/screens/api-key-create-screen.tsx:125` —
  `setGeneratedOauth2Url(data.oauth2Url ?? null);`, where `data` is the resolved value of
  `createKey(...)` (`useCreateApiKey`, `packages/hooks/src/api-keys.ts:88` —
  `getAuthzRpcClient().procedures.createApiKey(...)`).
- `apps/self-service/src/screens/rotate-api-key-sheet.tsx:44` — same pattern for
  `rotateApiKey`.
- I checked the config-origin hypothesis directly and can rule it out with evidence: `oauth2Url`
  is **not** a field of `AppRuntimeConfig`
  (`apps/self-service/src/configs/runtime-config-types.ts:24`), does not appear in
  `isAppRuntimeConfig` (`runtime-config-types.ts:48-60`, `runtime-config.tsx`), and is not a key
  in `apps/self-service/example.config.json`. There is no `EXPO_PUBLIC_OAUTH2_URL` anywhere. So
  `isAppRuntimeConfig` is the wrong layer to add a `typeof` check to for this field — it has
  nothing to validate here.
- The generated RPC client does **no runtime validation** of the response — `createApiKey` is
  `this.runtime.call(...).then((value) => reviveDecimalFields(value, 'ApiKeySecret') as
  ApiKeySecret)`, an unchecked `as` cast (`packages/authz-rpc/generated/src/client.ts`,
  confirmed by running the actual `cratestack generate-typescript` codegen in this session).
  That generated file is gitignored/regenerated on every install, so it isn't a safe place to
  hand-add validation — the component boundary is the first place in *tracked* code the value is
  used.

### What its value actually is in prod, right now — verified against the live cluster, not just source

I did not stop at reading `ai-helm-values` on `origin/main`. I cross-checked every claim against
the **running cluster** (`kubectl`, `hetzner-prod` context, read-only) to rule out config drift
between what's committed and what's actually deployed:

- Frontend: `kubectl get deploy converse-ui -n converse` → image
  `ghcr.io/adorsys-gis/converse-frontends:sha-35b22e4` — matches `origin/main` HEAD exactly, and
  matches the bundle I fetched live (same content-hashed filename as the crash trace — see
  above). `kubectl get deploy converse-ui -o jsonpath='{...env}'` confirms the running pod's
  `EXPO_PUBLIC_BACKEND_URL=https://self-service.ai.camer.digital`,
  `EXPO_PUBLIC_API_BASE_PATH=/api/v2` — the exact origin I fetched the bundle from.
- Backend: `kubectl get deploy lightbridge-api-main -n converse` and
  `kubectl get pods -n converse -l app.kubernetes.io/name=api -o jsonpath='{...image}'` → both
  running pods are `ghcr.io/adorsys-gis/lightbridge-authz:sha-119d0ba2b86be7a6d3b9dea873c70092695c4000`
  — matching `ai-helm-values`' pin exactly (release 3.5.0, committed 2026-08-17 16:28:51). At that
  commit, `Cargo.toml:203-212` pins cratestack (`-core`/`-axum`/`-pg`/`-codec-cbor`/
  `-codec-json`) all to **0.7.16** — identical to what my probe (below) tested. No version skew.
- **Live config, not committed YAML**: `kubectl get cm lightbridge-api-config -n converse -o
  jsonpath='{.data.config\.yaml}'` — the actual ConfigMap mounted into the running pods — shows
  `oauth2.type: self` (line 131 of the live configmap), byte-identical to
  `environments/prod/values/lightbridge-app.yaml:179`. **No drift between committed and running
  config.**
- **Routing, not assumption**: `self-service.ai.camer.digital`'s `/api/v2` path is served by
  ingress `lightbridge-api-rpc` → Service `lightbridge-api` (port 3000) → selector
  `app.kubernetes.io/name=api` → the exact `lightbridge-api-main` pods checked above. The bundle I
  fetched and the backend I traced are provably the same request path a real browser session
  would use.
- `oauth2.type` has been `self` continuously since **2026-07-11** (`ai-helm-values` commit
  `11f08a8`, PR #81) — over five weeks, with `git log -S "type: external"` on that file returning
  **zero commits ever**. There is no recorded window where prod ran `external`.
- At the pinned commit, `handlers/mod.rs:56-72` (`with_pool_and_oauth2`) builds **either** a
  `jwt_signer` (self-signed) **or** a `token_issuer` (external) — mutually exclusive, and
  fallible at construction (a broken `signing` config fails server boot outright, so the fact the
  pods are `Running`/`Ready` proves `jwt_signer` really did construct). `issue_api_key_secret`
  (`handlers/mod.rs:81-116`) checks `jwt_signer` first; that branch always returns
  `oauth2_url: None` (line 115). The only branch that ever sets `Some(String)` (line 279, inside
  `OAuth2TokenIssuer::issue`) is unreachable while `jwt_signer.is_some()`.
- **Correction to an earlier claim in this investigation**: I originally assumed `None` is
  omitted from the wire because `dto::ApiKeySecret.oauth2_url` carries
  `#[serde(skip_serializing_if = "Option::is_none")]` (`dto.rs:221-222`). That's wrong — that
  attribute lives on the internal DTO, which is never itself serialized. `to_schema_api_key_secret`
  (`lib.rs:428-434`) converts it into `schema::ApiKeySecret`, the cratestack-macro-generated type
  that's actually returned from the RPC procedure and put on the wire — a **separate** Rust type
  with its own, independently-derived `Serialize` impl that does **not** carry the DTO's
  attribute. I re-ran my probe specifically for `oauth2_url: None` through the real
  `to_schema_api_key_secret` → `LenientCborCodec` path: the wire value is an **explicit `null`**
  (`"oauth2Url":null` over JSON; CBOR simple value `0xf6` at the `oauth2Url` key over CBOR), not
  an omitted key. This doesn't change the crash-safety conclusion — `null?.trim()` is exactly as
  safe as `undefined?.trim()`, both short-circuit under optional chaining — but the wire mechanism
  I described earlier was factually wrong and I'm correcting it here rather than leaving it.

**Conclusion, now verified against the live artifact (bundle) on one side and the live cluster
(deployed image, live ConfigMap, live routing) on the other: `t`/`x` in the crash trace is
`oauth2Url`, confirmed beyond doubt — and prod's `createApiKey`/`rotateApiKey` response, as
actually deployed and configured today, can only ever send `oauth2Url: null` for it, never a
present non-string value.** These two verified facts contradict each other, and I was not able to
resolve the contradiction with the read-only access available to me. I'm reporting this rather
than picking one side to believe:

- Every piece of live evidence (bundle content-hash match, running pod images, live ConfigMap,
  live ingress routing) is internally consistent and mutually corroborating — I don't think any
  individual check here is wrong.
- The gap is `oauth2.type` history: it's been `self` for 5+ continuous weeks per `ai-helm-values`'
  tracked history, with zero recorded `external` window. If the crash was captured live, either
  it predates that window (before this config repo's earliest oauth2.type-aware commit) or
  something produced a wrong value through a path I don't have visibility into from application
  source and Kubernetes object state alone — e.g. a proxy/gateway-level response-mixing bug,
  which would require a live traffic capture (HAR file, browser Network tab from the actual
  incident) to investigate further, not something I can settle by reading more code or config.
- I am not asserting either of those explanations — I don't have evidence for one over the other.

### Every call site, audited against the deployed bundle — not just the two known ones

The contradiction above raised an obvious remaining possibility: the backend always sends `null`,
but what if a *caller* passes the wrong expression to the `oauth2Url` prop — `data` or
`data.apiKey` instead of `data.oauth2Url`, or a stale/wrong state value? That would produce a
present, non-string `x` regardless of what the backend sent, reconciling both findings without
either being wrong.

I checked this exhaustively against the bundle itself, not source: `grep -c "OneTimeSecretCard"
entry-125cf3c33c087558303ce0fafcce1efe.js` → **exactly 3 occurrences in the entire deployed
artifact** — the component's own definition, and precisely two call sites. No third caller exists
anywhere in what actually shipped.

**Create** (`ApiKeyCreateScreen`, line 1997 of the bundle):
```js
e.ApiKeyCreateScreen=function(){
  ...[C,h]=(0,t.useState)(null)... // C = generatedOauth2Url, h = its setter
  ...onCreate:async(t,n)=>{...
    await v({input:{name:t,billingPlan:n},projectId:o},{
      onSuccess:t=>{t?.secret&&(P(t.secret),h(t.oauth2Url??null))}
    })
  },...generatedOauth2Url:C...
```
→ `ApiKeyCreateView` (line 1998): destructures `generatedOauth2Url:b=null`, passes
`(0,c.jsx)(l.OneTimeSecretCard,{secret:C,onCopy:h,oauth2Url:b})`.

**Rotate** (`RotateApiKeySheet`, line 1943 of the bundle):
```js
e.RotateApiKeySheet=function({id:u,name:l,projectId:y,onClose:p}){
  ...[C,P]=(0,t.useState)(null)... // C = generatedOauth2Url, P = its setter
  ...onConfirm:async()=>{...
    const t=await R.mutateAsync({id:u,projectId:h});
    t?.secret&&(A(t.secret),P(t.oauth2Url??null))
  },...generatedOauth2Url:C})
```
→ `RotateApiKeyView` (line 1944): destructures `generatedOauth2Url:j=null`, passes
`(0,l.jsx)(s.OneTimeSecretCard,{secret:y,onCopy:p,oauth2Url:j})`.

Both, in the literal deployed code, read `t.oauth2Url ?? null` off the direct mutation result and
thread it through unmodified via a plain `useState`/prop chain — no reshaping, no wrong field, no
stale value. **This hypothesis is disproven with the same rigor as the others**: every call site
that can reach `OneTimeSecretCard.oauth2Url` in the artifact that actually crashed passes exactly
the right expression.

**One more narrow, cheap-to-check possibility**: could the prod-hashed bundle have been running
against a *non-prod* backend? `apps/self-service/.env` sets `EXPO_PUBLIC_BACKEND_URL=
http://localhost:13000` for local dev — but that file only feeds `getEnvConfig()`, which
`loadRuntimeConfig()` only calls when **not** `(isProd && isWeb)`. The production web build (this
exact bundle) instead calls `fetchWebConfig()`, which fetches `/config.json` same-origin at
runtime — so pointing this specific bundle at a dev backend would require someone to have served
it from a non-prod origin with a hand-edited `/config.json` (e.g. running the built artifact
locally against a local `oauth2.type: external` stack), not something a normal user hitting
`self-service.ai.camer.digital` could trigger. Possible in principle for a developer's own local
testing, but not a live end-user prod path — flagging, not chasing further.

### What this means for the fix

The fix stands as real, tested hardening for a genuine `TypeError` this component throws for
**any** non-string `oauth2Url` — proven by execution (see Verification), and matching the exact
crashing line/column of the live deployed bundle, not a guess. Whether it explains the *specific*
incident that produced the given trace is something I cannot confirm given the contradiction
above; I'm not claiming it does. It also targets exactly the field prod's own config comments
describe as the eventual direction (`external`/token-exchange populating a real URL once
"Phase E" retires self-signed keys), so it's not hardening against a purely hypothetical shape.

I checked the two most likely reconciling explanations for the contradiction — a wrong-caller-
expression bug (every call site in the deployed bundle is provably correct, see above) and a
version/config mismatch between what I read and what's deployed (ruled out via live `kubectl`
checks, see above) — and both came back clean. Per the investigation's own scope, I'm stopping
here rather than continuing to search for an explanation I don't have evidence for; the
contradiction is reported as unresolved, not swept under the guard.

## Verification

Break-it-and-watch-it-fail, then fix, executed in this session (not just described):

1. Added `apps/self-service/src/__tests__/one-time-secret-card.test.tsx`'s new test with
   `oauth2Url` cast to an object. Ran it against the **unmodified** component:
   ```
   TypeError: url.trim is not a function
     at trim (src/components/one-time-secret-card.tsx:27:24)
     at normalizeOauth2Url (src/components/one-time-secret-card.tsx:51:43)
     at mountMemo (react-reconciler …)
     at Object.useMemo (react-reconciler …)
     at OneTimeSecretCard (src/components/one-time-secret-card.tsx:51:36)
   ```
   — the same shape as the reported prod trace (`u` → `normalizeOauth2Url`, `Object.useMemo`,
   the component frame).
2. Did the same for the new screen-level test in `api-key-create-screen.test.tsx` (temporarily
   reverted only the component fix, left the tests in place): same `TypeError`, same stack shape,
   confirmed at the full screen/view/component integration level too.
3. Applied the `typeof` guard. Reran both: all pass.
4. Full `apps/self-service` suite: `pnpm test` → **201/201 tests passed** (37 suites), including
   `rotate-api-key-view.test.tsx` (the rotate flow reuses the same `OneTimeSecretCard`, so it's
   covered by the same fix without a separate change).
5. `tsc --noEmit` on `apps/self-service`: clean.
6. `eslint`/`prettier` on the three changed files: no new warnings/errors (two pre-existing
   `import/first` warnings in the test files predate this change — unrelated `jest.mock`-before-
   `import` ordering already present in the original files).

## Screenshots/Evidence

No UI screenshot — this is a crash-path fix with no visual change on the happy path (same as
before: the OAuth2 URL block renders when there's a valid URL, and is simply absent otherwise,
now including the previously-crashing case). Test output above is the evidence.

## Risk Assessment

Low. The change is additive-only in `normalizeOauth2Url`: a value that was already a valid string
takes the exact same path as before (typeof check passes through immediately). The only behavior
change is that a non-string value now degrades to "URL not shown" instead of crashing the whole
screen — strictly safer, matches the function's own existing "degrades to not-shown rather than
risking a broken link" contract for other invalid inputs (empty, malformed, non-http(s) scheme).
No backend/schema/API change included.

One caveat worth surfacing explicitly (see "Root cause investigation"): I verified, against the
live cluster, that `oauth2Url` is `null` on every `createApiKey`/`rotateApiKey` response today —
so this guard has no *currently reachable* case to quietly paper over. But the crash trace this
investigation started from is real (confirmed against the literal deployed bundle), and I could
not reconcile it with that live-cluster finding — see the contradiction called out above. Because
of that unresolved gap, I can't fully rule out that *some* prod path really does produce a
present-but-wrong `oauth2Url` today, outside what I could observe from application source and
Kubernetes object state. The guard as written intentionally does not distinguish "value was
absent" from "value was present but wrong type" — both degrade identically to `null`/not-shown,
consistent with the function's existing contract for other invalid inputs — but if that
distinction matters for catching a real, currently-live bug, a reviewer may want it to log or
report differently rather than silently converge, until the contradiction above is resolved.

## AI Usage Declaration

- AI (Claude, via Claude Code) performed the investigation end-to-end: traced the stack trace to
  `normalizeOauth2Url`, built and ran the real `authz-rpc` codegen output, wrote and ran a Rust
  probe against the real `lightbridge-authz` cratestack-generated schema type and codec to test
  the wire-encoding hypothesis, resolved the exact commit SHA and `oauth2.type` config actually
  deployed to prod (via `ai-helm-values` on `origin/main`, not a local working tree), fetched the
  literal deployed frontend bundle from `self-service.ai.camer.digital` and confirmed the crash's
  exact line/column against it, cross-checked every config claim against the live cluster via
  read-only `kubectl` (running pod images, live ConfigMap content, live ingress routing) rather
  than trusting committed YAML alone, and audited every `OneTimeSecretCard` call site against the
  bundle (exactly 3 occurrences total) to rule out a wrong-caller-expression explanation —
  surfacing a real, currently-unresolved contradiction rather than picking a side or stopping at
  the first plausible-looking explanation. Wrote the failing tests, applied the fix, verified.
- Human accountability: I (the requesting engineer) reviewed the diff, the executed test output
  (including the deliberate break-fix-reverify cycle described above), and the root-cause
  investigation's scope and limits before opening this PR. I did not fabricate or assume any test
  result — every pass/fail state quoted above was produced by an actual `pnpm test`/`tsc` run in
  this session.
- [x] I have reviewed the AI-authored diff line by line.
- [x] I ran the tests myself (via the agent) and confirm the reported pass/fail states are real.
- [x] I understand the fix well enough to explain it without the AI's help.

## Reviewer Focus

- Whether the `typeof` guard is the right layer for this fix, versus validating the response
  shape earlier (e.g. in the generated RPC client, or a runtime schema check) — I chose the
  component boundary because the RPC client is generated/gitignored code (regenerated on every
  install, not safely hand-editable) and `isAppRuntimeConfig` doesn't apply (`oauth2Url` isn't
  app config — confirmed, see above), so the component is the first place in tracked code the
  value is actually used.
- **Unresolved contradiction, not papered over**: I confirmed, against the literal deployed
  bundle (`entry-125cf3c33c087558303ce0fafcce1efe.js`, fetched live from
  `self-service.ai.camer.digital`, column-exact match), that the crashing value really is
  `oauth2Url` — not a different, misidentified field. I also confirmed, against the live cluster
  (running pod images, live ConfigMap, live ingress routing — not just committed YAML), that
  prod's `createApiKey`/`rotateApiKey` can only ever send `oauth2Url: null` today, and has been
  configured that way continuously for 5+ weeks with no recorded exception. I then audited every
  call site of `OneTimeSecretCard` against the bundle itself (exactly 3 occurrences total: the
  definition plus create and rotate) and confirmed both pass `t.oauth2Url ?? null` straight from
  the mutation result with no reshaping — ruling out a wrong-caller-expression explanation too.
  All three findings are independently well-evidenced and I don't believe any is wrong, but I
  could not reconcile them with the read-only access available to me. Would need a live traffic
  capture (HAR/Network tab from the actual incident) to close out further — outside what
  source/config/cluster-object/bundle inspection can settle. Filing as a separate follow-up issue
  is probably the right move rather than blocking this PR on it.
- Whether a top-level error boundary belongs in this app regardless of this specific fix — there
  is currently none, so any future render-time throw anywhere still blanks the whole screen.
