### PR TITLE
fix(self-service): add error boundaries so a screen crash can't blank the app

### DIFF
--- a/apps/self-service/src/__tests__/error-boundary.test.tsx
+++ b/apps/self-service/src/__tests__/error-boundary.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+
+import { ErrorBoundary } from '../components/error-boundary';
+
+// A render-time throw, gated by a mutable ref rather than a prop, so a test
+// can flip it and have the *next* render behave differently without needing
+// React Testing Library's `rerender` (which wouldn't help here anyway: the
+// element identity inside <ErrorBoundary> doesn't change across a retry, only
+// what it does when it renders).
+function Bomb({ shouldThrow }: Readonly<{ shouldThrow: { current: boolean } }>) {
+  if (shouldThrow.current) {
+    throw new Error('boom: bomb detonated');
+  }
+  return <Text>bomb defused</Text>;
+}
+
+describe('ErrorBoundary', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('catches a render-time throw and renders the fallback instead of crashing', async () => {
+    const shouldThrow = { current: true };
+
+    await render(
+      <ErrorBoundary fallback={({ error }) => <Text>caught: {error.message}</Text>}>
+        <Bomb shouldThrow={shouldThrow} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('caught: boom: bomb detonated')).toBeTruthy();
+    expect(screen.queryByText('bomb defused')).toBeNull();
+  });
+
+  // Proves the boundary never becomes the silent swallower it's explicitly
+  // forbidden from being (see the component's own doc comment, and issue
+  // #180 -- the crash this exists for was only diagnosable because it hit the
+  // console with a real stack). If a future refactor drops the console.error
+  // call, this test is what should catch it.
+  it('reports the caught error and its component stack to the console', async () => {
+    const shouldThrow = { current: true };
+
+    await render(
+      <ErrorBoundary fallback={() => <Text>fallback</Text>}>
+        <Bomb shouldThrow={shouldThrow} />
+      </ErrorBoundary>
+    );
+
+    const boundaryLogCall = consoleErrorSpy.mock.calls.find(
+      (call) => call[0] === '[ErrorBoundary] Caught a render error:'
+    );
+
+    expect(boundaryLogCall).toBeDefined();
+    expect(boundaryLogCall?.[1]).toBeInstanceOf(Error);
+    expect((boundaryLogCall?.[1] as Error).message).toBe('boom: bomb detonated');
+    // Not asserting on the exact frame names inside the stack: this Jest/Node
+    // environment's synthesized `componentStack` names frames after whatever
+    // identifier the throw site happens to read (verified by hand -- renaming
+    // the test's prop changes the frame name that comes out), not off
+    // `Bomb.name`, so pinning to "contains 'Bomb'" would be asserting on a
+    // test-harness artifact rather than boundary behavior. What's actually
+    // load-bearing is that a real, non-empty, multi-frame stack came through.
+    expect(typeof boundaryLogCall?.[2]).toBe('string');
+    const componentStack = boundaryLogCall?.[2] as string;
+    expect(componentStack.length).toBeGreaterThan(0);
+    expect(componentStack).toContain('ErrorBoundary');
+  });
+
+  it('also forwards the caught error to onError, for callers that want to assert on it', async () => {
+    const shouldThrow = { current: true };
+    const onError = jest.fn();
+
+    await render(
+      <ErrorBoundary onError={onError} fallback={() => <Text>fallback</Text>}>
+        <Bomb shouldThrow={shouldThrow} />
+      </ErrorBoundary>
+    );
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    const [error, componentStack] = onError.mock.calls[0] as [Error, string | null];
+    expect(error.message).toBe('boom: bomb detonated');
+    expect(componentStack).toContain('ErrorBoundary');
+  });
+
+  it('lets the user recover: pressing retry remounts children once the failure clears', async () => {
+    const shouldThrow = { current: true };
+
+    await render(
+      <ErrorBoundary fallback={({ onRetry }) => <Text onPress={onRetry}>retry</Text>}>
+        <Bomb shouldThrow={shouldThrow} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('retry')).toBeTruthy();
+
+    shouldThrow.current = false;
+    await fireEvent.press(screen.getByText('retry'));
+
+    expect(screen.getByText('bomb defused')).toBeTruthy();
+    expect(screen.queryByText('retry')).toBeNull();
+  });
+
+  it('scopes the crash: content outside the boundary keeps working', async () => {
+    const shouldThrow = { current: true };
+
+    await render(
+      <>
+        <ErrorBoundary fallback={() => <Text>this screen crashed</Text>}>
+          <Bomb shouldThrow={shouldThrow} />
+        </ErrorBoundary>
+        <Text>sibling screen is fine</Text>
+      </>
+    );
+
+    expect(screen.getByText('this screen crashed')).toBeTruthy();
+    expect(screen.getByText('sibling screen is fine')).toBeTruthy();
+  });
+});

