### PR TITLE
feat(self-service): API-key expiry selection (create, edit, list legibility)

### DIFF
--- a/apps/self-service/src/components/__tests__/expiry-selector.test.tsx
+++ b/apps/self-service/src/components/__tests__/expiry-selector.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { initI18n } from '@lightbridge/i18n';
+
+import { ExpirySelector } from '../expiry-selector';
+
+beforeAll(() => {
+  initI18n('en');
+});
+
+// `DateField` renders a raw DOM `<input type="date">` (react-native-web host element, see
+// `packages/ui/src/components/date-field/component.tsx`), which only exposes a web-style
+// `onChange` prop -- not RN's `onChangeText`. `fireEvent.changeText` looks for `onChangeText`
+// and finds nothing on this element, so it silently no-ops; firing a plain 'change' event with
+// a DOM-shaped `{ target: { value } }` payload is what actually invokes `onChange` here.
+async function typeIntoDateField(text: string) {
+  await fireEvent(screen.getByLabelText('Expiration date'), 'change', { target: { value: text } });
+}
+
+describe('ExpirySelector', () => {
+  it('defaults to the 30-day preset and reports its resolved expiresAt on mount', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-06-01T00:00:00.000Z'));
+    const onChange = jest.fn();
+
+    await render(<ExpirySelector onChange={onChange} />);
+
+    expect(onChange).toHaveBeenCalledWith('2026-07-01T00:00:00.000Z');
+    jest.useRealTimers();
+  });
+
+  it('switches to 60/90-day presets and reports the recomputed expiresAt', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-06-01T00:00:00.000Z'));
+    const onChange = jest.fn();
+
+    await render(<ExpirySelector onChange={onChange} />);
+    onChange.mockClear();
+
+    await fireEvent.press(screen.getByText('60 days'));
+    expect(onChange).toHaveBeenLastCalledWith('2026-07-31T00:00:00.000Z');
+
+    await fireEvent.press(screen.getByText('90 days'));
+    expect(onChange).toHaveBeenLastCalledWith('2026-08-30T00:00:00.000Z');
+
+    jest.useRealTimers();
+  });
+
+  it('reports null for "No expiry"', async () => {
+    const onChange = jest.fn();
+    await render(<ExpirySelector onChange={onChange} />);
+    onChange.mockClear();
+
+    await fireEvent.press(screen.getByText('No expiry'));
+
+    expect(onChange).toHaveBeenLastCalledWith(null);
+  });
+
+  it('reveals a date field for "Custom" and reports undefined until a date is entered', async () => {
+    const onChange = jest.fn();
+    await render(<ExpirySelector onChange={onChange} />);
+    onChange.mockClear();
+
+    await fireEvent.press(screen.getByText('Custom'));
+
+    expect(onChange).toHaveBeenLastCalledWith(undefined);
+    expect(screen.getByLabelText('Expiration date')).toBeTruthy();
+  });
+
+  it('reports the resolved ISO datetime once a custom date is entered', async () => {
+    const onChange = jest.fn();
+    await render(<ExpirySelector onChange={onChange} />);
+
+    await fireEvent.press(screen.getByText('Custom'));
+    await typeIntoDateField('2026-12-31');
+
+    expect(onChange).toHaveBeenLastCalledWith('2026-12-31T00:00:00.000Z');
+  });
+
+  it('reports undefined again if the custom date is cleared', async () => {
+    const onChange = jest.fn();
+    await render(<ExpirySelector onChange={onChange} />);
+
+    await fireEvent.press(screen.getByText('Custom'));
+    await typeIntoDateField('2026-12-31');
+    await typeIntoDateField('');
+
+    expect(onChange).toHaveBeenLastCalledWith(undefined);
+  });
+
+  it('seeds "No expiry" when the initial value is null', async () => {
+    const onChange = jest.fn();
+    await render(<ExpirySelector initialValue={null} onChange={onChange} />);
+
+    expect(onChange).toHaveBeenCalledWith(null);
+    expect(screen.queryByLabelText('Expiration date')).toBeNull();
+  });
+
+  it('seeds "Custom" pre-filled with an existing expiresAt', async () => {
+    const onChange = jest.fn();
+    await render(<ExpirySelector initialValue="2026-09-15T00:00:00.000Z" onChange={onChange} />);
+
+    expect(onChange).toHaveBeenCalledWith('2026-09-15T00:00:00.000Z');
+    // `getByDisplayValue` targets RN's `TextInput`, not a raw DOM `<input>` -- read the host
+    // element's `value` prop directly instead.
+    expect(screen.getByLabelText('Expiration date').props.value).toBe('2026-09-15');
+  });
+
+  it('disables every preset option when disabled', async () => {
+    await render(<ExpirySelector onChange={jest.fn()} disabled />);
+
+    expect(screen.getByRole('button', { name: '30 days' }).props.accessibilityState.disabled).toBe(
+      true
+    );
+    expect(
+      screen.getByRole('button', { name: 'No expiry' }).props.accessibilityState.disabled
+    ).toBe(true);
+  });
+});

