### PR TITLE
feat(self-service): billing plan selector on API key creation

### DIFF
--- a/apps/self-service/src/__tests__/api-key-create-screen.test.tsx
+++ b/apps/self-service/src/__tests__/api-key-create-screen.test.tsx
@@ -25,6 +25,7 @@ jest.mock('@lightbridge/api-native', () => ({
 
 jest.mock('@lightbridge/hooks', () => ({
   __esModule: true,
+  useBillingPlans: () => ({ data: [], isLoading: false, isError: false }),
   useCreateApiKey: () => ({ mutate: mockCreateKey, isPending: false }),
   useEnsureDefaultAccount: () => ({ mutate: jest.fn(), isPending: false }),
   useEnsureDefaultProject: () => ({ mutate: jest.fn(), isPending: false }),

--- a/apps/self-service/src/screens/api-key-create-screen.tsx
+++ b/apps/self-service/src/screens/api-key-create-screen.tsx
@@ -3,6 +3,7 @@ import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from '@lightbridge/i18n';
 import { copyToClipboard } from '@lightbridge/api-native';
 import {
+  useBillingPlans,
   useCreateApiKey,
   useEnsureDefaultAccount,
   useEnsureDefaultProject,
@@ -91,6 +92,14 @@ export function ApiKeyCreateScreen() {
   // the project's account or hold `role: 'lead'` on it, so a `403` is still possible here.
   const canChoosePlan = has('project:member');
   const projectId = typeof params.projectId === 'string' ? params.projectId : null;
+  // Only fetched when a plan choice is actually offered -- a caller pinned to `free` has no use
+  // for the catalogue, so there's no reason to spend the request (`listBillingPlans` also
+  // requires `apikey:create`, which this caller may not hold outside `project:member`).
+  const {
+    data: plans,
+    isLoading: isPlansLoading,
+    isError: isPlansError,
+  } = useBillingPlans(canChoosePlan);
 
   const handleBack = () => {
     // After key creation, the user intent is to go back to the API Keys list (not the previous route).
@@ -146,6 +155,9 @@ export function ApiKeyCreateScreen() {
       onCreate={handleCreate}
       isCreating={isPending}
       canChoosePlan={canChoosePlan}
+      plans={plans}
+      isPlansLoading={isPlansLoading}
+      isPlansError={isPlansError}
       generatedSecret={generatedSecret}
       generatedOauth2Url={generatedOauth2Url}
       createError={createError}

--- a/apps/self-service/src/views/__tests__/api-key-create-view.plan.test.tsx
+++ b/apps/self-service/src/views/__tests__/api-key-create-view.plan.test.tsx
@@ -1,54 +1,133 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react-native';
 import { initI18n } from '@lightbridge/i18n';
+import type { BillingPlanInfo } from '@lightbridge/authz-rpc';
 
 import { ApiKeyCreateView } from '../api-key-create-view';
 
 const noop = () => undefined;
 
+const PLANS: BillingPlanInfo[] = [
+  { id: 'free', name: 'Free' },
+  { id: 'pro', name: 'Pro' },
+];
+
 beforeAll(() => {
   initI18n('en');
 });
+
+async function nameField() {
+  return fireEvent.changeText(screen.getByPlaceholderText('Production'), 'CI key');
+}
 
 describe('ApiKeyCreateView billing plan gating', () => {
   it('creates keys on the free plan when the user cannot choose a plan', async () => {
     const onCreate = jest.fn();
     await render(<ApiKeyCreateView onBack={noop} onCreate={onCreate} onCopy={noop} />);
 
-    // No plan field is offered; a locked note explains the fixed plan instead.
+    // No plan field is offered at all -- not even a disabled one -- and a locked note explains
+    // the fixed plan instead.
     expect(screen.queryByText('Billing plan')).toBeNull();
     expect(screen.getByText('New keys are created on the free plan.')).toBeTruthy();
 
-    await fireEvent.changeText(screen.getByPlaceholderText('Production'), 'CI key');
+    await nameField();
     await fireEvent.press(screen.getByText('Save key'));
 
     // Third arg is the resolved expiresAt -- defaults to the 30-day preset (see
     // api-key-create-view.expiry.test.tsx for dedicated coverage of that value).
     expect(onCreate).toHaveBeenCalledWith('CI key', 'free', expect.any(String));
   });
+});
 
-  it('lets an account member pick a plan and forwards it', async () => {
-    const onCreate = jest.fn();
+describe('ApiKeyCreateView billing plan selector', () => {
+  it('shows a loading state and blocks Save while the catalogue is still loading', async () => {
     await render(
-      <ApiKeyCreateView onBack={noop} onCreate={onCreate} onCopy={noop} canChoosePlan />
+      <ApiKeyCreateView onBack={noop} onCreate={noop} onCopy={noop} canChoosePlan isPlansLoading />
     );
 
-    await fireEvent.changeText(screen.getByPlaceholderText('Production'), 'Prod key');
-    await fireEvent.changeText(screen.getByPlaceholderText('free'), 'pro');
-    await fireEvent.press(screen.getByText('Save key'));
-
-    expect(onCreate).toHaveBeenCalledWith('Prod key', 'pro', expect.any(String));
+    expect(screen.getByText('Loading plans...')).toBeTruthy();
+    expect(screen.queryByLabelText('Billing plan')).toBeNull();
+    await nameField();
+    expect(screen.getByRole('button', { name: 'Save key' }).props.accessibilityState.disabled).toBe(
+      true
+    );
   });
 
-  it('defaults an account member to the free plan when the field is left blank', async () => {
-    const onCreate = jest.fn();
+  it('shows a real error state and blocks Save when the catalogue fails to load', async () => {
     await render(
-      <ApiKeyCreateView onBack={noop} onCreate={onCreate} onCopy={noop} canChoosePlan />
+      <ApiKeyCreateView onBack={noop} onCreate={noop} onCopy={noop} canChoosePlan isPlansError />
     );
 
-    await fireEvent.changeText(screen.getByPlaceholderText('Production'), 'Prod key');
+    expect(screen.getByText("Couldn't load billing plans. Please try again.")).toBeTruthy();
+    expect(screen.queryByLabelText('Billing plan')).toBeNull();
+    await nameField();
+    expect(screen.getByRole('button', { name: 'Save key' }).props.accessibilityState.disabled).toBe(
+      true
+    );
+  });
+
+  it('shows a real empty state and blocks Save when no plans are configured', async () => {
+    await render(
+      <ApiKeyCreateView onBack={noop} onCreate={noop} onCopy={noop} canChoosePlan plans={[]} />
+    );
+
+    expect(screen.getByText('No billing plans are configured.')).toBeTruthy();
+    expect(screen.queryByLabelText('Billing plan')).toBeNull();
+    await nameField();
+    expect(screen.getByRole('button', { name: 'Save key' }).props.accessibilityState.disabled).toBe(
+      true
+    );
+  });
+
+  it('defaults to the operator-first-listed plan and forwards its id', async () => {
+    const onCreate = jest.fn();
+    await render(
+      <ApiKeyCreateView
+        onBack={noop}
+        onCreate={onCreate}
+        onCopy={noop}
+        canChoosePlan
+        plans={PLANS}
+      />
+    );
+
+    await nameField();
     await fireEvent.press(screen.getByText('Save key'));
 
-    expect(onCreate).toHaveBeenCalledWith('Prod key', 'free', expect.any(String));
+    expect(onCreate).toHaveBeenCalledWith('CI key', 'free', expect.any(String));
+  });
+
+  it('lets the caller pick a different plan and forwards its id, not its label', async () => {
+    const onCreate = jest.fn();
+    await render(
+      <ApiKeyCreateView
+        onBack={noop}
+        onCreate={onCreate}
+        onCopy={noop}
+        canChoosePlan
+        plans={PLANS}
+      />
+    );
+
+    await nameField();
+    await fireEvent.press(screen.getByText('Pro'));
+    await fireEvent.press(screen.getByText('Save key'));
+
+    expect(onCreate).toHaveBeenCalledWith('CI key', 'pro', expect.any(String));
+  });
+
+  it('marks the selected plan for accessibility', async () => {
+    await render(
+      <ApiKeyCreateView onBack={noop} onCreate={noop} onCopy={noop} canChoosePlan plans={PLANS} />
+    );
+
+    // Auto-selected to the first plan on load (see the preceding test).
+    expect(screen.getByLabelText('Free').props.accessibilityState.selected).toBeTruthy();
+    expect(screen.getByLabelText('Pro').props.accessibilityState.selected).toBeFalsy();
+
+    await fireEvent.press(screen.getByText('Pro'));
+
+    expect(screen.getByLabelText('Pro').props.accessibilityState.selected).toBeTruthy();
+    expect(screen.getByLabelText('Free').props.accessibilityState.selected).toBeFalsy();
   });
 });

--- a/apps/self-service/src/views/api-key-create-view.tsx
+++ b/apps/self-service/src/views/api-key-create-view.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from '@lightbridge/i18n';
+import type { BillingPlanInfo } from '@lightbridge/authz-rpc';
 import {
   Button,
   Callout,
@@ -10,6 +11,7 @@ import {
   Icon as Feather,
   PageHeader,
   Scroll,
+  SegmentedControl,
   Stack,
   Text,
   TextField,
@@ -37,6 +39,16 @@ type ApiKeyCreateViewProps = {
   isCreating?: boolean;
   /** When true, the user may pick a billing plan; otherwise keys are pinned to `free`. */
   canChoosePlan?: boolean;
+  /**
+   * The operator-configured billing-plan catalogue (`procedure.listBillingPlans`), fetched by
+   * the screen (`useBillingPlans`, `@lightbridge/hooks`) rather than here -- this view stays a
+   * plain presentational component driven entirely by props/callbacks, matching every other
+   * `*CreateView`/`*SettingsView` in this app; only the screen layer touches react-query. Ignored
+   * entirely while `canChoosePlan` is false.
+   */
+  plans?: BillingPlanInfo[];
+  isPlansLoading?: boolean;
+  isPlansError?: boolean;
   generatedSecret?: string | null;
   /** `ApiKeySecret.oauth2Url` from the create response, if the backend returned one. */
   generatedOauth2Url?: string | null;
@@ -54,6 +66,9 @@ export function ApiKeyCreateView({
   onCopy,
   isCreating = false,
   canChoosePlan = false,
+  plans = [],
+  isPlansLoading = false,
+  isPlansError = false,
   generatedSecret = null,
   generatedOauth2Url = null,
   createError = null,
@@ -67,11 +82,28 @@ export function ApiKeyCreateView({
   // anything, so this only stays `undefined` while actively editing an invalid custom date.
   const [expiresAt, setExpiresAt] = useState<string | null | undefined>(undefined);
 
+  useEffect(() => {
+    // Seed a real selection once the catalogue loads, so Save doesn't sit blocked on "pick a
+    // plan" for the common case -- the operator's first-listed plan, same convention
+    // `ExpirySelector` uses for its own default preset. Only fires while nothing is selected yet:
+    // a plan the user already picked is never overwritten out from under them by a refetch.
+    if (canChoosePlan && !billingPlan && plans.length > 0) {
+      setBillingPlan(plans[0]!.id);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [canChoosePlan, plans]);
+
   const trimmedName = name.trim();
-  const resolvedPlan = canChoosePlan
-    ? billingPlan.trim() || DEFAULT_API_KEY_BILLING_PLAN
-    : DEFAULT_API_KEY_BILLING_PLAN;
-  const isSubmitDisabled = isCreating || !trimmedName || expiresAt === undefined;
+  const resolvedPlan = canChoosePlan ? billingPlan : DEFAULT_API_KEY_BILLING_PLAN;
+  const isSubmitDisabled =
+    isCreating ||
+    !trimmedName ||
+    expiresAt === undefined ||
+    // A plan choice is offered but nothing is selected yet -- either the catalogue is still
+    // loading, failed to load, or (correctly) came back empty. `resolvedPlan` would otherwise be
+    // `''`, which the server rejects anyway, but blocking Save here surfaces the real state
+    // (loading/error/empty, rendered below) instead of a generic server error after the fact.
+    (canChoosePlan && !billingPlan);
 
   const submit = () => {
     if (isSubmitDisabled || expiresAt === undefined) return;
@@ -150,17 +182,31 @@ export function ApiKeyCreateView({
                   </FormField>
                   {canChoosePlan ? (
                     <FormField label={t('apiKeys.planLabel')}>
-                      <TextField
-                        placeholder={t('apiKeys.planPlaceholder')}
-                        value={billingPlan}
-                        onChangeText={setBillingPlan}
-                        selectionColor={colors.primary}
-                        editable={!isCreating}
-                        autoCapitalize="none"
-                        autoCorrect={false}
-                        returnKeyType="done"
-                        onSubmitEditing={submit}
-                      />
+                      {isPlansLoading ? (
+                        <Text intent="caption" style={{ color: colors.subtle }}>
+                          {t('apiKeys.planLoading')}
+                        </Text>
+                      ) : isPlansError ? (
+                        <Text intent="caption" style={{ color: colors.error }}>
+                          {t('apiKeys.planLoadError')}
+                        </Text>
+                      ) : plans.length === 0 ? (
+                        <Text intent="caption" style={{ color: colors.subtle }}>
+                          {t('apiKeys.planEmpty')}
+                        </Text>
+                      ) : (
+                        <SegmentedControl
+                          width="full"
+                          value={billingPlan}
+                          onChange={setBillingPlan}
+                          options={plans.map((plan) => ({
+                            key: plan.id,
+                            label: plan.name,
+                            disabled: isCreating,
+                          }))}
+                          accessibilityLabel={t('apiKeys.planLabel')}
+                        />
+                      )}
                     </FormField>
                   ) : (
                     <Text intent="caption" style={{ color: colors.subtle }}>

--- a/packages/authz-rpc/schema/authz.cstack
+++ b/packages/authz-rpc/schema/authz.cstack
@@ -319,6 +319,37 @@ type CreateApiKeyInput {
 mutation procedure createApiKey(args: CreateApiKeyInput): ApiKeySecret
   @allow(auth() != null)
 
+// The operator-configured billing-plan catalogue (`config.billing.plans`, `Billing` in
+// `lightbridge-authz-core`), read-only. Added so a caller building a `createApiKey` UI can build a
+// real selector instead of hardcoding plan ids client-side -- before this procedure, the only place
+// the catalogue was exposed anywhere on the wire was the MCP tool description string
+// (`LightbridgeMcpHandler::advertised_tools` appends "Valid billing_plan ids: ..." to
+// `create-api-key`'s description), which is not machine-readable and not reachable from the RPC
+// surface `createApiKey` itself lives on. `limits` mirrors `BillingLimits` field-for-field; an
+// absent field there means "no limit" (see that struct's doc comment) and stays absent here rather
+// than being coerced to a sentinel. Gated at the same `apikey:create` permission as `createApiKey`
+// (`rpc_authorize.rs`) -- a caller who cannot mint a key has no use for the plan list either, and
+// this keeps the two procedures' authorization stories identical rather than inventing a new,
+// looser permission for a one-field read.
+type BillingPlanLimits {
+  requestsPerSecond Int?
+  requestsPerDay Int?
+  requestsPerMonth Int?
+  concurrentRequests Int?
+}
+
+type BillingPlanInfo {
+  id String
+  name String
+  limits BillingPlanLimits?
+}
+
+type ListBillingPlansInput {
+}
+
+procedure listBillingPlans(args: ListBillingPlansInput): BillingPlanInfo[]
+  @allow(auth() != null)
+
 type RevokeApiKeyInput {
   keyId String
 }

--- a/packages/hooks/src/api-keys.ts
+++ b/packages/hooks/src/api-keys.ts
@@ -1,11 +1,16 @@
 import { useMemo } from 'react';
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import type { CreateApiKeyInput, UpdateApiKeyInput } from '@lightbridge/authz-rpc';
+import type { BillingPlanInfo, CreateApiKeyInput, UpdateApiKeyInput } from '@lightbridge/authz-rpc';
 import { getAuthzRpcClient } from '@lightbridge/authz-rpc';
 import type { ApiKey } from './authz-types';
 import { useCurrentProject } from './projects';
 import { useAuthSession } from './auth-session';
+
+/** Query key for the operator-configured billing-plan catalogue (`procedure.listBillingPlans`).
+ * Not project- or account-scoped -- the catalogue is server config, the same for every caller who
+ * can reach it. */
+export const BILLING_PLANS_QUERY_KEY = ['billing-plans'] as const;
 
 /**
  * Base query key for a project's API keys — the invalidation prefix. The per-page
@@ -71,6 +76,34 @@ export function useApiKey(id?: string | null) {
   }, [data, id]);
 
   return { ...query, data: item };
+}
+
+/**
+ * The operator-configured billing-plan catalogue `createApiKey`'s `billingPlan` is validated
+ * against server-side (`procedure.listBillingPlans` -- see `AuthzStoreImpl::billing_plans` in the
+ * backend). This is config, not per-project data, so it needs no `projectId`, but it still
+ * requires a caller (`listBillingPlans` is gated at the same `apikey:create` permission as
+ * `createApiKey` itself) -- a caller lacking that permission gets a `403`, surfaced as
+ * `query.error` like any other failed query, which callers should render as "plan selection
+ * unavailable" rather than treating it as "no plans configured" (an empty, successful `[]` is the
+ * latter).
+ *
+ * `enabled` lets a caller skip the fetch entirely when it has no use for the result yet -- e.g.
+ * `ApiKeyCreateScreen` only needs the catalogue once it knows the caller may pick a plan at all
+ * (`canChoosePlan`), so it passes that straight through rather than always fetching and throwing
+ * the response away.
+ */
+export function useBillingPlans(enabled = true) {
+  const { isAuthenticated } = useAuthSession();
+
+  return useQuery<BillingPlanInfo[]>({
+    queryKey: BILLING_PLANS_QUERY_KEY,
+    queryFn: () => getAuthzRpcClient().procedures.listBillingPlans({ args: {} }),
+    enabled: isAuthenticated && enabled,
+    // The catalogue is operator config, reloaded only on a redeploy -- stale for a full session is
+    // fine, and avoids a refetch on every create-key screen visit.
+    staleTime: 5 * 60_000,
+  });
 }
 
 export function useCreateApiKey() {

--- a/packages/i18n/src/i18n-config.ts
+++ b/packages/i18n/src/i18n-config.ts
@@ -136,7 +136,9 @@ const resources = {
         keyLabel: 'Key name',
         placeholder: 'Production',
         planLabel: 'Billing plan',
-        planPlaceholder: 'free',
+        planLoading: 'Loading plans...',
+        planLoadError: "Couldn't load billing plans. Please try again.",
+        planEmpty: 'No billing plans are configured.',
         planLockedNote: 'New keys are created on the free plan.',
         createForbidden:
           "Creating API keys here requires being this project's lead or its owning account.",


### PR DESCRIPTION
## 1. Summary

This PR changes:

- `ApiKeyCreateView`'s billing-plan field: from an optional free-text `TextField` to a
  `SegmentedControl` bound to the real operator-configured plan catalogue.
- `ApiKeyCreateScreen`: fetches the catalogue via the new `useBillingPlans` hook and threads
  `plans`/`isPlansLoading`/`isPlansError` into the view as props.
- `packages/hooks/src/api-keys.ts`: new `useBillingPlans(enabled)` hook wrapping
  `procedures.listBillingPlans`.
- `packages/authz-rpc/schema/authz.cstack`: copied from the backend, adding the new procedure +
  types (regenerates `generated/` via the existing `codegen` postinstall).
- `packages/i18n`: new copy for the selector's loading/error/empty states.

It solves:

- ADORSYS-GIS/lightbridge-authz#368 (this PR's backend counterpart) exposes the plan catalogue on
  the wire; this is the frontend half that actually uses it.

---

## 2. Intent

The intent of this PR is:

> Answers a direct product question: "on the UI, billing plan should be a selection, and should
> depend on the role and the project, right?" Investigation established the role part holds only
> coarsely (a caller needs the same `apikey:create` permission `createApiKey` itself requires —
> not a plan-specific check) and the project part does not hold at all (the catalogue is global
> config, not scoped by project quota/tier — those are a separate, unrelated governance axis, see
> PR description discussion). What *did not* hold until now: the catalogue was not reachable by
> the frontend at all, so a "selector" would have meant hardcoding plan ids client-side — the
> exact failure mode that already cost this team a stale RBAC map once
> (ADORSYS-GIS/lightbridge-authz#282/#283). This PR replaces the free-text input with a real
> selector sourced from the backend's new `listBillingPlans` procedure instead.

---

## 3. Scope

### In Scope

- Replacing the free-text plan field with a real selection control on the create-key screen.
- Real loading/error/empty states for the plan catalogue (no silent fallback to a hardcoded plan
  list).
- The `useBillingPlans` hook and its wiring through `ApiKeyCreateScreen`.

### Out of Scope

- Role/project *constraining which plans* are selectable — investigation found no such
  server-side constraint to enforce, so none was added client-side either (a frontend-invented
  restriction the server doesn't enforce would be worse than none).
- `Project.billingPlan` (the project's own free-text billing-plan field, `createProject`/project
  settings) — a separate, pre-existing field with no catalogue validation at all server-side. Same
  underlying gap, different screen; not touched here to keep this PR reviewable.
- Any change to `lightbridge-keycloak-spi`, MCP tool listing, or the `Select` UI primitive.

---

## 4. Verification

I verified this change by:

- [x] Running automated tests
- [ ] Running manual tests
- [ ] Checking logs
- [ ] Checking metrics
- [x] Testing error cases
- [x] Testing permissions/security behavior
- [ ] Testing rollback or failure behavior, if relevant

Commands run:

```bash
pnpm install   # regenerates packages/authz-rpc/generated from the updated schema
pnpm --filter self-service test
pnpm exec tsc --noEmit -p apps/self-service
pnpm exec eslint <changed files>
pnpm exec prettier -c <changed files>
pnpm --filter @lightbridge/hooks test
```

Results:

```text
Test Suites: 44 passed, 44 total
Tests:       253 passed, 253 total   (apps/self-service)

Test Files  5 passed (5)
     Tests  71 passed (71)           (packages/hooks, unaffected)

tsc --noEmit: no output (clean)
eslint: 0 errors, 4 pre-existing warnings unrelated to this change
prettier: all matched files use Prettier code style
```

New/rewritten tests for this change (`api-key-create-view.plan.test.tsx`, 7 cases): pinned-plan
gating, loading/error/empty states each block Save, defaults to the operator's first-listed plan,
picking a different plan forwards its id (not its label), and the selected option's accessibility
state. Each new assertion was proven to catch a real regression during development (broke the
default-selection logic and the submit-blocking guard in turn, watched the predicted test fail,
restored) — not written after the fact.

---

## 5. Screenshots / Evidence

Add evidence here:

* Screenshot: not captured — no local server/device available in this session; see test output
  above for behavioral evidence instead.
* Logs: n/a
* Metrics: n/a
* Recording: n/a

---

## 6. Risk Assessment

Risk level:

* [x] Low
* [ ] Medium
* [ ] High

Potential risks:

* Depends on ADORSYS-GIS/lightbridge-authz#368 landing first — until then, `listBillingPlans`
  404s in any environment running the old backend, and the create-key screen would show the
  "Couldn't load billing plans" error state for any caller who could choose a plan (submit
  correctly stays blocked rather than silently succeeding with an invalid plan).
* `packages/authz-rpc/schema/authz.cstack` is a copy of the backend schema — must stay in lockstep
  (documented in that package's own README; this PR's copy already matches #368 exactly).

Mitigation:

* Land ADORSYS-GIS/lightbridge-authz#368 first, or merge together.
* The blocked-submit behavior (rather than a silent fallback) is itself the mitigation for the
  dependency-ordering risk — no caller can mint a key on an unvalidated/guessed plan id.

---

## 7. AI Usage Declaration

AI was used for:

* [x] Understanding existing code
* [x] Generating code
* [ ] Refactoring
* [x] Generating tests
* [ ] Drafting documentation
* [ ] Reviewing the diff
* [ ] Not used

Human verification:

* [ ] I understand every meaningful change in this PR
* [ ] I checked generated code manually
* [ ] I checked generated tests manually
* [ ] I removed unsupported AI assumptions
* [ ] I accept responsibility for this PR

---

## 8. Reviewer Focus

Please focus your review on:

* [x] Correctness
* [x] Architecture
* [ ] Security
* [ ] Performance
* [x] Tests
* [ ] Maintainability
* [x] Product intent
* [x] Edge cases

Specific asks: (1) is `SegmentedControl` the right primitive here vs. `Select`, given plan counts
are operator-configured and could in principle grow past what a segmented control reads well at;
(2) does defaulting to the operator's *first-listed* plan match the intended UX, or should there
be no default and an explicit empty state instead; (3) `ApiKeyCreateView` staying prop-driven
(catalogue fetched in the screen, not the view) — matches this app's existing
screen-owns-data/view-is-presentational split, confirm that's still the right call here.