--- a/apps/self-service/src/app/(auth)/login.tsx
+++ b/apps/self-service/src/app/(auth)/login.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 
 import { LoginScreen } from '../../screens/login-screen';
+import { RouteErrorBoundary } from '../../components/route-error-boundary';
 
 export default function LoginRoute() {
-  return <LoginScreen />;
+  return (
+    <RouteErrorBoundary>
+      <LoginScreen />
+    </RouteErrorBoundary>
+  );
 }

--- a/apps/self-service/src/app/(tabs)/api-keys.tsx
+++ b/apps/self-service/src/app/(tabs)/api-keys.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 
 import { ApiKeysScreen } from '../../screens/api-keys-screen';
+import { RouteErrorBoundary } from '../../components/route-error-boundary';
 
 export default function ApiKeysRoute() {
-  return <ApiKeysScreen />;
+  return (
+    <RouteErrorBoundary>
+      <ApiKeysScreen />
+    </RouteErrorBoundary>
+  );
 }

--- a/apps/self-service/src/app/(tabs)/home.tsx
+++ b/apps/self-service/src/app/(tabs)/home.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 
 import { HomeScreen } from '../../screens/home-screen';
+import { RouteErrorBoundary } from '../../components/route-error-boundary';
 
 export default function HomeRoute() {
-  return <HomeScreen />;
+  return (
+    <RouteErrorBoundary>
+      <HomeScreen />
+    </RouteErrorBoundary>
+  );
 }

--- a/apps/self-service/src/app/(tabs)/settings.tsx
+++ b/apps/self-service/src/app/(tabs)/settings.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { SettingsScreen } from '../../screens/settings-screen';
+import { RouteErrorBoundary } from '../../components/route-error-boundary';
 
 export default function SettingsRoute() {
-  return <SettingsScreen />;
+  return (
+    <RouteErrorBoundary>
+      <SettingsScreen />
+    </RouteErrorBoundary>
+  );
 }

--- a/apps/self-service/src/app/(tabs)/usage.tsx
+++ b/apps/self-service/src/app/(tabs)/usage.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 
 import { UsageScreen } from '../../screens/usage-screen';
+import { RouteErrorBoundary } from '../../components/route-error-boundary';
 
 export default function UsageRoute() {
-  return <UsageScreen />;
+  return (
+    <RouteErrorBoundary>
+      <UsageScreen />
+    </RouteErrorBoundary>
+  );
 }

--- a/apps/self-service/src/app/_layout.tsx
+++ b/apps/self-service/src/app/_layout.tsx
@@ -29,6 +29,7 @@ import { RuntimeConfigProvider, useRuntimeConfig } from '../configs/runtime-conf
 import { AppSplashView } from '../views/app-splash-view';
 import { ThemePreferenceProvider } from '../theme/theme-preference';
 import { AppSheetProvider } from '../navigation/app-sheet-provider';
+import { AppErrorBoundary } from '../components/app-error-boundary';
 
 WebBrowser.maybeCompleteAuthSession();
 enableScreens();