--- a/apps/self-service/src/components/expiry-selector.tsx
+++ b/apps/self-service/src/components/expiry-selector.tsx
@@ -1,0 +1,136 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from '@lightbridge/i18n';
+import { DateField, FormField, SegmentedControl, Stack, Text } from '@lightbridge/ui';
+
+import {
+  EXPIRY_PRESET_DAYS,
+  EXPIRY_PRESET_ORDER,
+  dateOnlyToExpiresAt,
+  expiresAtToDateOnly,
+  presetToExpiresAt,
+} from '../lib/api-key-expiry';
+import type { ExpiryDurationPreset, ExpiryPresetKey } from '../lib/api-key-expiry';
+
+/** Derives which preset an existing `expiresAt` should show as selected on mount: unset starts
+ * on "No expiry"; any set value starts on "Custom" pre-filled with that exact date. There is no
+ * way to tell from a stored `expiresAt` alone whether it was originally set via a duration
+ * preset or a specific date, so re-showing it as "Custom" is the only choice that doesn't
+ * silently round an existing key's real expiration when its settings screen re-opens it. */
+function initialPresetFor(expiresAt?: string | null): ExpiryPresetKey {
+  return expiresAt ? 'custom' : 'noExpiry';
+}
+
+function resolve(
+  preset: ExpiryPresetKey,
+  customDraft: string,
+  now: Date
+): string | null | undefined {
+  if (preset === 'noExpiry') return null;
+  if (preset === 'custom') {
+    return customDraft.trim() === '' ? undefined : dateOnlyToExpiresAt(customDraft);
+  }
+  return presetToExpiresAt(EXPIRY_PRESET_DAYS[preset], now);
+}
+
+export type ExpirySelectorProps = {
+  /**
+   * Seeds the initial preset/custom-date UI, read once on mount: `undefined` defaults to the
+   * 30-day preset (a fresh create form); an ISO datetime seeds "Custom" pre-filled with that
+   * date; `null` seeds "No expiry" (an existing key with no expiration).
+   *
+   * Only read once -- callers that need to reset this when switching to a different key (e.g.
+   * the settings screen's key picker) should remount via `key={apiKey?.id}` rather than push
+   * updated props into an already-mounted selector.
+   */
+  initialValue?: string | null;
+  /** Fires on every user interaction with the resolved value: an ISO datetime, `null` for "no
+   * expiry", or `undefined` while "Custom" holds an incomplete/invalid date (callers should
+   * block Save on `undefined`, the same convention used elsewhere in this app). */
+  onChange: (value: string | null | undefined) => void;
+  disabled?: boolean;
+  /** Caption rendered above the preset control, styled like `FormField`'s own label. Callers
+   * should pass this instead of wrapping in a `FormField` themselves -- the "Custom" date field
+   * already renders its own sub-label, and nesting two `FormField` labels reads oddly. */
+  label?: string;
+};
+
+export function ExpirySelector({
+  initialValue,
+  onChange,
+  disabled = false,
+  label,
+}: Readonly<ExpirySelectorProps>) {
+  const { t } = useTranslation();
+  const [preset, setPreset] = useState<ExpiryPresetKey>(() =>
+    initialValue === undefined ? 'thirtyDays' : initialPresetFor(initialValue)
+  );
+  const [customDraft, setCustomDraft] = useState(() => expiresAtToDateOnly(initialValue));
+
+  useEffect(() => {
+    onChange(resolve(preset, customDraft, new Date()));
+    // Fire once on mount with the initial preset/custom-date resolution so callers (e.g. the
+    // create form) have a real value before any interaction. Every later change is driven
+    // directly by the handlers below, which call `onChange` themselves -- this effect
+    // intentionally does not re-run on `preset`/`customDraft` changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const presetLabels: Record<ExpiryPresetKey, string> = {
+    thirtyDays: t('apiKeys.expiry.thirtyDays'),
+    sixtyDays: t('apiKeys.expiry.sixtyDays'),
+    ninetyDays: t('apiKeys.expiry.ninetyDays'),
+    custom: t('apiKeys.expiry.custom'),
+    noExpiry: t('apiKeys.expiry.noExpiry'),
+  };
+
+  const options = EXPIRY_PRESET_ORDER.map((key) => ({
+    key,
+    label: presetLabels[key],
+    disabled,
+  }));
+
+  const handlePresetChange = (key: string) => {
+    const nextPreset = key as ExpiryPresetKey;
+    setPreset(nextPreset);
+    onChange(resolve(nextPreset, customDraft, new Date()));
+  };
+
+  const handleDraftChange = (draft: string) => {
+    setCustomDraft(draft);
+    onChange(resolve('custom', draft, new Date()));
+  };
+
+  const todayDateOnly = expiresAtToDateOnly(new Date().toISOString());
+  const customInvalid =
+    preset === 'custom' &&
+    customDraft.trim() !== '' &&
+    dateOnlyToExpiresAt(customDraft) === undefined;
+
+  return (
+    <Stack gap="sm" width="full">
+      {label ? <Text intent="bodyStrong">{label}</Text> : null}
+      <SegmentedControl
+        width="full"
+        options={options}
+        value={preset}
+        onChange={handlePresetChange}
+        accessibilityLabel={t('apiKeys.expiry.label')}
+      />
+      {preset === 'custom' ? (
+        <FormField
+          label={t('apiKeys.expiry.customDateLabel')}
+          error={customInvalid ? t('apiKeys.expiry.customDateInvalid') : undefined}>
+          <DateField
+            value={customDraft}
+            onValueChange={handleDraftChange}
+            min={todayDateOnly}
+            disabled={disabled}
+            accessibilityLabel={t('apiKeys.expiry.customDateLabel')}
+          />
+        </FormField>
+      ) : null}
+    </Stack>
+  );
+}
+
+export type { ExpiryDurationPreset, ExpiryPresetKey };

--- a/apps/self-service/src/lib/__tests__/api-key-expiry.test.ts
+++ b/apps/self-service/src/lib/__tests__/api-key-expiry.test.ts
@@ -1,0 +1,191 @@
+import {
+  EXPIRING_SOON_WINDOW_DAYS,
+  EXPIRY_PRESET_DAYS,
+  dateOnlyToExpiresAt,
+  daysUntilExpiry,
+  expiresAtToDateOnly,
+  getDerivedStatus,
+  getExpiryUrgency,
+  isExpired,
+  presetToExpiresAt,
+} from '../api-key-expiry';
+
+describe('presetToExpiresAt', () => {
+  it('adds the preset day count to now, preserving time-of-day', () => {
+    const now = new Date('2026-06-01T09:30:00.000Z');
+
+    expect(presetToExpiresAt(EXPIRY_PRESET_DAYS.thirtyDays, now)).toBe('2026-07-01T09:30:00.000Z');
+    expect(presetToExpiresAt(EXPIRY_PRESET_DAYS.sixtyDays, now)).toBe('2026-07-31T09:30:00.000Z');
+    expect(presetToExpiresAt(EXPIRY_PRESET_DAYS.ninetyDays, now)).toBe('2026-08-30T09:30:00.000Z');
+  });
+});
+
+describe('dateOnlyToExpiresAt', () => {
+  it('anchors a valid YYYY-MM-DD date at UTC midnight', () => {
+    expect(dateOnlyToExpiresAt('2026-12-31')).toBe('2026-12-31T00:00:00.000Z');
+  });
+
+  it('rejects malformed input', () => {
+    expect(dateOnlyToExpiresAt('12/31/2026')).toBeUndefined();
+    expect(dateOnlyToExpiresAt('not-a-date')).toBeUndefined();
+    expect(dateOnlyToExpiresAt('2026-13-40')).toBeUndefined();
+    expect(dateOnlyToExpiresAt('')).toBeUndefined();
+    expect(dateOnlyToExpiresAt('   ')).toBeUndefined();
+  });
+});
+
+describe('expiresAtToDateOnly', () => {
+  it('returns an empty string for null/undefined/unparseable input', () => {
+    expect(expiresAtToDateOnly(null)).toBe('');
+    expect(expiresAtToDateOnly(undefined)).toBe('');
+    expect(expiresAtToDateOnly('not-a-date')).toBe('');
+  });
+
+  it('reads back the UTC calendar day', () => {
+    expect(expiresAtToDateOnly('2026-12-31T00:00:00.000Z')).toBe('2026-12-31');
+  });
+});
+
+describe('timezone handling (dateOnlyToExpiresAt <-> expiresAtToDateOnly round-trip)', () => {
+  // The regression this module exists to prevent: naively using local-time getters
+  // (`getFullYear`/`getMonth`/`getDate`, or `toLocaleDateString`) to read back a UTC-midnight
+  // `Date` reads the day *before* the one that was actually stored, for any timezone with a
+  // negative UTC offset (i.e. most of the Americas) -- and the day *after*, for positive
+  // offsets, once the input crosses 23:00 UTC.
+  //
+  // Reassigning `process.env.TZ` mid-test does NOT reliably flip these functions' behavior in
+  // this repo's jest-expo test environment -- verified directly: `Intl.DateTimeFormat().
+  // resolvedOptions().timeZone` still reports the machine's real zone after an in-test
+  // `process.env.TZ = 'America/New_York'`, so a test asserting on wall-clock output would pass
+  // or fail depending on the *runner's* real timezone, not on whether the implementation is
+  // actually UTC-safe -- exactly the kind of flake this suite must not have.
+  //
+  // Instead, this spies on `Date.prototype`'s local-time getters and proves the two functions
+  // never call them at all -- they only ever use `getTime()`/`toISOString()` (UTC-based), which
+  // is the actual property that makes them timezone-safe on every machine, not just this one.
+  const localGetterNames = [
+    'getFullYear',
+    'getMonth',
+    'getDate',
+    'getDay',
+    'getHours',
+    'getMinutes',
+    'getSeconds',
+    'getMilliseconds',
+  ] as const;
+
+  function spyOnLocalGetters() {
+    return localGetterNames.map((name) => jest.spyOn(Date.prototype, name));
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('dateOnlyToExpiresAt never reads local-time fields', () => {
+    const spies = spyOnLocalGetters();
+
+    expect(dateOnlyToExpiresAt('2026-01-15')).toBe('2026-01-15T00:00:00.000Z');
+
+    for (const spy of spies) {
+      expect(spy).not.toHaveBeenCalled();
+    }
+  });
+
+  it('expiresAtToDateOnly never reads local-time fields', () => {
+    const spies = spyOnLocalGetters();
+
+    expect(expiresAtToDateOnly('2026-01-15T00:00:00.000Z')).toBe('2026-01-15');
+
+    for (const spy of spies) {
+      expect(spy).not.toHaveBeenCalled();
+    }
+  });
+
+  it('round-trips a plain date and a New Year boundary date back to themselves', () => {
+    for (const draft of ['2026-01-15', '2027-01-01', '2026-12-31']) {
+      const isoValue = dateOnlyToExpiresAt(draft);
+      expect(isoValue).toBe(`${draft}T00:00:00.000Z`);
+      expect(expiresAtToDateOnly(isoValue)).toBe(draft);
+    }
+  });
+});
+
+describe('isExpired', () => {
+  const now = new Date('2026-06-15T00:00:00.000Z');
+
+  it('is false when there is no expiration', () => {
+    expect(isExpired(null, now)).toBe(false);
+    expect(isExpired(undefined, now)).toBe(false);
+  });
+
+  it('is false for a future expiration and true for a past one', () => {
+    expect(isExpired('2026-07-01T00:00:00.000Z', now)).toBe(false);
+    expect(isExpired('2026-06-01T00:00:00.000Z', now)).toBe(true);
+  });
+
+  it('treats the exact expiry instant as already expired', () => {
+    expect(isExpired('2026-06-15T00:00:00.000Z', now)).toBe(true);
+  });
+});
+
+describe('daysUntilExpiry', () => {
+  const now = new Date('2026-06-15T00:00:00.000Z');
+
+  it('returns null when there is no expiration or the value is unparseable', () => {
+    expect(daysUntilExpiry(null, now)).toBeNull();
+    expect(daysUntilExpiry('not-a-date', now)).toBeNull();
+  });
+
+  it('rounds up to whole days remaining', () => {
+    expect(daysUntilExpiry('2026-06-16T00:00:00.000Z', now)).toBe(1);
+    expect(daysUntilExpiry('2026-06-16T01:00:00.000Z', now)).toBe(2);
+    expect(daysUntilExpiry('2026-06-01T00:00:00.000Z', now)).toBe(-14);
+  });
+});
+
+describe('getExpiryUrgency', () => {
+  const now = new Date('2026-06-15T00:00:00.000Z');
+
+  it('is "none" when there is no expiration', () => {
+    expect(getExpiryUrgency(null, now)).toBe('none');
+    expect(getExpiryUrgency(undefined, now)).toBe('none');
+  });
+
+  it('is "expired" once past the expiry instant', () => {
+    expect(getExpiryUrgency('2026-06-01T00:00:00.000Z', now)).toBe('expired');
+  });
+
+  it(`is "soon" within the ${EXPIRING_SOON_WINDOW_DAYS}-day window`, () => {
+    const soonDate = new Date(now.getTime() + EXPIRING_SOON_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+    expect(getExpiryUrgency(soonDate.toISOString(), now)).toBe('soon');
+  });
+
+  it('is "far" just outside the soon window', () => {
+    const farDate = new Date(now.getTime() + (EXPIRING_SOON_WINDOW_DAYS + 1) * 24 * 60 * 60 * 1000);
+    expect(getExpiryUrgency(farDate.toISOString(), now)).toBe('far');
+  });
+});
+
+describe('getDerivedStatus', () => {
+  const now = new Date('2026-06-15T00:00:00.000Z');
+
+  it('is "revoked" whenever the backend status says so, regardless of expiry', () => {
+    expect(
+      getDerivedStatus({ status: 'revoked', expiresAt: '2030-01-01T00:00:00.000Z' }, now)
+    ).toBe('revoked');
+  });
+
+  it('is "expired" for an active-but-past-expiry key', () => {
+    expect(getDerivedStatus({ status: 'active', expiresAt: '2026-01-01T00:00:00.000Z' }, now)).toBe(
+      'expired'
+    );
+  });
+
+  it('is "active" for an active key with no expiration or a future one', () => {
+    expect(getDerivedStatus({ status: 'active', expiresAt: null }, now)).toBe('active');
+    expect(getDerivedStatus({ status: 'active', expiresAt: '2030-01-01T00:00:00.000Z' }, now)).toBe(
+      'active'
+    );
+  });
+});

--- a/apps/self-service/src/lib/api-key-expiry.ts
+++ b/apps/self-service/src/lib/api-key-expiry.ts
@@ -1,0 +1,131 @@
+import type { ApiKey } from '@lightbridge/hooks';
+
+/**
+ * Pure date/expiry helpers shared by the API-key create, settings/edit, and list views.
+ *
+ * Two different kinds of "expiry" flow through here and must not be confused:
+ *  - Preset durations (30/60/90 days) are relative to *now*: `presetToExpiresAt` adds N days to
+ *    the current instant and keeps the resulting time-of-day, so there is no date-only/timezone
+ *    conversion involved.
+ *  - The "Custom" date picker only ever collects a calendar day (`YYYY-MM-DD`, no time-of-day),
+ *    so round-tripping it through an ISO `DateTime` needs an explicit, fixed anchor. This module
+ *    always anchors at UTC midnight in both directions (`dateOnlyToExpiresAt` /
+ *    `expiresAtToDateOnly`), matching what the pre-existing settings-view draft parser already
+ *    did. Anchoring anywhere else (e.g. the browser's local midnight) would make the stored
+ *    calendar day silently drift by one depending on the caller's timezone offset -- this module
+ *    exists specifically to keep that bug from being reintroduced; see
+ *    `apps/self-service/src/lib/__tests__/api-key-expiry.test.ts`'s timezone-drift tests.
+ */
+
+export const EXPIRY_PRESET_DAYS = {
+  thirtyDays: 30,
+  sixtyDays: 60,
+  ninetyDays: 90,
+} as const;
+
+export type ExpiryDurationPreset = keyof typeof EXPIRY_PRESET_DAYS;
+export type ExpiryPresetKey = ExpiryDurationPreset | 'noExpiry' | 'custom';
+
+export const EXPIRY_PRESET_ORDER: ExpiryPresetKey[] = [
+  'thirtyDays',
+  'sixtyDays',
+  'ninetyDays',
+  'custom',
+  'noExpiry',
+];
+
+/**
+ * How many days out counts as "expiring soon" in the list/detail views. Set to half of the
+ * shortest offered preset (30 days) so a key minted on the shortest preset spends a visible
+ * stretch of its life flagged before it lapses, without flagging keys for most of their life.
+ */
+export const EXPIRING_SOON_WINDOW_DAYS = 14;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/** `now + days`, as a full ISO instant (time-of-day preserved from `now`). Used for the
+ * duration presets, which are relative durations, not calendar-date selections. */
+export function presetToExpiresAt(days: number, now: Date = new Date()): string {
+  return new Date(now.getTime() + days * MS_PER_DAY).toISOString();
+}
+
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Parses a `YYYY-MM-DD` custom-date draft into an ISO `DateTime` anchored at UTC midnight.
+ * Returns `undefined` for anything that isn't a well-formed calendar date -- callers treat
+ * `undefined` as "invalid, block Save", matching the rest of this app's inline validation.
+ */
+export function dateOnlyToExpiresAt(dateOnly: string): string | undefined {
+  const trimmed = dateOnly.trim();
+  if (!DATE_ONLY_PATTERN.test(trimmed)) return undefined;
+  const date = new Date(`${trimmed}T00:00:00.000Z`);
+  if (Number.isNaN(date.getTime())) return undefined;
+  return date.toISOString();
+}
+
+/**
+ * Renders a nullable ISO expiration back to the `YYYY-MM-DD` the date picker edits, reading the
+ * UTC calendar day -- the exact inverse of `dateOnlyToExpiresAt`. Uses `toISOString().slice(0,
+ * 10)` (UTC), never `getFullYear`/`getMonth`/`getDate` or `toLocaleDateString` (local time) --
+ * those would read back the day *before* the stored UTC midnight for any timezone with a
+ * negative UTC offset.
+ */
+export function expiresAtToDateOnly(value?: string | null): string {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toISOString().slice(0, 10);
+}
+
+export function isExpired(expiresAt?: string | null, now: Date = new Date()): boolean {
+  if (!expiresAt) return false;
+  const date = new Date(expiresAt);
+  if (Number.isNaN(date.getTime())) return false;
+  return date.getTime() <= now.getTime();
+}
+
+/** Whole days remaining until `expiresAt` (rounded up), or `null` when there is no expiration
+ * or the value doesn't parse. Zero or negative once the key has expired. */
+export function daysUntilExpiry(expiresAt?: string | null, now: Date = new Date()): number | null {
+  if (!expiresAt) return null;
+  const date = new Date(expiresAt);
+  if (Number.isNaN(date.getTime())) return null;
+  return Math.ceil((date.getTime() - now.getTime()) / MS_PER_DAY);
+}
+
+export type ExpiryUrgency = 'none' | 'far' | 'soon' | 'expired';
+
+/** Classifies an expiration for display purposes: `'none'` (no expiry set), `'far'` (set, well
+ * out), `'soon'` (within `EXPIRING_SOON_WINDOW_DAYS`, still valid), or `'expired'` (in the
+ * past). */
+export function getExpiryUrgency(expiresAt?: string | null, now: Date = new Date()): ExpiryUrgency {
+  if (!expiresAt) return 'none';
+  const days = daysUntilExpiry(expiresAt, now);
+  if (days === null) return 'none';
+  if (days <= 0) return 'expired';
+  if (days <= EXPIRING_SOON_WINDOW_DAYS) return 'soon';
+  return 'far';
+}
+
+export type DerivedKeyStatus = 'active' | 'revoked' | 'expired';
+
+/**
+ * The status a key should *read* as, distinct from `ApiKey.status` (the raw backend field,
+ * which only ever holds `'active'` or `'revoked'` -- the backend does not flip it to anything
+ * expiry-related on its own). A key can be `status: 'active'` in the database yet already
+ * rejected at validation time because it's past `expiresAt` (see `authz-opa`'s validation
+ * endpoint, which rejects revoked *and* expired keys); this derives the label that makes that
+ * state legible instead of misreporting it as `'active'`.
+ *
+ * Deliberately does not gate button `disabled` state -- rotate/revoke stay keyed off the real
+ * backend `status` (an expired-but-not-revoked key can still be rotated or explicitly revoked).
+ */
+export function getDerivedStatus(
+  key: Pick<ApiKey, 'status' | 'expiresAt'>,
+  now: Date = new Date()
+): DerivedKeyStatus {
+  if (key.status === 'revoked') return 'revoked';
+  if (isExpired(key.expiresAt, now)) return 'expired';
+  return 'active';
+}

--- a/apps/self-service/src/screens/api-key-create-screen.tsx
+++ b/apps/self-service/src/screens/api-key-create-screen.tsx
@@ -109,15 +109,19 @@ export function ApiKeyCreateScreen() {
     router.navigate('/api-keys');
   };
 
-  const handleCreate = async (name: string, billingPlan: string) => {
+  const handleCreate = async (name: string, billingPlan: string, expiresAt: string | null) => {
     // Clear any stale failure from a previous attempt as soon as a new one starts, so a retry
     // never shows an old error next to a fresh, still-in-flight submission.
     setCreateError(null);
     try {
       const resolvedProjectId = projectId ?? (await ensureProject((await ensureAccount()).id)).id;
 
+      // `expiresAt` is passed explicitly as `null` for "no expiry", never omitted -- an omitted
+      // (`undefined`) field and an explicit `null` encode differently over this app's CBOR wire
+      // codec, and the codec has drifted on exactly that distinction before (see the
+      // createProject prod incident this pattern guards against).
       await createKey(
-        { input: { name, billingPlan }, projectId: resolvedProjectId },
+        { input: { name, billingPlan, expiresAt }, projectId: resolvedProjectId },
         {
           onSuccess: (data) => {
             if (data?.secret) {

--- a/apps/self-service/src/views/__tests__/api-key-create-view.expiry.test.tsx
+++ b/apps/self-service/src/views/__tests__/api-key-create-view.expiry.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { initI18n } from '@lightbridge/i18n';
+
+import { ApiKeyCreateView } from '../api-key-create-view';
+
+const noop = () => undefined;
+
+beforeAll(() => {
+  initI18n('en');
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+async function nameField() {
+  return fireEvent.changeText(screen.getByPlaceholderText('Production'), 'CI key');
+}
+
+describe('ApiKeyCreateView expiry', () => {
+  it('defaults to a 30-days-out expiresAt', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-06-01T00:00:00.000Z'));
+    const onCreate = jest.fn();
+    await render(<ApiKeyCreateView onBack={noop} onCreate={onCreate} onCopy={noop} />);
+
+    await nameField();
+    await fireEvent.press(screen.getByText('Save key'));
+
+    expect(onCreate).toHaveBeenCalledWith('CI key', 'free', '2026-07-01T00:00:00.000Z');
+  });
+
+  it('sends explicit null (not omitted) when "No expiry" is chosen', async () => {
+    const onCreate = jest.fn();
+    await render(<ApiKeyCreateView onBack={noop} onCreate={onCreate} onCopy={noop} />);
+
+    await nameField();
+    await fireEvent.press(screen.getByText('No expiry'));
+    await fireEvent.press(screen.getByText('Save key'));
+
+    expect(onCreate).toHaveBeenCalledWith('CI key', 'free', null);
+  });
+
+  it('sends the resolved date once a custom date is entered', async () => {
+    const onCreate = jest.fn();
+    await render(<ApiKeyCreateView onBack={noop} onCreate={onCreate} onCopy={noop} />);
+
+    await nameField();
+    await fireEvent.press(screen.getByText('Custom'));
+    await fireEvent(screen.getByLabelText('Expiration date'), 'change', {
+      target: { value: '2026-12-31' },
+    });
+    await fireEvent.press(screen.getByText('Save key'));
+
+    expect(onCreate).toHaveBeenCalledWith('CI key', 'free', '2026-12-31T00:00:00.000Z');
+  });
+
+  it('disables Save while "Custom" has no date entered yet', async () => {
+    await render(<ApiKeyCreateView onBack={noop} onCreate={noop} onCopy={noop} />);
+
+    await nameField();
+    await fireEvent.press(screen.getByText('Custom'));
+
+    expect(screen.getByRole('button', { name: 'Save key' }).props.accessibilityState.disabled).toBe(
+      true
+    );
+  });
+});

--- a/apps/self-service/src/views/__tests__/api-key-create-view.plan.test.tsx
+++ b/apps/self-service/src/views/__tests__/api-key-create-view.plan.test.tsx
@@ -22,7 +22,9 @@ describe('ApiKeyCreateView billing plan gating', () => {
     await fireEvent.changeText(screen.getByPlaceholderText('Production'), 'CI key');
     await fireEvent.press(screen.getByText('Save key'));
 
-    expect(onCreate).toHaveBeenCalledWith('CI key', 'free');
+    // Third arg is the resolved expiresAt -- defaults to the 30-day preset (see
+    // api-key-create-view.expiry.test.tsx for dedicated coverage of that value).
+    expect(onCreate).toHaveBeenCalledWith('CI key', 'free', expect.any(String));
   });
 
   it('lets an account member pick a plan and forwards it', async () => {
@@ -35,7 +37,7 @@ describe('ApiKeyCreateView billing plan gating', () => {
     await fireEvent.changeText(screen.getByPlaceholderText('free'), 'pro');
     await fireEvent.press(screen.getByText('Save key'));
 
-    expect(onCreate).toHaveBeenCalledWith('Prod key', 'pro');
+    expect(onCreate).toHaveBeenCalledWith('Prod key', 'pro', expect.any(String));
   });
 
   it('defaults an account member to the free plan when the field is left blank', async () => {
@@ -47,6 +49,6 @@ describe('ApiKeyCreateView billing plan gating', () => {
     await fireEvent.changeText(screen.getByPlaceholderText('Production'), 'Prod key');
     await fireEvent.press(screen.getByText('Save key'));
 
-    expect(onCreate).toHaveBeenCalledWith('Prod key', 'free');
+    expect(onCreate).toHaveBeenCalledWith('Prod key', 'free', expect.any(String));
   });
 });

--- a/apps/self-service/src/views/__tests__/api-keys-list-view.expiry.test.tsx
+++ b/apps/self-service/src/views/__tests__/api-keys-list-view.expiry.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { initI18n } from '@lightbridge/i18n';
+import type { ApiKey } from '@lightbridge/hooks';
+
+import { ApiKeysListView } from '../api-keys-list-view';
+
+const noop = () => undefined;
+
+const baseItem: ApiKey = {
+  id: 'key-1',
+  projectId: 'project-1',
+  name: 'Production',
+  keyPrefix: 'TEST-FIXTURE-PREFIX',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  status: 'active',
+  billingPlan: 'free',
+};
+
+beforeAll(() => {
+  initI18n('en');
+});
+
+beforeEach(() => {
+  jest.useFakeTimers().setSystemTime(new Date('2026-06-15T00:00:00.000Z'));
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+async function renderList(item: ApiKey) {
+  return render(
+    <ApiKeysListView
+      items={[item]}
+      onBack={noop}
+      onCreate={noop}
+      onDelete={noop}
+      onRevoke={noop}
+      onRotate={noop}
+      onSelectAccount={noop}
+      onSelectProject={noop}
+      onOpenAccountPicker={noop}
+      onOpenProjectPicker={noop}
+    />
+  );
+}
+
+describe('ApiKeysListView expiry legibility', () => {
+  it('shows "No expiry" as an explicit state, not a blank gap', async () => {
+    await renderList({ ...baseItem, expiresAt: null });
+
+    expect(screen.getByText('No expiry')).toBeTruthy();
+  });
+
+  it('shows a plain "Expires on" caption for a far-out expiration', async () => {
+    await renderList({ ...baseItem, expiresAt: '2027-01-01T00:00:00.000Z' });
+
+    expect(screen.getByText(/Expires Jan 01, 2027/)).toBeTruthy();
+    // Still reads as "Active" -- far out is not urgent.
+    expect(screen.getByText('Active')).toBeTruthy();
+  });
+
+  it('flags an expiring-soon key with a warning-toned days-remaining badge', async () => {
+    // 5 days out from the frozen "now" -- inside the 14-day soon window.
+    await renderList({ ...baseItem, expiresAt: '2026-06-20T00:00:00.000Z' });
+
+    expect(screen.getByText('Expires in 5 days')).toBeTruthy();
+    // The key is still functionally active -- this is a warning, not an error state.
+    expect(screen.getByText('Active')).toBeTruthy();
+  });
+
+  it('makes an expired-but-not-revoked key unmistakable via the header badge', async () => {
+    await renderList({ ...baseItem, status: 'active', expiresAt: '2026-01-01T00:00:00.000Z' });
+
+    // The raw backend status is still "active", but the badge must read "Expired", not "Active".
+    expect(screen.queryByText('Active')).toBeNull();
+    expect(screen.getByText('Expired')).toBeTruthy();
+    expect(screen.getByText(/Expired Jan 01, 2026/)).toBeTruthy();
+  });
+
+  it('still lets an expired-but-not-revoked key be rotated and revoked', async () => {
+    await renderList({ ...baseItem, status: 'active', expiresAt: '2026-01-01T00:00:00.000Z' });
+
+    expect(screen.getByLabelText('Rotate Production').props.accessibilityState.disabled).toBe(
+      false
+    );
+    expect(screen.getByLabelText('Revoke Production').props.accessibilityState.disabled).toBe(
+      false
+    );
+  });
+
+  it('shows "Revoked" (not "Expired") for a revoked key, even if it is also past its expiry', async () => {
+    await renderList({
+      ...baseItem,
+      status: 'revoked',
+      expiresAt: '2026-01-01T00:00:00.000Z',
+      revokedAt: '2026-01-02T00:00:00.000Z',
+    });
+
+    expect(screen.getByText('Revoked')).toBeTruthy();
+    expect(screen.queryByText('Expired')).toBeNull();
+  });
+});

--- a/apps/self-service/src/views/api-key-create-view.tsx
+++ b/apps/self-service/src/views/api-key-create-view.tsx
@@ -14,6 +14,7 @@ import {
   Text,
   TextField,
 } from '@lightbridge/ui';
+import { ExpirySelector } from '../components/expiry-selector';
 import { OneTimeSecretCard } from '../components/one-time-secret-card';
 import { useThemeColors } from '../hooks/use-theme-colors';
 
@@ -29,7 +30,9 @@ const DEFAULT_API_KEY_BILLING_PLAN = 'free';
 
 type ApiKeyCreateViewProps = {
   onBack: () => void;
-  onCreate: (name: string, billingPlan: string) => void;
+  /** `expiresAt` is always resolved before Save can be pressed: an ISO datetime, or `null` for
+   * "no expiry" -- never `undefined` (see `isSubmitDisabled` below). */
+  onCreate: (name: string, billingPlan: string, expiresAt: string | null) => void;
   onCopy: (value: string) => void;
   isCreating?: boolean;
   /** When true, the user may pick a billing plan; otherwise keys are pinned to `free`. */
@@ -59,16 +62,20 @@ export function ApiKeyCreateView({
   const colors = useThemeColors();
   const [name, setName] = useState('');
   const [billingPlan, setBillingPlan] = useState('');
+  // `undefined` means "Custom" is selected with no valid date yet -- ExpirySelector's mount
+  // effect replaces this with a real value (the 30-day preset by default) before the user does
+  // anything, so this only stays `undefined` while actively editing an invalid custom date.
+  const [expiresAt, setExpiresAt] = useState<string | null | undefined>(undefined);
 
   const trimmedName = name.trim();
   const resolvedPlan = canChoosePlan
     ? billingPlan.trim() || DEFAULT_API_KEY_BILLING_PLAN
     : DEFAULT_API_KEY_BILLING_PLAN;
-  const isSubmitDisabled = isCreating || !trimmedName;
+  const isSubmitDisabled = isCreating || !trimmedName || expiresAt === undefined;
 
   const submit = () => {
-    if (isSubmitDisabled) return;
-    onCreate(trimmedName, resolvedPlan);
+    if (isSubmitDisabled || expiresAt === undefined) return;
+    onCreate(trimmedName, resolvedPlan, expiresAt);
   };
 
   return (
@@ -160,6 +167,11 @@ export function ApiKeyCreateView({
                       {t('apiKeys.planLockedNote')}
                     </Text>
                   )}
+                  <ExpirySelector
+                    label={t('apiKeys.expiry.label')}
+                    onChange={setExpiresAt}
+                    disabled={isCreating}
+                  />
                   {createError ? (
                     <Callout
                       tone="error"

--- a/apps/self-service/src/views/api-keys-list-view.tsx
+++ b/apps/self-service/src/views/api-keys-list-view.tsx
@@ -26,6 +26,8 @@ import {
   toProjectPickerOptions,
 } from '../components/entity-picker-field';
 import { useThemeColors } from '../hooks/use-theme-colors';
+import type { DerivedKeyStatus } from '../lib/api-key-expiry';
+import { daysUntilExpiry, getDerivedStatus, getExpiryUrgency } from '../lib/api-key-expiry';
 
 const i18nLocaleMap: Record<string, string> = {
   en: 'en-US',
@@ -78,6 +80,58 @@ export const formatNullableDate = (value?: string | null, locale?: string) => {
 
   return formatDate(value, locale);
 };
+
+/** `Badge` tone for the header status pill. `revoked` and `expired` read equally severe (both
+ * mean the key can't authenticate right now) -- only the label differs. */
+const STATUS_BADGE_TONE: Record<DerivedKeyStatus, 'success' | 'error'> = {
+  active: 'success',
+  revoked: 'error',
+  expired: 'error',
+};
+
+/** The footer caption for a key's expiration -- always renders something (including "No
+ * expiry" as an explicit state, never an empty gap), and escalates to a warning-toned `Badge`
+ * once the key is within the "expiring soon" window so it doesn't read as identical to the
+ * plain `createdOn`/`lastUsed` captions beside it. Expired keys are already unmistakable via
+ * the header status badge (see `STATUS_BADGE_TONE`); this still shows the exact date so "when"
+ * is legible, not just "that it happened". */
+function ExpiryCaption({
+  expiresAt,
+  dateLocale,
+}: Readonly<{ expiresAt?: string | null; dateLocale: string }>) {
+  const { t } = useTranslation();
+  const colors = useThemeColors();
+  const urgency = getExpiryUrgency(expiresAt);
+
+  if (urgency === 'none') {
+    return <Text intent="caption">{t('apiKeys.expiry.noExpiryLabel')}</Text>;
+  }
+
+  if (urgency === 'expired') {
+    return (
+      <Text intent="caption" style={{ color: colors.error }}>
+        {t('apiKeys.expiry.expiredOn', { date: formatNullableDate(expiresAt, dateLocale) })}
+      </Text>
+    );
+  }
+
+  if (urgency === 'soon') {
+    const days = daysUntilExpiry(expiresAt) ?? 0;
+    return (
+      <Badge tone="warning">
+        {days <= 0
+          ? t('apiKeys.expiry.expiresToday')
+          : t('apiKeys.expiry.expiresInDays', { count: days })}
+      </Badge>
+    );
+  }
+
+  return (
+    <Text intent="caption">
+      {t('apiKeys.expiresOn', { date: formatNullableDate(expiresAt, dateLocale) })}
+    </Text>
+  );
+}
 
 export function ApiKeysListView({
   accounts = [],
@@ -248,7 +302,12 @@ export function ApiKeysListView({
                 const createdLabel = t('apiKeys.createdOn', {
                   date: formatDate(item.createdAt, dateLocale),
                 });
+                // `isActive` gates the Rotate/Revoke buttons and stays tied to the real backend
+                // `status` -- an expired-but-not-revoked key can still be rotated or explicitly
+                // revoked. `derivedStatus` only drives the badge label/tone below, so an expired
+                // key reads as "Expired" instead of misreporting as "Active".
                 const isActive = item.status === 'active';
+                const derivedStatus = getDerivedStatus(item);
 
                 return (
                   <DataCard
@@ -263,9 +322,9 @@ export function ApiKeysListView({
                           {item.name}
                         </Text>
                         <Badge
-                          tone={isActive ? 'success' : 'error'}
-                          accessibilityLabel={t(`apiKeys.status.${item.status}`)}>
-                          {t(`apiKeys.status.${item.status}`)}
+                          tone={STATUS_BADGE_TONE[derivedStatus]}
+                          accessibilityLabel={t(`apiKeys.status.${derivedStatus}`)}>
+                          {t(`apiKeys.status.${derivedStatus}`)}
                         </Badge>
                       </Stack>
                     }
@@ -321,7 +380,7 @@ export function ApiKeysListView({
                           </Stack>
                         ) : null}
 
-                        <Stack direction="row" gap="md" wrap="wrap" width="full">
+                        <Stack direction="row" gap="md" wrap="wrap" width="full" align="center">
                           <Text intent="caption">{createdLabel}</Text>
                           <Text intent="caption">
                             {item.lastUsedAt
@@ -330,13 +389,7 @@ export function ApiKeysListView({
                                 })
                               : t('apiKeys.neverUsed')}
                           </Text>
-                          {item.expiresAt ? (
-                            <Text intent="caption">
-                              {t('apiKeys.expiresOn', {
-                                date: formatNullableDate(item.expiresAt, dateLocale),
-                              })}
-                            </Text>
-                          ) : null}
+                          <ExpiryCaption expiresAt={item.expiresAt} dateLocale={dateLocale} />
                         </Stack>
                       </Stack>
                     }

--- a/apps/self-service/src/views/settings/__tests__/api-key-settings-view.test.tsx
+++ b/apps/self-service/src/views/settings/__tests__/api-key-settings-view.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/react-native';
 import { initI18n } from '@lightbridge/i18n';
 import type { Account, ApiKey, Project } from '@lightbridge/hooks';
 
-import { ApiKeySettingsView, parseExpirationDraft } from '../api-key-settings-view';
+import { ApiKeySettingsView } from '../api-key-settings-view';
 
 const noop = () => undefined;
 
@@ -81,23 +81,6 @@ function renderView(overrides: Partial<React.ComponentProps<typeof ApiKeySetting
   );
 }
 
-describe('parseExpirationDraft', () => {
-  it('maps an empty draft to null (no expiration)', () => {
-    expect(parseExpirationDraft('')).toBeNull();
-    expect(parseExpirationDraft('   ')).toBeNull();
-  });
-
-  it('parses a valid YYYY-MM-DD date to an ISO datetime', () => {
-    expect(parseExpirationDraft('2026-12-31')).toBe('2026-12-31T00:00:00.000Z');
-  });
-
-  it('rejects malformed input as undefined (invalid)', () => {
-    expect(parseExpirationDraft('12/31/2026')).toBeUndefined();
-    expect(parseExpirationDraft('not-a-date')).toBeUndefined();
-    expect(parseExpirationDraft('2026-13-40')).toBeUndefined();
-  });
-});
-
 describe('ApiKeySettingsView', () => {
   it('renders the account/project/key selectors and the selected key details', async () => {
     await renderView();
@@ -105,7 +88,11 @@ describe('ApiKeySettingsView', () => {
     expect(screen.getByText('acc-1')).toBeTruthy();
     expect(screen.getByText('production')).toBeTruthy();
     expect(screen.getByDisplayValue('ci-runner')).toBeTruthy();
-    expect(screen.getByDisplayValue('2026-12-31')).toBeTruthy();
+    // The expiry picker seeds "Custom" pre-filled with the key's existing expiration.
+    expect(screen.getByRole('button', { name: 'Custom' }).props.accessibilityState.selected).toBe(
+      true
+    );
+    expect(screen.getByLabelText('Expiration date').props.value).toBe('2026-12-31');
   });
 
   it('calls onSelectKey when a key chip is pressed', async () => {
@@ -134,7 +121,7 @@ describe('ApiKeySettingsView', () => {
     );
   });
 
-  it('calls onSaveDetails with the trimmed name and parsed expiration', async () => {
+  it('calls onSaveDetails with the trimmed name and the unchanged expiration', async () => {
     const onSaveDetails = jest.fn();
     await renderView({ onSaveDetails });
 
@@ -151,16 +138,18 @@ describe('ApiKeySettingsView', () => {
     const onSaveDetails = jest.fn();
     await renderView({ onSaveDetails });
 
-    await fireEvent.changeText(screen.getByDisplayValue('2026-12-31'), '');
+    await fireEvent.press(screen.getByText('No expiry'));
     await fireEvent.press(screen.getByText('Save'));
 
     expect(onSaveDetails).toHaveBeenCalledWith({ name: 'ci-runner', expiresAt: null });
   });
 
-  it('disables Save when the expiration draft is not a valid date', async () => {
+  it('disables Save when the custom expiration draft is not a valid date', async () => {
     await renderView();
 
-    await fireEvent.changeText(screen.getByDisplayValue('2026-12-31'), 'not-a-date');
+    await fireEvent(screen.getByLabelText('Expiration date'), 'change', {
+      target: { value: 'not-a-date' },
+    });
 
     expect(screen.getByRole('button', { name: 'Save' }).props.accessibilityState.disabled).toBe(
       true
@@ -185,15 +174,33 @@ describe('ApiKeySettingsView', () => {
     await renderView({ apiKey: revokedKey, apiKeys: [revokedKey] });
 
     expect(screen.getByText('This key has already been revoked.')).toBeTruthy();
-    expect(
-      screen.getByLabelText('Revoke old-key').props.accessibilityState.disabled
-    ).toBe(true);
+    expect(screen.getByLabelText('Revoke old-key').props.accessibilityState.disabled).toBe(true);
   });
 
   it('renders a Revoked badge and a revoked-on row for a revoked key', async () => {
     await renderView({ apiKey: revokedKey, apiKeys: [revokedKey] });
 
     expect(screen.getAllByText('Revoked').length).toBeGreaterThan(0);
+  });
+
+  it('shows an Expired badge and the expired notice for an active-but-past-expiry key, while keeping Revoke enabled', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2027-01-01T00:00:00.000Z'));
+    const expiredKey: ApiKey = { ...activeKey, expiresAt: '2026-12-31T00:00:00Z' };
+    await renderView({ apiKey: expiredKey, apiKeys: [expiredKey] });
+
+    // Appears twice by design: the header status pill, and the metadata section's "Status" row
+    // (which now shows the same derived status rather than the raw, possibly-stale backend
+    // value, so the two never contradict each other on the same screen).
+    expect(screen.getAllByText('Expired').length).toBe(2);
+    expect(screen.queryByText('Active')).toBeNull();
+    expect(
+      screen.getByText(
+        'This key expired and can no longer authenticate requests. Extend or clear its expiration above to restore it.'
+      )
+    ).toBeTruthy();
+    expect(screen.getByLabelText('Revoke ci-runner').props.accessibilityState.disabled).toBe(false);
+
+    jest.useRealTimers();
   });
 
   it('calls onRevoke and onDelete from the danger zone', async () => {

--- a/apps/self-service/src/views/settings/api-key-settings-view.tsx
+++ b/apps/self-service/src/views/settings/api-key-settings-view.tsx
@@ -21,35 +21,15 @@ import {
   TextField,
 } from '@lightbridge/ui';
 import type { Account, ApiKey, Project } from '@lightbridge/hooks';
+import { ExpirySelector } from '../../components/expiry-selector';
 import { useThemeColors } from '../../hooks/use-theme-colors';
+import { expiresAtToDateOnly, getDerivedStatus } from '../../lib/api-key-expiry';
 import { formatDate, formatNullableDate } from '../api-keys-list-view';
 
 export type ApiKeyDetailsInput = {
   name: string;
   /** ISO datetime string, or `null` to clear the expiration. */
   expiresAt: string | null;
-};
-
-/** Renders a nullable ISO expiration as a `YYYY-MM-DD` draft ('' = no expiration). */
-const expiresAtToDraft = (value?: string | null) => {
-  if (!value) return '';
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return '';
-  return date.toISOString().slice(0, 10);
-};
-
-/**
- * Parses a `YYYY-MM-DD` expiration draft back to an ISO datetime (midnight UTC): '' means "no
- * expiration" (null), a valid date string becomes an ISO datetime, anything else is `undefined`
- * (invalid, blocks Save the same way `parseLimitDraft` does in project-settings-view).
- */
-export const parseExpirationDraft = (draft: string): string | null | undefined => {
-  const trimmed = draft.trim();
-  if (trimmed === '') return null;
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) return undefined;
-  const date = new Date(`${trimmed}T00:00:00.000Z`);
-  if (Number.isNaN(date.getTime())) return undefined;
-  return date.toISOString();
 };
 
 type ApiKeySettingsViewProps = {
@@ -105,33 +85,42 @@ export function ApiKeySettingsView({
   const dateLocale = i18n.language;
 
   const [nameDraft, setNameDraft] = useState(apiKey?.name ?? '');
-  const [expirationDraft, setExpirationDraft] = useState(expiresAtToDraft(apiKey?.expiresAt));
+  const [expiresAtDraft, setExpiresAtDraft] = useState<string | null | undefined>(
+    apiKey?.expiresAt ?? null
+  );
 
   useEffect(() => {
     setNameDraft(apiKey?.name ?? '');
-    setExpirationDraft(expiresAtToDraft(apiKey?.expiresAt));
+    // `expiresAtDraft` is deliberately NOT reset here. `ExpirySelector` below is remounted via
+    // `key={apiKey.id}` whenever the selected key changes, and its own mount effect reports the
+    // freshly-seeded resolved value through `onChange` (= `setExpiresAtDraft`) -- React fires a
+    // child's mount effect before this parent effect in the same commit, so resetting it here
+    // too would win the race and clobber that resolved value back to the raw, unnormalized
+    // `apiKey.expiresAt` (observed as a real bug: `2026-12-31T00:00:00Z` overwriting the
+    // correctly-resolved `2026-12-31T00:00:00.000Z` on every render).
   }, [apiKey]);
 
   const trimmedName = nameDraft.trim();
-  const parsedExpiration = parseExpirationDraft(expirationDraft);
-  const expirationValid = parsedExpiration !== undefined;
-  // Compare drafts at the same `YYYY-MM-DD` granularity the TextField edits, not the raw ISO
-  // strings — `apiKey.expiresAt` may carry a different (but equal) timestamp representation than
-  // `parseExpirationDraft` produces (e.g. no milliseconds vs `.000`), which would otherwise read
-  // as "changed" on first render even though the user touched nothing.
+  const expirationValid = expiresAtDraft !== undefined;
+  // Compare at the same `YYYY-MM-DD` (calendar-day) granularity `ExpirySelector`'s "Custom"
+  // picker edits, not the raw ISO strings: a preset-derived `apiKey.expiresAt` carries a
+  // non-midnight time-of-day, and re-seeding "Custom" from it always resolves back to that same
+  // calendar day at UTC midnight (see `ExpirySelector`'s `initialPresetFor`) -- comparing full
+  // ISO strings would misreport "changed" on first render even though the user touched nothing.
   const hasDetailsChanged =
     !!apiKey &&
     (trimmedName !== apiKey.name ||
-      expirationDraft.trim() !== expiresAtToDraft(apiKey.expiresAt));
+      expiresAtToDateOnly(expiresAtDraft) !== expiresAtToDateOnly(apiKey.expiresAt));
   const canSaveDetails =
     hasDetailsChanged && trimmedName.length > 0 && expirationValid && !isSavingDetails;
 
   const handleSaveDetails = () => {
-    if (!expirationValid || parsedExpiration === undefined) return;
-    onSaveDetails({ name: trimmedName, expiresAt: parsedExpiration });
+    if (expiresAtDraft === undefined) return;
+    onSaveDetails({ name: trimmedName, expiresAt: expiresAtDraft });
   };
 
   const isActive = apiKey?.status === 'active';
+  const derivedStatus = apiKey ? getDerivedStatus(apiKey) : 'active';
 
   return (
     <Div tone="muted" width="full" style={{ flex: 1 }}>
@@ -251,9 +240,9 @@ export function ApiKeySettingsView({
               <Stack direction="row" align="center" gap="sm">
                 <Heading tone="title">{apiKey.name}</Heading>
                 <Badge
-                  tone={isActive ? 'success' : 'error'}
-                  accessibilityLabel={t(`apiKeys.status.${apiKey.status}`)}>
-                  {t(`apiKeys.status.${apiKey.status}`)}
+                  tone={derivedStatus === 'active' ? 'success' : 'error'}
+                  accessibilityLabel={t(`apiKeys.status.${derivedStatus}`)}>
+                  {t(`apiKeys.status.${derivedStatus}`)}
                 </Badge>
               </Stack>
 
@@ -273,22 +262,13 @@ export function ApiKeySettingsView({
                         autoCorrect={false}
                       />
                     </Stack>
-                    <Stack gap="xs">
-                      <Text intent="caption">{t('settings.apiKey.expirationLabel')}</Text>
-                      <TextField
-                        value={expirationDraft}
-                        onChangeText={setExpirationDraft}
-                        placeholder={t('settings.apiKey.expirationPlaceholder')}
-                        editable={!isSavingDetails}
-                        autoCapitalize="none"
-                        autoCorrect={false}
-                      />
-                      <Text intent="caption" style={{ color: colors.subtle }}>
-                        {expirationValid
-                          ? t('settings.apiKey.expirationHint')
-                          : t('settings.apiKey.expirationInvalid')}
-                      </Text>
-                    </Stack>
+                    <ExpirySelector
+                      key={apiKey.id}
+                      label={t('apiKeys.expiry.label')}
+                      initialValue={apiKey.expiresAt ?? null}
+                      onChange={setExpiresAtDraft}
+                      disabled={isSavingDetails}
+                    />
                     <Button
                       variant="primary"
                       size="sm"
@@ -310,12 +290,9 @@ export function ApiKeySettingsView({
                   <Divider tone="muted" />
                   <KeyValue
                     label={t('settings.apiKey.statusLabel')}
-                    value={t(`apiKeys.status.${apiKey.status}`)}
+                    value={t(`apiKeys.status.${derivedStatus}`)}
                   />
-                  <KeyValue
-                    label={t('settings.apiKey.keyPrefixLabel')}
-                    value={apiKey.keyPrefix}
-                  />
+                  <KeyValue label={t('settings.apiKey.keyPrefixLabel')} value={apiKey.keyPrefix} />
                   <KeyValue
                     label={t('settings.apiKey.billingPlanLabel')}
                     value={apiKey.billingPlan}
@@ -369,6 +346,8 @@ export function ApiKeySettingsView({
                   <Stack gap="sm" align="start">
                     {!isActive ? (
                       <Callout tone="warning">{t('settings.apiKey.revokedNotice')}</Callout>
+                    ) : derivedStatus === 'expired' ? (
+                      <Callout tone="error">{t('settings.apiKey.expiredNotice')}</Callout>
                     ) : null}
                     <Stack direction="row" gap="sm" wrap="wrap">
                       {canRevoke ? (

--- a/packages/i18n/src/i18n-config.ts
+++ b/packages/i18n/src/i18n-config.ts
@@ -81,8 +81,12 @@ const resources = {
         rotate: 'Rotate',
         rotateNamed: 'Rotate {{name}}',
         rotateTitle: 'Rotate API key',
+        // "Its expiration date stays the same" is load-bearing, not filler: `rotateApiKey`
+        // preserves the key's existing `expiresAt` (`RotateApiKeyInput` has no field for the
+        // caller to change it -- see `resolve_rotated_expires_at` server-side). Rotation neither
+        // resets nor extends expiry, so this must say "stays the same", not "renews" or "resets".
         rotateDescription:
-          'Rotating "{{name}}" issues a new secret and immediately invalidates the current one. Update any client using this key with the new secret.',
+          'Rotating "{{name}}" issues a new secret and immediately invalidates the current one. Its expiration date stays the same -- update any client using this key with the new secret.',
         rotateConfirm: 'Rotate key',
         rotateCancel: 'Cancel',
         rotating: 'Rotating...',
@@ -104,6 +108,30 @@ const resources = {
         status: {
           active: 'Active',
           revoked: 'Revoked',
+          // Not a backend status value -- `apiKeys.status` also keys the derived-status badge
+          // (see `getDerivedStatus` in `apps/self-service/src/lib/api-key-expiry.ts`), which
+          // reads a key that is `status: 'active'` in the database but past its `expiresAt` as
+          // "expired" rather than misreporting it as active.
+          expired: 'Expired',
+        },
+        // Preset + custom expiration picker, shared by the create and settings/edit screens via
+        // `ExpirySelector` (`apps/self-service/src/components/expiry-selector.tsx`), and the
+        // expiring-soon/expired labels in the list/settings views (`api-key-expiry.ts`'s
+        // `getExpiryUrgency`).
+        expiry: {
+          label: 'Expiration',
+          thirtyDays: '30 days',
+          sixtyDays: '60 days',
+          ninetyDays: '90 days',
+          custom: 'Custom',
+          noExpiry: 'No expiry',
+          customDateLabel: 'Expiration date',
+          customDateInvalid: 'Enter a valid date.',
+          noExpiryLabel: 'No expiry',
+          expiresInDays_one: 'Expires in {{count}} day',
+          expiresInDays_other: 'Expires in {{count}} days',
+          expiresToday: 'Expires today',
+          expiredOn: 'Expired {{date}}',
         },
         keyLabel: 'Key name',
         placeholder: 'Production',
@@ -338,10 +366,6 @@ const resources = {
           detailsDescription: 'The name and expiration date for this key.',
           nameLabel: 'Key name',
           namePlaceholder: 'production-server',
-          expirationLabel: 'Expiration date',
-          expirationPlaceholder: 'YYYY-MM-DD',
-          expirationHint: 'Leave empty for no expiration.',
-          expirationInvalid: 'Enter a date as YYYY-MM-DD, or leave empty for no expiration.',
           detailsSave: 'Save',
           detailsSaving: 'Saving...',
           metadataSection: 'Lifecycle metadata',
@@ -356,13 +380,18 @@ const resources = {
           revokedLabel: 'Revoked',
           rotationSection: 'Rotation',
           rotationDescription:
-            'Rotating a key issues a new secret and immediately invalidates the current one.',
+            'Rotating a key issues a new secret and immediately invalidates the current one. Its expiration date stays the same.',
           rotationNote: 'Rotate this key from the API Keys list, alongside its other actions.',
           goToApiKeys: 'Go to API Keys',
           dangerSection: 'Danger zone',
           dangerDescription:
             'Revoke disables the key immediately but keeps its record for auditing. Delete removes the key and its history permanently — this cannot be undone.',
           revokedNotice: 'This key has already been revoked.',
+          // Shown alongside `revokedNotice` when the key is `status: 'active'` in the database
+          // but past its `expiresAt` -- distinct wording because unlike a revoke, this state is
+          // fixable from this same screen (extend or clear the expiration above).
+          expiredNotice:
+            'This key expired and can no longer authenticate requests. Extend or clear its expiration above to restore it.',
         },
         // Self-service budget refill (#148). "Budget tier" is deliberately never called "quota
         // tier" anywhere in this block -- `project.quotaTier` (roster, per-member request-rate

--- a/packages/ui/src/components/date-field/component.stories.tsx
+++ b/packages/ui/src/components/date-field/component.stories.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { DateField } from './component';
+
+const meta: Meta<typeof DateField> = {
+  title: 'UI/DateField',
+  component: DateField,
+  args: {
+    accessibilityLabel: 'Expiration date',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 280 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof DateField>;
+
+export const Empty: Story = {};
+
+export const WithValue: Story = {
+  args: { value: '2026-12-31' },
+};
+
+export const WithMinToday: Story = {
+  args: { min: new Date().toISOString().slice(0, 10) },
+};
+
+export const Disabled: Story = {
+  args: { value: '2026-12-31', disabled: true },
+};
+
+// A named PascalCase component (not an inline arrow assigned to `render`) so the
+// `react-hooks/rules-of-hooks` lint rule recognizes `useState` below as a legitimate hook call.
+function InteractiveDateField(args: React.ComponentProps<typeof DateField>) {
+  const [value, setValue] = useState('');
+  return <DateField {...args} value={value} onValueChange={setValue} />;
+}
+
+export const Interactive: Story = {
+  render: InteractiveDateField,
+};

--- a/packages/ui/src/components/date-field/component.tsx
+++ b/packages/ui/src/components/date-field/component.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import { cn } from '../../cn';
+import { textFieldVariants } from '../text-field/cva';
+import type { DateFieldProps } from './types';
+
+// Web-first primitive, mirroring `Select` (see its component.tsx for the fuller rationale):
+// this app is pure react-native-web, so the most accessible, keyboard- and screen-reader-
+// friendly date input is a real DOM `<input type="date">` -- every evergreen browser renders
+// its own native calendar affordance for it, with zero added dependency. `React.createElement`
+// with an intrinsic 'input' tag sidesteps the same react-native-web typing gap Select's comment
+// documents (react-native-web@0.21.2 ships no TypeScript declarations for
+// `unstable_createElement`).
+//
+// Deliberately reuses `textFieldVariants` as-is (no extra `appearance-none`/caret-spacing layer
+// like `Select` adds): browsers render their own calendar-icon affordance inside a date input,
+// and stripping native appearance would hide that icon rather than just restyling a caret.
+export function DateField({
+  value,
+  onValueChange,
+  min,
+  max,
+  disabled,
+  size,
+  accessibilityLabel,
+}: DateFieldProps) {
+  return React.createElement('input', {
+    type: 'date',
+    value: value ?? '',
+    min,
+    max,
+    disabled,
+    'aria-label': accessibilityLabel,
+    className: cn(textFieldVariants({ size })),
+    onChange: (event: React.ChangeEvent<HTMLInputElement>) => onValueChange?.(event.target.value),
+  });
+}

--- a/packages/ui/src/components/date-field/index.tsx
+++ b/packages/ui/src/components/date-field/index.tsx
@@ -1,0 +1,2 @@
+export { DateField } from './component';
+export type { DateFieldProps } from './types';

--- a/packages/ui/src/components/date-field/types.tsx
+++ b/packages/ui/src/components/date-field/types.tsx
@@ -1,0 +1,12 @@
+import type { TextFieldVariantProps } from '../text-field/cva';
+
+export type DateFieldProps = TextFieldVariantProps & {
+  /** `YYYY-MM-DD`, matching the native `<input type="date">` wire format. */
+  value?: string;
+  onValueChange?: (value: string) => void;
+  /** `YYYY-MM-DD` floor/ceiling the native date picker enforces. */
+  min?: string;
+  max?: string;
+  disabled?: boolean;
+  accessibilityLabel?: string;
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -30,6 +30,8 @@ export { Scroll, scrollContentVariants, scrollVariants } from './components/scro
 export type { ScrollProps } from './components/scroll';
 export { Select, selectVariants } from './components/select';
 export type { SelectOption, SelectProps } from './components/select';
+export { DateField } from './components/date-field';
+export type { DateFieldProps } from './components/date-field';
 export { SectionCard, sectionCardVariants, sectionTitleVariants } from './components/section-card';
 export type { SectionCardProps } from './components/section-card';
 export {


### PR DESCRIPTION
## 1. Summary

This PR changes:

- Adds expiry selection (30/60/90-day presets, "No expiry", or a "Custom" date) to the API-key **create** flow, which previously only offered Name + billing plan.
- Upgrades the existing API-key **settings/edit** screen's raw `YYYY-MM-DD` text field (`api-key-settings-view.tsx`) to the same preset + custom-date picker.
- Makes expiry legible in the **list** and **settings** views: an expiring-soon key gets a warning-toned badge, an expired-but-not-revoked key reads unmistakably as "Expired" (previously it silently still said "Active"), and "No expiry" is now an explicit label rather than a blank gap.
- Updates rotation copy to state that expiry is preserved by `rotateApiKey`, not reset or extended.

It solves:

- The gap `#55`'s "remaining scope" comment in `api-key-settings-view.tsx` flagged (name + expiration editable, but expiration was a bare date-string text field with no create-flow equivalent and no legibility work in the list).

---

## 2. Intent

The intent of this PR is:

> API keys can already carry an `expiresAt` on the wire (`CreateApiKeyInput`/`UpdateApiKeyInput`/`ApiKey` in `packages/authz-rpc/schema/authz.cstack`), but the UI never let a caller set one at creation time, and the one place that did edit it (`api-key-settings-view.tsx`) used a raw `YYYY-MM-DD` text field with no picker and no legibility work elsewhere. This closes that gap end to end: set expiry at creation, edit it later through the same control, and see it clearly in the list once it matters (expiring soon / expired).

---

## 3. Scope

### In Scope

- `ExpirySelector` (new, `apps/self-service/src/components/expiry-selector.tsx`): preset `SegmentedControl` (30/60/90 days, Custom, No expiry) + a revealed date field for "Custom", shared by create and settings/edit.
- `DateField` (new primitive, `packages/ui/src/components/date-field/`): the "Custom" date input.
- `apps/self-service/src/lib/api-key-expiry.ts` (new): preset/custom-date math, UTC-safe date-only round-tripping, expiry urgency classification, and the derived active/expired/revoked status used by the list and settings views.
- `api-key-create-view.tsx` / `api-key-create-screen.tsx`: `onCreate` now carries a resolved `expiresAt`, sent as an explicit `null` for "no expiry" (never omitted — see the CBOR undefined-vs-null codec-drift note in the diff).
- `api-keys-list-view.tsx` / `api-key-settings-view.tsx`: derived-status badges, expiring-soon warning badge, expired-but-active unmistakability, "No expiry" as an explicit caption.
- i18n copy for all of the above (`packages/i18n/src/i18n-config.ts`).

### Out of Scope

- No frontend-invented maximum lifetime — every preset the backend accepts (including no-expiry) stays offered; this PR does not add a cap.
- Native iOS/Android date-picker UX — `Select`'s own docstring documents this app as "pure react-native-web" today, and `DateField` deliberately follows that same precedent rather than adding a cross-platform date-picker dependency for platforms not currently shipped.
- No change to `rotateApiKey`'s actual behavior — only its description copy, to correctly state the existing expiry-preserving behavior.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [ ] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
pnpm exec jest                                        # apps/self-service, full suite
pnpm exec tsc --noEmit -p apps/self-service/tsconfig.json
pnpm exec tsc --noEmit -p packages/ui/tsconfig.json
pnpm exec eslint apps/self-service/src packages/ui/src packages/i18n/src
pnpm exec prettier -c <all touched files>
```

Results:

```text
Test Suites: 44 passed, 44 total
Tests:       249 passed, 249 total
Snapshots:   0 total

tsc --noEmit (both workspaces): 0 errors

eslint: 0 errors introduced by this PR. (5 pre-existing react-hooks/rules-of-hooks
errors remain in *unrelated* packages/ui stories files this PR didn't touch --
checkbox/pagination/segmented-control/select `component.stories.tsx` all predate
this branch; flagged separately, not fixed here to stay in scope.)

prettier -c: all matched files use Prettier code style
```

Timezone-handling proof (the classic "off-by-one-day" bug this task explicitly
called out): `apps/self-service/src/lib/__tests__/api-key-expiry.test.ts` spies on
`Date.prototype`'s local-time getters (`getFullYear`/`getMonth`/`getDate`/etc.) and
asserts `dateOnlyToExpiresAt`/`expiresAtToDateOnly` never call them, only
`toISOString()`/`getTime()` (UTC-based). I broke the implementation on purpose
(swapped in a `getFullYear`/`getMonth`/`getDate`-based version), watched the spy
test fail for exactly the predicted reason (`expected 0 calls, received 1`), then
restored the fix. A second real bug was caught the same way while wiring
`ExpirySelector` into `api-key-settings-view.tsx`: a stale `useEffect` reset was
clobbering the child's freshly-resolved expiry value back to an unnormalized raw
string on every render (`2026-12-31T00:00:00Z` instead of the resolved
`2026-12-31T00:00:00.000Z`) — caught by
`api-key-settings-view.test.tsx`'s "calls onSaveDetails with the trimmed name and
the unchanged expiration" test failing with exactly that diff before the fix.

---

## 5. Screenshots / Evidence

No live screenshot: this environment's browser-preview tooling is scoped to a
different repository's worktree in this session and could not be repointed at
`converse-frontends` without writing outside the intended sandbox (declined). The
design is grounded in concrete reference screens instead of a rendered screenshot:
Appwrite's API-key creation modal (`Expiration date` dropdown: Never / 7 Days / 30
Days / 90 Days / 1 Year / Custom Date) is the closest real-product precedent for
"presets + custom" in exactly this domain, and this repo's own `SegmentedControl`
(ADR 0001, already used for the theme toggle) is the established primitive for
"period toggle" style pickers — so the preset row reuses it directly rather than
introducing a new control. `DateField` mirrors `Select`'s own documented
"web-first primitive" rationale line for line.

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* `onCreate`'s signature changed (`(name, billingPlan)` → `(name, billingPlan, expiresAt)`) — a breaking change to `ApiKeyCreateView`'s prop contract, but it has exactly one production consumer (`api-key-create-screen.tsx`), which is updated in the same commit.
* `expiresAt: null` must be sent explicitly (not omitted) for "no expiry" over this app's CBOR codec — same class of bug as the prior prod `createProject` incident (undefined-vs-null codec drift). Handled explicitly in `api-key-create-screen.tsx`'s `handleCreate` and called out in a comment there.

Mitigation:

* Full existing settings-view/create-view/list-view test suites still pass unmodified in the parts unrelated to expiry, plus new dedicated `*.expiry.test.tsx` files for the new behavior.
* `ExpirySelector`'s "Custom" path blocks Save/Create on an incomplete/invalid date (`undefined` return value), so a malformed or in-progress custom date can never reach the RPC call.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [x] Refactoring
* [x] Generating tests
* [ ] Drafting documentation
* [x] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [ ] Architecture
* [ ] Security
* [x] Tests
* [ ] Performance
* [ ] Maintainability
* [x] Product intent
* [x] Edge cases