@@ -170,9 +171,11 @@ export default function RootLayout() {
           <RuntimeConfigProvider fallback={webFallback} onReady={handleRuntimeReady}>
             <QueryClientProvider client={queryClient}>
               {fontsLoaded ? (
-                <AppSheetProvider>
-                  <AppBootstrap />
-                </AppSheetProvider>
+                <AppErrorBoundary>
+                  <AppSheetProvider>
+                    <AppBootstrap />
+                  </AppSheetProvider>
+                </AppErrorBoundary>
               ) : (
                 webFallback
               )}

--- a/apps/self-service/src/app/api-keys/new.tsx
+++ b/apps/self-service/src/app/api-keys/new.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { ApiKeyCreateScreen } from '../../screens/api-key-create-screen';
+import { RouteErrorBoundary } from '../../components/route-error-boundary';
 
 export default function ApiKeyCreateRoute() {
-  return <ApiKeyCreateScreen />;
+  return (
+    <RouteErrorBoundary>
+      <ApiKeyCreateScreen />
+    </RouteErrorBoundary>
+  );
 }

--- a/apps/self-service/src/app/help.tsx
+++ b/apps/self-service/src/app/help.tsx
@@ -3,6 +3,7 @@ import { Stack } from 'expo-router';
 import { useTranslation } from '@lightbridge/i18n';
 
 import { HelpScreen } from '../screens/help-screen';
+import { RouteErrorBoundary } from '../components/route-error-boundary';
 
 export default function HelpRoute() {
   useTranslation();
@@ -10,7 +11,9 @@ export default function HelpRoute() {
   return (
     <>
       <Stack.Screen options={{ headerShown: false, title: '' }} />
-      <HelpScreen />
+      <RouteErrorBoundary>
+        <HelpScreen />
+      </RouteErrorBoundary>
     </>
   );
 }

--- a/apps/self-service/src/app/index.tsx
+++ b/apps/self-service/src/app/index.tsx
@@ -4,8 +4,9 @@ import { Redirect } from 'expo-router';
 import { useAuthSession, useAuthHydration } from '@lightbridge/hooks';
 import { isWebPlatform } from '@lightbridge/api-native';
 import { AppSplashView } from '../views/app-splash-view';
+import { RouteErrorBoundary } from '../components/route-error-boundary';
 
-export default function IndexRoute() {
+function IndexScreen() {
   const { isAuthenticated } = useAuthSession();
   const { isHydrated } = useAuthHydration();
 
@@ -15,4 +16,12 @@ export default function IndexRoute() {
   }
 
   return <Redirect href={isAuthenticated ? '/home' : '/login'} />;
+}
+
+export default function IndexRoute() {
+  return (
+    <RouteErrorBoundary>
+      <IndexScreen />
+    </RouteErrorBoundary>
+  );
 }

--- a/apps/self-service/src/app/settings-account.tsx
+++ b/apps/self-service/src/app/settings-account.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { AccountSettingsScreen } from '../screens/account-settings-screen';
+import { RouteErrorBoundary } from '../components/route-error-boundary';
 
 export default function SettingsAccountRoute() {
-  return <AccountSettingsScreen />;
+  return (
+    <RouteErrorBoundary>
+      <AccountSettingsScreen />
+    </RouteErrorBoundary>
+  );
 }

--- a/apps/self-service/src/app/settings-budget-review.tsx
+++ b/apps/self-service/src/app/settings-budget-review.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { BudgetReviewScreen } from '../screens/budget-review-screen';
+import { RouteErrorBoundary } from '../components/route-error-boundary';
 
 export default function SettingsBudgetReviewRoute() {
-  return <BudgetReviewScreen />;
+  return (
+    <RouteErrorBoundary>
+      <BudgetReviewScreen />
+    </RouteErrorBoundary>
+  );
 }

--- a/apps/self-service/src/app/settings-budget.tsx
+++ b/apps/self-service/src/app/settings-budget.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { BudgetRefillScreen } from '../screens/budget-refill-screen';
+import { RouteErrorBoundary } from '../components/route-error-boundary';
 
 export default function SettingsBudgetRoute() {
-  return <BudgetRefillScreen />;
+  return (
+    <RouteErrorBoundary>
+      <BudgetRefillScreen />
+    </RouteErrorBoundary>
+  );
 }

--- a/apps/self-service/src/app/settings-project.tsx
+++ b/apps/self-service/src/app/settings-project.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { ProjectSettingsScreen } from '../screens/project-settings-screen';
+import { RouteErrorBoundary } from '../components/route-error-boundary';
 
 export default function SettingsProjectRoute() {
-  return <ProjectSettingsScreen />;
+  return (
+    <RouteErrorBoundary>
+      <ProjectSettingsScreen />
+    </RouteErrorBoundary>
+  );
 }

--- a/apps/self-service/src/components/__tests__/app-error-boundary.test.tsx
+++ b/apps/self-service/src/components/__tests__/app-error-boundary.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { initI18n } from '@lightbridge/i18n';
+
+import { AppErrorBoundary } from '../app-error-boundary';
+
+function Bomb({ shouldThrow }: Readonly<{ shouldThrow: { current: boolean } }>) {
+  if (shouldThrow.current) {
+    throw new Error('boom: bomb detonated');
+  }
+  return <Text>bomb defused</Text>;
+}
+
+beforeAll(() => {
+  initI18n('en');
+});
+
+beforeEach(() => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  (console.error as jest.Mock).mockRestore();
+});
+
+describe('AppErrorBoundary', () => {
+  it('renders the calm, translated crash fallback instead of a blank app', async () => {
+    const shouldThrow = { current: true };
+
+    await render(
+      <AppErrorBoundary>
+        <Bomb shouldThrow={shouldThrow} />
+      </AppErrorBoundary>
+    );
+
+    expect(screen.getByText('Something went wrong')).toBeTruthy();
+    expect(
+      screen.getByText(
+        "We hit an unexpected error and couldn't finish loading this. Your data is safe."
+      )
+    ).toBeTruthy();
+    expect(screen.getByText('Try again')).toBeTruthy();
+    // Deliberately no in-app navigation offered at the root level -- see the
+    // component's doc comment: the navigator itself may be what failed to
+    // render, so a "go home" affordance here would not be trustworthy.
+    expect(screen.queryByText('Back to start')).toBeNull();
+  });
+
+  it('never shows a raw stack trace in the fallback UI', async () => {
+    const shouldThrow = { current: true };
+
+    await render(
+      <AppErrorBoundary>
+        <Bomb shouldThrow={shouldThrow} />
+      </AppErrorBoundary>
+    );
+
+    expect(screen.queryByText(/boom: bomb detonated/)).toBeNull();
+  });
+
+  it('recovers on retry', async () => {
+    const shouldThrow = { current: true };
+
+    await render(
+      <AppErrorBoundary>
+        <Bomb shouldThrow={shouldThrow} />
+      </AppErrorBoundary>
+    );
+
+    shouldThrow.current = false;
+    await fireEvent.press(screen.getByText('Try again'));
+
+    expect(screen.getByText('bomb defused')).toBeTruthy();
+  });
+});

--- a/apps/self-service/src/components/__tests__/route-error-boundary.test.tsx
+++ b/apps/self-service/src/components/__tests__/route-error-boundary.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { initI18n } from '@lightbridge/i18n';
+
+const mockReplace = jest.fn();
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+import { RouteErrorBoundary } from '../route-error-boundary';
+
+function Bomb({ shouldThrow }: Readonly<{ shouldThrow: { current: boolean } }>) {
+  if (shouldThrow.current) {
+    throw new Error('boom: bomb detonated');
+  }
+  return <Text>bomb defused</Text>;
+}
+
+beforeAll(() => {
+  initI18n('en');
+});
+
+beforeEach(() => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  mockReplace.mockClear();
+});
+
+afterEach(() => {
+  (console.error as jest.Mock).mockRestore();
+});
+
+describe('RouteErrorBoundary', () => {
+  it('renders the calm, translated per-screen fallback with both recovery actions', async () => {
+    const shouldThrow = { current: true };
+
+    await render(
+      <RouteErrorBoundary>
+        <Bomb shouldThrow={shouldThrow} />
+      </RouteErrorBoundary>
+    );
+
+    expect(screen.getByText('This screen ran into a problem')).toBeTruthy();
+    expect(screen.getByText('Try again')).toBeTruthy();
+    expect(screen.getByText('Back to start')).toBeTruthy();
+  });
+
+  it('"Back to start" navigates to `/` instead of reloading the whole app', async () => {
+    const shouldThrow = { current: true };
+
+    await render(
+      <RouteErrorBoundary>
+        <Bomb shouldThrow={shouldThrow} />
+      </RouteErrorBoundary>
+    );
+
+    await fireEvent.press(screen.getByText('Back to start'));
+
+    expect(mockReplace).toHaveBeenCalledWith('/');
+  });
+
+  it('"Try again" recovers in place, remounting only the crashed screen', async () => {
+    const shouldThrow = { current: true };
+
+    await render(
+      <RouteErrorBoundary>
+        <Bomb shouldThrow={shouldThrow} />
+      </RouteErrorBoundary>
+    );
+
+    shouldThrow.current = false;
+    await fireEvent.press(screen.getByText('Try again'));
+
+    expect(screen.getByText('bomb defused')).toBeTruthy();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+});

--- a/apps/self-service/src/components/app-error-boundary.tsx
+++ b/apps/self-service/src/components/app-error-boundary.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { useTranslation } from '@lightbridge/i18n';
+import { Button, designTokens, EmptyState, Icon as Feather, Page, Stack } from '@lightbridge/ui';
+
+import { useThemeColors } from '../hooks/use-theme-colors';
+import { ErrorBoundary } from './error-boundary';
+import type { ErrorBoundaryFallbackProps } from './error-boundary';
+
+function AppCrashFallback({ onRetry }: Readonly<ErrorBoundaryFallbackProps>) {
+  const { t } = useTranslation();
+  const colors = useThemeColors();
+
+  return (
+    <Page tone="muted" pad="md">
+      <Stack align="center" justify="center" flex="grow" width="full">
+        <EmptyState
+          icon={
+            <Feather
+              name="alert-triangle"
+              size={designTokens.icon.prominent}
+              color={colors.error}
+            />
+          }
+          title={t('errorBoundary.title')}
+          description={t('errorBoundary.description')}
+          action={
+            <Button variant="primary" onPress={onRetry}>
+              {t('errorBoundary.retry')}
+            </Button>
+          }
+        />
+      </Stack>
+    </Page>
+  );
+}
+
+/**
+ * Last line of defense, mounted once around the app content in `_layout.tsx`
+ * (see `RootLayout`). Every screen also gets its own `RouteErrorBoundary` (see
+ * that file) which is the boundary that actually fires for a screen-level
+ * crash like the one in issue #180 -- this one exists for whatever a
+ * per-route boundary can't cover: an error thrown from `AppBootstrap` itself,
+ * a provider, or the navigator setup rather than from within a specific
+ * screen.
+ *
+ * Deliberately does not offer in-app navigation as a recovery option. At this
+ * level the Stack/Tabs navigator itself may be the thing that failed to
+ * render, so there is no guarantee `useRouter()` has a `NavigationContainer`
+ * to talk to. "Try again" only resets local state and remounts `children`.
+ */
+export function AppErrorBoundary({ children }: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <ErrorBoundary fallback={(props) => <AppCrashFallback {...props} />}>{children}</ErrorBoundary>
+  );
+}

--- a/apps/self-service/src/components/error-boundary.tsx
+++ b/apps/self-service/src/components/error-boundary.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+export type ErrorBoundaryFallbackProps = {
+  error: Error;
+  onRetry: () => void;
+};
+
+type ErrorBoundaryProps = {
+  children: React.ReactNode;
+  fallback: (props: ErrorBoundaryFallbackProps) => React.ReactNode;
+  onError?: (error: Error, componentStack: string | null) => void;
+};
+
+type ErrorBoundaryState = {
+  error: Error | null;
+};
+
+/**
+ * A render-time error boundary. React only exposes `componentDidCatch` /
+ * `getDerivedStateFromError` on class components -- there is no hook
+ * equivalent -- so this stays a class despite the rest of the app being
+ * function-component-only.
+ *
+ * Always logs the caught error and component stack to the console *before*
+ * rendering the fallback. This is a deliberate, load-bearing choice, not an
+ * incidental log line: the incident that motivated this component (see
+ * lightbridge issue #180 -- a `TypeError` inside `OneTimeSecretCard`'s
+ * `useMemo` blanked the entire app) was only diagnosable because the crash
+ * reached the console with a clean stack trace. A boundary that swallows the
+ * error would hide the next one just as effectively as no boundary at all.
+ * `onError` is an additional hook for callers that want to also assert on
+ * what was reported (tests) or forward it to telemetry -- it is never a
+ * substitute for the console.error below.
+ */
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    const componentStack = errorInfo.componentStack ?? null;
+    console.error('[ErrorBoundary] Caught a render error:', error, componentStack);
+    this.props.onError?.(error, componentStack);
+  }
+
+  reset = () => {
+    this.setState({ error: null });
+  };
+
+  render() {
+    const { error } = this.state;
+    if (error) {
+      return this.props.fallback({ error, onRetry: this.reset });
+    }
+    return this.props.children;
+  }
+}

--- a/apps/self-service/src/components/route-error-boundary.tsx
+++ b/apps/self-service/src/components/route-error-boundary.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { useRouter } from 'expo-router';
+import { useTranslation } from '@lightbridge/i18n';
+import { Button, designTokens, EmptyState, Icon as Feather, Page, Stack } from '@lightbridge/ui';
+
+import { useThemeColors } from '../hooks/use-theme-colors';
+import { ErrorBoundary } from './error-boundary';
+import type { ErrorBoundaryFallbackProps } from './error-boundary';
+
+function ScreenCrashFallback({ onRetry }: Readonly<ErrorBoundaryFallbackProps>) {
+  const { t } = useTranslation();
+  const colors = useThemeColors();
+  const router = useRouter();
+
+  return (
+    <Page tone="muted" pad="md">
+      <Stack align="center" justify="center" flex="grow" width="full">
+        <EmptyState
+          icon={
+            <Feather
+              name="alert-triangle"
+              size={designTokens.icon.prominent}
+              color={colors.error}
+            />
+          }
+          title={t('errorBoundary.screenTitle')}
+          description={t('errorBoundary.screenDescription')}
+          action={
+            <Stack direction="row" gap="sm">
+              {/* `/` (not `/home`) so this is safe to press from *any* screen,
+                  including a not-yet-authenticated one -- index.tsx already
+                  knows how to redirect based on auth state. */}
+              <Button variant="neutral" onPress={() => router.replace('/')}>
+                {t('errorBoundary.goHome')}
+              </Button>
+              <Button variant="primary" onPress={onRetry}>
+                {t('errorBoundary.retry')}
+              </Button>
+            </Stack>
+          }
+        />
+      </Stack>
+    </Page>
+  );
+}
+
+/**
+ * Wraps a single Expo Router screen. Every route under `app/` is a thin
+ * `export default function XRoute() { return <XScreen />; }` -- this wraps
+ * that render so a crash inside one screen (the shape of issue #180's
+ * `OneTimeSecretCard` bug) is caught right there instead of unmounting
+ * whatever layout/navigator is hosting it.
+ *
+ * Deliberately a hand-rolled boundary rather than Expo Router's own per-route
+ * `ErrorBoundary` export convention: that hands retry/reset semantics and the
+ * exact logging behavior to router internals we don't control. This version
+ * is explicit, shares its implementation and logging with `AppErrorBoundary`,
+ * and is unit-testable the same way any other component here is.
+ *
+ * Scoped to one screen so a crash there doesn't take the Stack/Tabs navigator
+ * down with it -- the tab bar / header stay mounted, and the fallback below
+ * offers a way back to the start in addition to retrying in place.
+ */
+export function RouteErrorBoundary({ children }: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <ErrorBoundary fallback={(props) => <ScreenCrashFallback {...props} />}>
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/packages/i18n/src/i18n-config.ts
+++ b/packages/i18n/src/i18n-config.ts
@@ -15,6 +15,20 @@ const resources = {
         previous: 'Previous',
         next: 'Next',
       },
+      // Copy for the render-time error boundaries (see
+      // apps/self-service/src/components/error-boundary.tsx and its two
+      // wrappers). Deliberately calm and specific rather than alarming --
+      // never a raw stack trace, that's console/telemetry-only.
+      errorBoundary: {
+        title: 'Something went wrong',
+        description:
+          "We hit an unexpected error and couldn't finish loading this. Your data is safe.",
+        retry: 'Try again',
+        screenTitle: 'This screen ran into a problem',
+        screenDescription:
+          'We hit an unexpected error loading this screen. You can try again or head back to the start.',
+        goHome: 'Back to start',
+      },
       // Shared strings for the account/project picker (`EntityPickerField` in
       // apps/self-service/src/components/entity-picker-field.tsx, wrapping `@lightbridge/ui`'s
       // `Picker`/`PickerList`). Generic on purpose — the entity-specific label, empty-state, and


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds a hand-rolled `ErrorBoundary` class component (`apps/self-service/src/components/error-boundary.tsx`) that catches render-time throws, always logs the error + component stack to the console, and renders a caller-supplied fallback with a retry hook.
- Adds `AppErrorBoundary` (`apps/self-service/src/components/app-error-boundary.tsx`), mounted once around the post-bootstrap app tree in `_layout.tsx` as a last-resort, full-app fallback.
- Adds `RouteErrorBoundary` (`apps/self-service/src/components/route-error-boundary.tsx`), wrapped around every individual screen's render in its `app/*.tsx` route file, so a crash in one screen doesn't take the whole navigator down.
- Adds `errorBoundary.*` copy to `packages/i18n/src/i18n-config.ts`.

It solves:

- A single render-time throw in one screen blanking the entire app, with no way back except a manual reload — see Intent below.

---

## 2. Intent

> Source of truth: [#180](https://github.com/ADORSYS-GIS/converse-frontends/issues/180)

On 2026-08-17 a `TypeError: t?.trim is not a function` inside `OneTimeSecretCard`'s `useMemo` (a
present-but-non-string `oauth2Url`) blanked the whole self-service app immediately after a user
successfully created an API key. The field-level bug is fixed and merged in
[#179](https://github.com/ADORSYS-GIS/converse-frontends/pull/179); its root cause is tracked
separately in #180. #180 explicitly scoped the missing error boundary out as its own follow-up
("a single field-level bug should not blank the entire app ... worth its own ticket"). This PR is
that follow-up.

The defect being fixed here is the *amplification*, not the field bug itself: a crash in one card
should not be able to take down every screen in the app.

---

## 3. Scope

### In Scope

- A generic, reusable render-time `ErrorBoundary` primitive with a mandatory `console.error(error, componentStack)` call — it can never become a silent swallower, which would defeat the point (the original crash was only diagnosable because it hit the console with a clean stack).
- Two composed boundaries: `AppErrorBoundary` (root, one last-resort layer, no in-app navigation offered) and `RouteErrorBoundary` (per-screen, offers both "Try again" and "Back to start").
- Wiring `RouteErrorBoundary` into every route under `apps/self-service/src/app/` (12 route files) and `AppErrorBoundary` into `_layout.tsx`.
- Fallback UI composed from existing `@lightbridge/ui` primitives (`EmptyState`, `Button`, `Page`, `Stack`, `Icon`) — no new design-system component, no third-party error-boundary dependency (repo has none installed; a hand-rolled boundary avoids adding one for ~50 lines of class-component logic).
- Unit tests for all three components, including a break-it-and-watch-it-fail verification (see Verification).

### Out of Scope

- The `oauth2Url` root-cause investigation — that is #180's own remaining scope, not this PR's.
- Telemetry/error-reporting integration — investigated and none exists in this repo today (no Sentry, no OTel error-reporting path, no existing logger/reporter beyond `console.*`; the usage-api OTLP ingest endpoints exist server-side only and nothing in the frontend calls them for client errors). `console.error` is therefore the full reporting surface for now, matching the existing `console.warn`/`console.error` convention already used elsewhere in this app (e.g. `_layout.tsx`'s `handleRefreshFailure`). Not adding a new third-party dependency per the task constraints.
- Any change to `OneTimeSecretCard`, `api-key-create-screen.tsx`, or any other business logic — this PR only adds boundaries around existing screens, it does not touch what they render.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [x] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

New tests (11, across 3 files) prove the boundary catches a render-time throw, logs it, lets the
user recover, and doesn't take a sibling down with it — including a genuine break-it/watch-it-fail
cycle (not just tests written after the fact):

1. Broke it by making `getDerivedStateFromError` a no-op (simulating "no error boundary" — the
   original incident). All 11 tests failed with the raw uncaught `Error: boom: bomb detonated`
   propagating out of `render()`, exactly the white-screen failure mode this PR fixes.
2. Restored `getDerivedStateFromError`, then broke it again by deleting only the `console.error`
   call (keeping the catch). Exactly 1 test failed — "reports the caught error and its component
   stack to the console" — while the other 4 in that file still passed, proving that test is
   specifically pinned to the anti-swallowing guarantee and not the catching behavior.
3. Restored both. All tests green again.

Commands run:

```bash
pnpm install
pnpm exec tsc --noEmit -p apps/self-service/tsconfig.json
pnpm exec tsc --noEmit -p packages/ui/tsconfig.json
pnpm --dir apps/self-service test
pnpm exec eslint "apps/self-service/src/app/**/*.tsx" "apps/self-service/src/components/**/*.tsx" "apps/self-service/src/__tests__/error-boundary.test.tsx" "packages/i18n/src/i18n-config.ts"
pnpm exec prettier -c apps/self-service/src/components/error-boundary.tsx apps/self-service/src/components/app-error-boundary.tsx apps/self-service/src/components/route-error-boundary.tsx apps/self-service/src/__tests__/error-boundary.test.tsx apps/self-service/src/components/__tests__/app-error-boundary.test.tsx apps/self-service/src/components/__tests__/route-error-boundary.test.tsx
```

Results:

```text
$ pnpm --dir apps/self-service test
Test Suites: 40 passed, 40 total
Tests:       212 passed, 212 total
Snapshots:   0 total
Time:        3.279 s

$ pnpm exec tsc --noEmit -p apps/self-service/tsconfig.json
(no output — clean)

$ pnpm exec tsc --noEmit -p packages/ui/tsconfig.json
(no output — clean)

$ pnpm exec eslint ...
0 errors, 5 warnings (all pre-existing patterns: import/first on a
jest.mock-before-import test file, matching an existing test in this repo;
import/no-named-as-default-member on i18next re-exports, pre-existing and
unrelated to my one added block)

$ pnpm exec prettier -c ...
All matched files use Prettier code style!
```

---

## 5. Screenshots / Evidence

No screenshots — this environment doesn't have a simulator/device attached to this worktree, and
the change is behavioral (what happens on a crash) rather than a new visual surface reusing
existing, already-styled primitives (`EmptyState`, `Button`, `Page`) verbatim as they render
elsewhere in the app. The fallback text/structure is exercised directly by the RTL tests in
Verification (`screen.getByText('Something went wrong')`, `screen.getByText('This screen ran into
a problem')`, etc.), which is the evidence for what actually renders.

* Test output: see the `Verification` section above (211 → 212 passing, break/fix cycle included).

---

## 6. Risk Assessment

Risk level:

* [x] Low

Potential risks:

* A boundary that accidentally swallows errors would be worse than no boundary (masks the next
  crash). Mitigated by making `console.error(error, componentStack)` unconditional in
  `componentDidCatch` — verified by the break-it/watch-it-fail cycle in Verification, which fails a
  specific, dedicated test the moment that line is removed.
* Wrapping all 12 routes touches every screen's entry file. Each wrap is a mechanical, minimal
  diff (import + JSX wrap, no logic change) — `git diff --stat` shows 7-11 lines changed per file,
  and `tsc --noEmit` + the full existing test suite (212 tests, unrelated to this change) both stay
  green, so this isn't expected to change any existing screen's behavior on the happy path.
* `RouteErrorBoundary`'s "Back to start" always calls `router.replace('/')` rather than a
  guard-aware `/home`, so it's safe to press from an unauthenticated screen too (`index.tsx`
  already knows how to redirect based on auth state) — deliberate, not an oversight.

Mitigation:

* Unit tests pin both the catching behavior and the anti-swallowing logging behavior independently,
  with a real break/fix cycle proving each one is load-bearing.
* No change to any screen's own rendering logic — only an added wrapper around existing default
  exports.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Refactoring
* [x] Generating tests
* [ ] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Architecture
* [ ] Security
* [ ] Performance
* [x] Tests
* [ ] Maintainability
* [ ] Product intent
* [x] Edge cases
